### PR TITLE
Equipment becomes unavailable for repairs

### DIFF
--- a/cmd/swagger/setup.go
+++ b/cmd/swagger/setup.go
@@ -65,6 +65,7 @@ func SetupAPI(entClient *ent.Client, lg *zap.Logger, conf *config.AppConfig) (*r
 	handlers.SetRegistrationHandler(lg, api, regConfirmService)
 	handlers.SetRoleHandler(lg, api)
 	handlers.SetEquipmentStatusNameHandler(lg, api)
+	handlers.SetEquipmentStatusHandler(lg, api)
 	handlers.SetUserHandler(lg, api, tokenManager, regConfirmService)
 	handlers.SetPetKindHandler(lg, api)
 	handlers.SetHealthHandler(lg, api)

--- a/internal/handlers/equipment_status.go
+++ b/internal/handlers/equipment_status.go
@@ -164,16 +164,14 @@ func equipmentStatusAccessRights(access interface{}) (bool, error) {
 		return false, err
 	}
 
-	// should be removed! for test purpouse
-	// isOperator, err := authentication.IsOperator(access)
-	// if err != nil {
-	// 	return false, err
-	// }
-	// return isManager || isOperator, nil
-
 	return isManager, nil
 }
 
 func checkStatus(status string) bool {
-	return status == domain.EquipmentStatusNotAvailable
+	if status == domain.EquipmentStatusAvailable ||
+		status == domain.EquipmentStatusNotAvailable {
+		return true
+	}
+
+	return false
 }

--- a/internal/handlers/equipment_status.go
+++ b/internal/handlers/equipment_status.go
@@ -93,7 +93,7 @@ func (c EquipmentStatus) GetEquipmentStatusCheckDatesFunc(
 		eqStatusResult, err := eqStatusRepository.GetEquipmentStatusByID(
 			ctx, int(*data.ID))
 		if err != nil {
-			c.logger.Error("receiving equipment status by id failed", zap.Error(err))
+			c.logger.Error("receiving equipment status by id failed during checking start/end dates", zap.Error(err))
 			return eqStatus.NewCheckEquipmentStatusDefault(http.StatusInternalServerError).
 				WithPayload(buildStringPayload("can't find equipment status by provided id"))
 		}
@@ -188,14 +188,24 @@ func (c EquipmentStatus) PutEquipmentStatusInRepairFunc(
 				WithPayload(buildStringPayload("Can't update order status"))
 		}
 
-		id := int64(updatedEqStatus.ID)
+		eqStatusResult, err := eqStatusRepository.GetEquipmentStatusByID(
+			ctx, int(*data.ID))
+		if err != nil {
+			c.logger.Error("receiving equipment status by id failed during changing status to unavailable", zap.Error(err))
+			return eqStatus.NewCheckEquipmentStatusDefault(http.StatusInternalServerError).
+				WithPayload(buildStringPayload("can't find equipment status by provided id"))
+		}
+
+		equipmentStatusID := int64(updatedEqStatus.ID)
+		equipmentID := int64(eqStatusResult.Edges.Equipments.ID)
 		return eqStatus.NewUpdateEquipmentStatusOnUnavailableOK().WithPayload(
 			&models.EquipmentStatusRepairResponse{
-				Data: &models.EquipmentStatusRepair{
-					EquipmentStatusID: &id,
-					EndDate:           (*strfmt.DateTime)(&updatedEqStatus.EndDate),
-					StartDate:         (*strfmt.DateTime)(&updatedEqStatus.StartDate),
-					StatusName:        newStatus,
+				Data: &models.EquipmentStatus{
+					ID:          &equipmentStatusID,
+					EndDate:     (*strfmt.DateTime)(&updatedEqStatus.EndDate),
+					StartDate:   (*strfmt.DateTime)(&updatedEqStatus.StartDate),
+					StatusName:  &eqStatusResult.Edges.EquipmentStatusName.Name,
+					EquipmentID: &equipmentID,
 				},
 			})
 	}
@@ -241,14 +251,24 @@ func (c EquipmentStatus) PutEquipmentStatusRemoveFromRepairFunc(
 				WithPayload(buildStringPayload("can't update equipment status on available status"))
 		}
 
-		id := int64(updatedEqStatus.ID)
+		eqStatusResult, err := eqStatusRepository.GetEquipmentStatusByID(
+			ctx, int(*data.ID))
+		if err != nil {
+			c.logger.Error("receiving equipment status by id failed during changing status to available", zap.Error(err))
+			return eqStatus.NewCheckEquipmentStatusDefault(http.StatusInternalServerError).
+				WithPayload(buildStringPayload("can't find equipment status by provided id"))
+		}
+
+		equipmentStatusID := int64(updatedEqStatus.ID)
+		equipmentID := int64(eqStatusResult.Edges.Equipments.ID)
 		return eqStatus.NewUpdateEquipmentStatusOnAvailableOK().WithPayload(
 			&models.EquipmentStatusRepairResponse{
-				Data: &models.EquipmentStatusRepair{
-					EquipmentStatusID: &id,
-					EndDate:           (*strfmt.DateTime)(&updatedEqStatus.EndDate),
-					StartDate:         (*strfmt.DateTime)(&updatedEqStatus.StartDate),
-					StatusName:        newStatus,
+				Data: &models.EquipmentStatus{
+					ID:          &equipmentStatusID,
+					EndDate:     (*strfmt.DateTime)(&updatedEqStatus.EndDate),
+					StartDate:   (*strfmt.DateTime)(&updatedEqStatus.StartDate),
+					StatusName:  &eqStatusResult.Edges.EquipmentStatusName.Name,
+					EquipmentID: &equipmentID,
 				},
 			})
 	}
@@ -294,13 +314,25 @@ func (c EquipmentStatus) PutEquipmentStatusEditDatesFunc(
 				WithPayload(buildStringPayload("can't update equipment status on available status"))
 		}
 
-		id := int64(updatedEqStatus.ID)
+		eqStatusResult, err := eqStatusRepository.GetEquipmentStatusByID(
+			ctx, int(*data.ID))
+		if err != nil {
+			c.logger.Error("receiving equipment status by id failed during editing dates", zap.Error(err))
+			return eqStatus.NewCheckEquipmentStatusDefault(http.StatusInternalServerError).
+				WithPayload(buildStringPayload("can't find equipment status by provided id"))
+		}
+
+		equipmentStatusID := int64(updatedEqStatus.ID)
+		equipmentID := int64(eqStatusResult.Edges.Equipments.ID)
+
 		return eqStatus.NewUpdateRepairedEquipmentStatusDatesOK().WithPayload(
 			&models.EquipmentStatusRepairResponse{
-				Data: &models.EquipmentStatusRepair{
-					EquipmentStatusID: &id,
-					EndDate:           (*strfmt.DateTime)(&updatedEqStatus.EndDate),
-					StartDate:         (*strfmt.DateTime)(&updatedEqStatus.StartDate),
+				Data: &models.EquipmentStatus{
+					ID:          &equipmentStatusID,
+					EndDate:     (*strfmt.DateTime)(&updatedEqStatus.EndDate),
+					StartDate:   (*strfmt.DateTime)(&updatedEqStatus.StartDate),
+					StatusName:  &eqStatusResult.Edges.EquipmentStatusName.Name,
+					EquipmentID: &equipmentID,
 				},
 			})
 	}

--- a/internal/handlers/equipment_status.go
+++ b/internal/handlers/equipment_status.go
@@ -29,9 +29,9 @@ func SetEquipmentStatusHandler(logger *zap.Logger, api *operations.BeAPI) {
 	statusHandler := NewEquipmentStatus(logger)
 
 	api.EquipmentStatusUpdateEquipmentStatusOnUnavailableHandler = statusHandler.PutEquipmentStatusInRepairFunc(equipmentStatusRepo, orderStatusRepo)
-	api.EquipmentStatusUpdateEquipmentStatusOnAvailableHandler = statusHandler.PutEquipmentStatusRemoveFromRepairFunc(equipmentStatusRepo, orderStatusRepo)
+	api.EquipmentStatusUpdateEquipmentStatusOnAvailableHandler = statusHandler.DeleteEquipmentStatusRemoveFromRepairFunc(equipmentStatusRepo, orderStatusRepo)
 	api.EquipmentStatusCheckEquipmentStatusHandler = statusHandler.GetEquipmentStatusCheckDatesFunc(equipmentStatusRepo)
-	api.EquipmentStatusUpdateRepairedEquipmentStatusDatesHandler = statusHandler.PutEquipmentStatusEditDatesFunc(equipmentStatusRepo)
+	api.EquipmentStatusUpdateRepairedEquipmentStatusDatesHandler = statusHandler.PatchEquipmentStatusEditDatesFunc(equipmentStatusRepo)
 }
 
 type EquipmentStatus struct {
@@ -220,7 +220,7 @@ func (c EquipmentStatus) PutEquipmentStatusInRepairFunc(
 	}
 }
 
-func (c EquipmentStatus) PutEquipmentStatusRemoveFromRepairFunc(
+func (c EquipmentStatus) DeleteEquipmentStatusRemoveFromRepairFunc(
 	eqStatusRepository domain.EquipmentStatusRepository,
 	orderStatusRepo domain.OrderStatusRepository) eqStatus.UpdateEquipmentStatusOnAvailableHandlerFunc {
 	return func(s eqStatus.UpdateEquipmentStatusOnAvailableParams, access interface{}) middleware.Responder {
@@ -287,7 +287,7 @@ func (c EquipmentStatus) PutEquipmentStatusRemoveFromRepairFunc(
 	}
 }
 
-func (c EquipmentStatus) PutEquipmentStatusEditDatesFunc(
+func (c EquipmentStatus) PatchEquipmentStatusEditDatesFunc(
 	eqStatusRepository domain.EquipmentStatusRepository,
 ) eqStatus.UpdateRepairedEquipmentStatusDatesHandlerFunc {
 	return func(s eqStatus.UpdateRepairedEquipmentStatusDatesParams, access interface{}) middleware.Responder {

--- a/internal/handlers/equipment_status.go
+++ b/internal/handlers/equipment_status.go
@@ -88,7 +88,8 @@ func (c EquipmentStatus) GetEquipmentStatusCheckDatesFunc(
 		}
 
 		if !eqStatusResult.EndDate.After(time.Time(*data.StartDate)) &&
-			eqStatusResult.StartDate.Before(time.Time(*data.EndDate)) {
+			eqStatusResult.StartDate.Before(time.Time(*data.EndDate)) ||
+			!eqStatusResult.StartDate.Before(time.Time(*data.EndDate)) {
 			return eqStatus.NewCheckEquipmentStatusOK().WithPayload(
 				&models.EquipmentStatusRepairConfirmationResponse{})
 		}

--- a/internal/handlers/equipment_status.go
+++ b/internal/handlers/equipment_status.go
@@ -3,9 +3,11 @@ package handlers
 import (
 	"net/http"
 
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/authentication"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/models"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi/operations"
 	eqStatus "git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi/operations/equipment_status"
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi/operations/orders"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/repositories"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/pkg/domain"
 	"github.com/go-openapi/runtime/middleware"
@@ -33,30 +35,66 @@ func NewEquipmentStatus(logger *zap.Logger) *EquipmentStatus {
 func (c EquipmentStatus) PutEquipmentStatusFunc(eqStatusRepository domain.EquipmentStatusRepository) eqStatus.UpdateEquipmentStatusHandlerFunc {
 	return func(s eqStatus.UpdateEquipmentStatusParams, access interface{}) middleware.Responder {
 		ctx := s.HTTPRequest.Context()
-		statusName := s.Name.StatusName
-		data := models.EquipmentStatus{}
-		data.EndDate = s.Name.EndDate
-		data.StartDate = s.Name.StartDate
-		data.StatusName = statusName
-		data.ID = &s.ID
+		newStatus := s.Name.StatusName
+
+		ok, err := equipmentStatusAccessRights(access)
+		if err != nil {
+			c.logger.Error("Error while getting authorization", zap.Error(err))
+			return orders.NewAddNewOrderStatusDefault(http.StatusInternalServerError).
+				WithPayload(&models.Error{Data: &models.ErrorData{Message: "Can't get authorization"}})
+		}
+
+		if !ok {
+			c.logger.Error("User have no right to update equipment status", zap.Any("access", access))
+			return orders.NewAddNewOrderStatusDefault(http.StatusForbidden).
+				WithPayload(&models.Error{Data: &models.ErrorData{Message: "You don't have rights to update equipment status"}})
+		}
+
+		if !checkStatus(*newStatus) {
+			c.logger.Error("Wrong new equipment status, status should be only 'not available'", zap.Any("access", access))
+			return orders.NewAddNewOrderStatusDefault(http.StatusForbidden).
+				WithPayload(&models.Error{Data: &models.ErrorData{Message: "Wrong new equipment status, status should be only 'not available'"}})
+		}
+
+		data := models.EquipmentStatus{
+			EndDate:    s.Name.EndDate,
+			StartDate:  s.Name.StartDate,
+			StatusName: newStatus,
+			ID:         &s.ID,
+		}
 
 		updatedEqStatus, err := eqStatusRepository.Update(ctx, &data)
 		if err != nil {
-			c.logger.Error("create status failed", zap.Error(err))
+			c.logger.Error("update equipment status failed", zap.Error(err))
 			return eqStatus.NewUpdateEquipmentStatusDefault(http.StatusInternalServerError).
-				WithPayload(buildStringPayload("can't create status"))
+				WithPayload(buildStringPayload("can't update equipment status"))
 		}
 
 		id := int64(updatedEqStatus.ID)
 		endTime := strfmt.DateTime(updatedEqStatus.EndDate)
 		startTime := strfmt.DateTime(updatedEqStatus.StartDate)
-		return eqStatus.NewUpdateEquipmentStatusOK().WithPayload(&models.EquipmentStatusUpdateResponse{
-			Data: &models.EquipmentStatusUpdate{
-				ID:         &id,
-				EndDate:    &endTime,
-				StartDate:  &startTime,
-				StatusName: statusName,
-			},
-		})
+
+		return eqStatus.NewUpdateEquipmentStatusOK().WithPayload(
+			&models.EquipmentStatusUpdateResponse{
+				Data: &models.EquipmentStatusUpdate{
+					ID:         &id,
+					EndDate:    &endTime,
+					StartDate:  &startTime,
+					StatusName: newStatus,
+				},
+			})
 	}
+}
+
+func equipmentStatusAccessRights(access interface{}) (bool, error) {
+	isManager, err := authentication.IsManager(access)
+	if err != nil {
+		return false, err
+	}
+
+	return isManager, nil
+}
+
+func checkStatus(status string) bool {
+	return status == domain.EquipmentStatusNotAvailable
 }

--- a/internal/handlers/equipment_status.go
+++ b/internal/handlers/equipment_status.go
@@ -16,7 +16,8 @@ import (
 	"go.uber.org/zap"
 )
 
-var timeNow = time.Now
+// timeNowEquipmentStatus necessary for mock time in tests
+var timeNowEquipmentStatus = time.Now
 
 const (
 	EQUIPMENT_UNDER_REPAIR_COMMENT_FOR_ORDER = "Equipment under repair"
@@ -29,7 +30,7 @@ func SetEquipmentStatusHandler(logger *zap.Logger, api *operations.BeAPI) {
 	statusHandler := NewEquipmentStatus(logger)
 
 	api.EquipmentStatusUpdateEquipmentStatusOnUnavailableHandler = statusHandler.PutEquipmentStatusInRepairFunc(equipmentStatusRepo, orderStatusRepo)
-	api.EquipmentStatusUpdateEquipmentStatusOnAvailableHandler = statusHandler.DeleteEquipmentStatusRemoveFromRepairFunc(equipmentStatusRepo, orderStatusRepo)
+	api.EquipmentStatusUpdateEquipmentStatusOnAvailableHandler = statusHandler.DeleteEquipmentStatusFromRepairFunc(equipmentStatusRepo, orderStatusRepo)
 	api.EquipmentStatusCheckEquipmentStatusHandler = statusHandler.GetEquipmentStatusCheckDatesFunc(equipmentStatusRepo)
 	api.EquipmentStatusUpdateRepairedEquipmentStatusDatesHandler = statusHandler.PatchEquipmentStatusEditDatesFunc(equipmentStatusRepo)
 }
@@ -162,7 +163,7 @@ func (c EquipmentStatus) PutEquipmentStatusInRepairFunc(
 		}
 
 		comment := EQUIPMENT_UNDER_REPAIR_COMMENT_FOR_ORDER
-		timeNow := timeNow()
+		timeNow := timeNowEquipmentStatus()
 		orderID := int64(orderResult.ID)
 		model := models.NewOrderStatus{
 			Comment:   &comment,
@@ -202,7 +203,7 @@ func (c EquipmentStatus) PutEquipmentStatusInRepairFunc(
 	}
 }
 
-func (c EquipmentStatus) DeleteEquipmentStatusRemoveFromRepairFunc(
+func (c EquipmentStatus) DeleteEquipmentStatusFromRepairFunc(
 	eqStatusRepository domain.EquipmentStatusRepository,
 	orderStatusRepo domain.OrderStatusRepository) eqStatus.UpdateEquipmentStatusOnAvailableHandlerFunc {
 	return func(s eqStatus.UpdateEquipmentStatusOnAvailableParams, access interface{}) middleware.Responder {
@@ -220,7 +221,7 @@ func (c EquipmentStatus) DeleteEquipmentStatusRemoveFromRepairFunc(
 				WithPayload(&models.Error{Data: &models.ErrorData{Message: "Wrong new equipment status, status should be only 'not available'"}})
 		}
 
-		timeNow := time.Now()
+		timeNow := timeNowEquipmentStatus()
 		addOneDayToCurrentDate := strfmt.DateTime(
 			time.Time(timeNow).AddDate(0, 0, 1),
 		)

--- a/internal/handlers/equipment_status.go
+++ b/internal/handlers/equipment_status.go
@@ -238,8 +238,11 @@ func (c EquipmentStatus) PutEquipmentStatusRemoveFromRepairFunc(
 		}
 
 		timeNow := time.Now()
+		addOneDayToCurrentDate := strfmt.DateTime(
+			time.Time(timeNow).AddDate(0, 0, 1),
+		)
 		data := models.EquipmentStatus{
-			EndDate:    (*strfmt.DateTime)(&timeNow),
+			EndDate:    (*strfmt.DateTime)(&addOneDayToCurrentDate),
 			StatusName: newStatus,
 			ID:         &s.EquipmentstatusID,
 		}

--- a/internal/handlers/equipment_status.go
+++ b/internal/handlers/equipment_status.go
@@ -3,108 +3,72 @@ package handlers
 import (
 	"net/http"
 
-	"github.com/go-openapi/runtime/middleware"
-	"go.uber.org/zap"
-
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/models"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi/operations"
-	eqStatusName "git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi/operations/equipment_status_name"
+	eqStatus "git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi/operations/equipment_status"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/repositories"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/pkg/domain"
+	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/strfmt"
+	"go.uber.org/zap"
 )
 
-func SetEquipmentStatusNameHandler(logger *zap.Logger, api *operations.BeAPI) {
-	equipmentStatusNameRepo := repositories.NewEquipmentStatusNameRepository()
-	statusHandler := NewEquipmentStatusName(logger)
+func SetEquipmentStatusHandler(logger *zap.Logger, api *operations.BeAPI) {
+	equipmentStatusRepo := repositories.NewEquipmentStatusRepository()
+	statusHandler := NewEquipmentStatus(logger)
 
-	api.EquipmentStatusNamePostEquipmentStatusNameHandler = statusHandler.PostEquipmentStatusNameFunc(equipmentStatusNameRepo)
-	api.EquipmentStatusNameListEquipmentStatusNamesHandler = statusHandler.ListEquipmentStatusNamesFunc(equipmentStatusNameRepo)
-	api.EquipmentStatusNameGetEquipmentStatusNameHandler = statusHandler.GetEquipmentStatusNameFunc(equipmentStatusNameRepo)
-	api.EquipmentStatusNameDeleteEquipmentStatusNameHandler = statusHandler.DeleteEquipmentStatusNameFunc(equipmentStatusNameRepo)
+	api.EquipmentStatusUpdateEquipmentStatusHandler = statusHandler.PutEquipmentStatusFunc(equipmentStatusRepo)
 }
 
-type EquipmentStatusName struct {
+type EquipmentStatus struct {
 	logger *zap.Logger
 }
 
-func NewEquipmentStatusName(logger *zap.Logger) *EquipmentStatusName {
-	return &EquipmentStatusName{
+func NewEquipmentStatus(logger *zap.Logger) *EquipmentStatus {
+	return &EquipmentStatus{
 		logger: logger,
 	}
 }
 
-func (c EquipmentStatusName) PostEquipmentStatusNameFunc(repository domain.EquipmentStatusNameRepository) eqStatusName.PostEquipmentStatusNameHandlerFunc {
-	return func(s eqStatusName.PostEquipmentStatusNameParams, access interface{}) middleware.Responder {
+func (c EquipmentStatus) PutEquipmentStatusFunc(eqStatusRepository domain.EquipmentStatusRepository) eqStatus.UpdateEquipmentStatusHandlerFunc {
+	return func(s eqStatus.UpdateEquipmentStatusParams, access interface{}) middleware.Responder {
 		ctx := s.HTTPRequest.Context()
-		name := s.Name.Name
-		createdStatus, err := repository.Create(ctx, *name)
+		statusName := s.Name.StatusName
+		data := models.EquipmentStatus{}
+		data.EndDate = s.Name.EndDate
+		data.StartDate = s.Name.StartDate
+		data.StatusName = statusName
+		data.ID = &s.ID
+
+		updatedEqStatus, err := eqStatusRepository.Update(ctx, &data)
 		if err != nil {
 			c.logger.Error("create status failed", zap.Error(err))
-			return eqStatusName.NewPostEquipmentStatusNameDefault(http.StatusInternalServerError).
+			return eqStatus.NewUpdateEquipmentStatusDefault(http.StatusInternalServerError).
 				WithPayload(buildStringPayload("can't create status"))
 		}
 
-		return eqStatusName.NewPostEquipmentStatusNameCreated().WithPayload(&models.SuccessEquipmentStatusNameOperationResponse{
-			Data: mapEquipmentStatusName(createdStatus),
+		id := int64(updatedEqStatus.ID)
+		endTime := strfmt.DateTime(updatedEqStatus.EndDate)
+		startTime := strfmt.DateTime(updatedEqStatus.StartDate)
+
+		return eqStatus.NewUpdateEquipmentStatusOK().WithPayload(&models.EquipmentStatusUpdateResponse{
+			ID:         &id,
+			EndDate:    &endTime,
+			StartDate:  &startTime,
+			StatusName: statusName,
 		})
 	}
 }
 
-func (c EquipmentStatusName) ListEquipmentStatusNamesFunc(repository domain.EquipmentStatusNameRepository) eqStatusName.ListEquipmentStatusNamesHandlerFunc {
-	return func(s eqStatusName.ListEquipmentStatusNamesParams, access interface{}) middleware.Responder {
-		ctx := s.HTTPRequest.Context()
-		statuses, err := repository.GetAll(ctx)
-		if err != nil {
-			c.logger.Error("get statuses failed", zap.Error(err))
-			return eqStatusName.NewListEquipmentStatusNamesDefault(http.StatusInternalServerError).
-				WithPayload(buildStringPayload("can't get statuses"))
-		}
-		listStatuses := models.ListEquipmentStatusNames{}
-		for _, element := range statuses {
-			listStatuses = append(listStatuses, mapEquipmentStatusName(element))
-		}
-		return eqStatusName.NewListEquipmentStatusNamesOK().WithPayload(listStatuses)
-	}
-}
-
-func (c EquipmentStatusName) GetEquipmentStatusNameFunc(repository domain.EquipmentStatusNameRepository) eqStatusName.GetEquipmentStatusNameHandlerFunc {
-	return func(s eqStatusName.GetEquipmentStatusNameParams, access interface{}) middleware.Responder {
-		ctx := s.HTTPRequest.Context()
-		foundStatus, err := repository.Get(ctx, int(s.StatusID))
-		if err != nil {
-			c.logger.Error("get status failed", zap.Error(err))
-			return eqStatusName.NewGetEquipmentStatusNameDefault(http.StatusInternalServerError).
-				WithPayload(buildStringPayload("can't get status"))
-		}
-
-		return eqStatusName.NewGetEquipmentStatusNameOK().WithPayload(&models.SuccessEquipmentStatusNameOperationResponse{
-			Data: mapEquipmentStatusName(foundStatus),
-		})
-	}
-}
-
-func (c EquipmentStatusName) DeleteEquipmentStatusNameFunc(repository domain.EquipmentStatusNameRepository) eqStatusName.DeleteEquipmentStatusNameHandlerFunc {
-	return func(s eqStatusName.DeleteEquipmentStatusNameParams, access interface{}) middleware.Responder {
-		ctx := s.HTTPRequest.Context()
-		deletedStatus, err := repository.Delete(ctx, int(s.StatusID))
-		if err != nil {
-			c.logger.Error("delete status failed", zap.Error(err))
-			return eqStatusName.NewDeleteEquipmentStatusNameDefault(http.StatusInternalServerError).
-				WithPayload(buildStringPayload("can't delete status"))
-		}
-		return eqStatusName.NewDeleteEquipmentStatusNameOK().WithPayload(
-			&models.SuccessEquipmentStatusNameOperationResponse{
-				Data: mapEquipmentStatusName(deletedStatus),
-			},
-		)
-	}
-}
-
-func mapEquipmentStatusName(status *ent.EquipmentStatusName) *models.EquipmentStatusName {
-	id := int64(status.ID)
-	return &models.EquipmentStatusName{
-		ID:   id,
-		Name: &status.Name,
+func mapEquipmentStatus(eqStatus *ent.EquipmentStatus) *models.EquipmentStatusUpdateResponse {
+	id := int64(eqStatus.ID)
+	endTime := strfmt.DateTime(eqStatus.EndDate)
+	startTime := strfmt.DateTime(eqStatus.StartDate)
+	return &models.EquipmentStatusUpdateResponse{
+		ID:         &id,
+		EndDate:    &endTime,
+		StartDate:  &startTime,
+		StatusName: &eqStatus.Edges.EquipmentStatusName.Name,
 	}
 }

--- a/internal/handlers/equipment_status.go
+++ b/internal/handlers/equipment_status.go
@@ -16,6 +16,8 @@ import (
 	"go.uber.org/zap"
 )
 
+var timeNow = time.Now
+
 const (
 	EQUIPMENT_UNDER_REPAIR_COMMENT_FOR_ORDER = "Equipment under repair"
 )
@@ -178,7 +180,7 @@ func (c EquipmentStatus) PutEquipmentStatusInRepairFunc(
 		}
 
 		comment := EQUIPMENT_UNDER_REPAIR_COMMENT_FOR_ORDER
-		timeNow := time.Now()
+		timeNow := timeNow()
 		orderID := int64(orderResult.ID)
 		model := models.NewOrderStatus{
 			Comment:   &comment,

--- a/internal/handlers/equipment_status.go
+++ b/internal/handlers/equipment_status.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"net/http"
 
-	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/models"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi/operations"
 	eqStatus "git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi/operations/equipment_status"
@@ -51,24 +50,13 @@ func (c EquipmentStatus) PutEquipmentStatusFunc(eqStatusRepository domain.Equipm
 		id := int64(updatedEqStatus.ID)
 		endTime := strfmt.DateTime(updatedEqStatus.EndDate)
 		startTime := strfmt.DateTime(updatedEqStatus.StartDate)
-
 		return eqStatus.NewUpdateEquipmentStatusOK().WithPayload(&models.EquipmentStatusUpdateResponse{
-			ID:         &id,
-			EndDate:    &endTime,
-			StartDate:  &startTime,
-			StatusName: statusName,
+			Data: &models.EquipmentStatusUpdate{
+				ID:         &id,
+				EndDate:    &endTime,
+				StartDate:  &startTime,
+				StatusName: statusName,
+			},
 		})
-	}
-}
-
-func mapEquipmentStatus(eqStatus *ent.EquipmentStatus) *models.EquipmentStatusUpdateResponse {
-	id := int64(eqStatus.ID)
-	endTime := strfmt.DateTime(eqStatus.EndDate)
-	startTime := strfmt.DateTime(eqStatus.StartDate)
-	return &models.EquipmentStatusUpdateResponse{
-		ID:         &id,
-		EndDate:    &endTime,
-		StartDate:  &startTime,
-		StatusName: &eqStatus.Edges.EquipmentStatusName.Name,
 	}
 }

--- a/internal/handlers/equipment_status_name.go
+++ b/internal/handlers/equipment_status_name.go
@@ -1,0 +1,110 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/go-openapi/runtime/middleware"
+	"go.uber.org/zap"
+
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent"
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/models"
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi/operations"
+	eqStatusName "git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi/operations/equipment_status_name"
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/repositories"
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/pkg/domain"
+)
+
+func SetEquipmentStatusNameHandler(logger *zap.Logger, api *operations.BeAPI) {
+	equipmentStatusNameRepo := repositories.NewEquipmentStatusNameRepository()
+	statusHandler := NewEquipmentStatusName(logger)
+
+	api.EquipmentStatusNamePostEquipmentStatusNameHandler = statusHandler.PostEquipmentStatusNameFunc(equipmentStatusNameRepo)
+	api.EquipmentStatusNameListEquipmentStatusNamesHandler = statusHandler.ListEquipmentStatusNamesFunc(equipmentStatusNameRepo)
+	api.EquipmentStatusNameGetEquipmentStatusNameHandler = statusHandler.GetEquipmentStatusNameFunc(equipmentStatusNameRepo)
+	api.EquipmentStatusNameDeleteEquipmentStatusNameHandler = statusHandler.DeleteEquipmentStatusNameFunc(equipmentStatusNameRepo)
+}
+
+type EquipmentStatusName struct {
+	logger *zap.Logger
+}
+
+func NewEquipmentStatusName(logger *zap.Logger) *EquipmentStatusName {
+	return &EquipmentStatusName{
+		logger: logger,
+	}
+}
+
+func (c EquipmentStatusName) PostEquipmentStatusNameFunc(repository domain.EquipmentStatusNameRepository) eqStatusName.PostEquipmentStatusNameHandlerFunc {
+	return func(s eqStatusName.PostEquipmentStatusNameParams, access interface{}) middleware.Responder {
+		ctx := s.HTTPRequest.Context()
+		name := s.Name.Name
+		createdStatus, err := repository.Create(ctx, *name)
+		if err != nil {
+			c.logger.Error("create status failed", zap.Error(err))
+			return eqStatusName.NewPostEquipmentStatusNameDefault(http.StatusInternalServerError).
+				WithPayload(buildStringPayload("can't create status"))
+		}
+
+		return eqStatusName.NewPostEquipmentStatusNameCreated().WithPayload(&models.SuccessEquipmentStatusNameOperationResponse{
+			Data: mapEquipmentStatusName(createdStatus),
+		})
+	}
+}
+
+func (c EquipmentStatusName) ListEquipmentStatusNamesFunc(repository domain.EquipmentStatusNameRepository) eqStatusName.ListEquipmentStatusNamesHandlerFunc {
+	return func(s eqStatusName.ListEquipmentStatusNamesParams, access interface{}) middleware.Responder {
+		ctx := s.HTTPRequest.Context()
+		statuses, err := repository.GetAll(ctx)
+		if err != nil {
+			c.logger.Error("get statuses failed", zap.Error(err))
+			return eqStatusName.NewListEquipmentStatusNamesDefault(http.StatusInternalServerError).
+				WithPayload(buildStringPayload("can't get statuses"))
+		}
+		listStatuses := models.ListEquipmentStatusNames{}
+		for _, element := range statuses {
+			listStatuses = append(listStatuses, mapEquipmentStatusName(element))
+		}
+		return eqStatusName.NewListEquipmentStatusNamesOK().WithPayload(listStatuses)
+	}
+}
+
+func (c EquipmentStatusName) GetEquipmentStatusNameFunc(repository domain.EquipmentStatusNameRepository) eqStatusName.GetEquipmentStatusNameHandlerFunc {
+	return func(s eqStatusName.GetEquipmentStatusNameParams, access interface{}) middleware.Responder {
+		ctx := s.HTTPRequest.Context()
+		foundStatus, err := repository.Get(ctx, int(s.StatusID))
+		if err != nil {
+			c.logger.Error("get status failed", zap.Error(err))
+			return eqStatusName.NewGetEquipmentStatusNameDefault(http.StatusInternalServerError).
+				WithPayload(buildStringPayload("can't get status"))
+		}
+
+		return eqStatusName.NewGetEquipmentStatusNameOK().WithPayload(&models.SuccessEquipmentStatusNameOperationResponse{
+			Data: mapEquipmentStatusName(foundStatus),
+		})
+	}
+}
+
+func (c EquipmentStatusName) DeleteEquipmentStatusNameFunc(repository domain.EquipmentStatusNameRepository) eqStatusName.DeleteEquipmentStatusNameHandlerFunc {
+	return func(s eqStatusName.DeleteEquipmentStatusNameParams, access interface{}) middleware.Responder {
+		ctx := s.HTTPRequest.Context()
+		deletedStatus, err := repository.Delete(ctx, int(s.StatusID))
+		if err != nil {
+			c.logger.Error("delete status failed", zap.Error(err))
+			return eqStatusName.NewDeleteEquipmentStatusNameDefault(http.StatusInternalServerError).
+				WithPayload(buildStringPayload("can't delete status"))
+		}
+		return eqStatusName.NewDeleteEquipmentStatusNameOK().WithPayload(
+			&models.SuccessEquipmentStatusNameOperationResponse{
+				Data: mapEquipmentStatusName(deletedStatus),
+			},
+		)
+	}
+}
+
+func mapEquipmentStatusName(status *ent.EquipmentStatusName) *models.EquipmentStatusName {
+	id := int64(status.ID)
+	return &models.EquipmentStatusName{
+		ID:   id,
+		Name: &status.Name,
+	}
+}

--- a/internal/handlers/equipment_status_name_test.go
+++ b/internal/handlers/equipment_status_name_test.go
@@ -1,0 +1,303 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-openapi/loads"
+	"github.com/go-openapi/runtime"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent"
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent/enttest"
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/mocks"
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/models"
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi"
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi/operations"
+	eqStatusName "git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi/operations/equipment_status_name"
+)
+
+func TestSetEquipmentStatusNameHandler(t *testing.T) {
+	client := enttest.Open(t, "sqlite3", "file:eqstatushandler?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	logger := zap.NewNop()
+
+	swaggerSpec, err := loads.Analyzed(restapi.SwaggerJSON, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	api := operations.NewBeAPI(swaggerSpec)
+	SetEquipmentStatusNameHandler(logger, api)
+	assert.NotEmpty(t, api.EquipmentStatusNamePostEquipmentStatusNameHandler)
+	assert.NotEmpty(t, api.EquipmentStatusNameGetEquipmentStatusNameHandler)
+	assert.NotEmpty(t, api.EquipmentStatusNameGetEquipmentStatusNameHandler)
+	assert.NotEmpty(t, api.EquipmentStatusNameDeleteEquipmentStatusNameHandler)
+}
+
+type EquipmentStatusNameTestSuite struct {
+	suite.Suite
+	logger     *zap.Logger
+	repository *mocks.EquipmentStatusNameRepository
+	handler    *EquipmentStatusName
+}
+
+func ValidStatus(t *testing.T) *ent.EquipmentStatusName {
+	t.Helper()
+	return &ent.EquipmentStatusName{
+		ID:   1,
+		Name: "available",
+	}
+
+}
+
+func TestStatusNameSuite(t *testing.T) {
+	suite.Run(t, new(EquipmentStatusNameTestSuite))
+}
+
+func (s *EquipmentStatusNameTestSuite) SetupTest() {
+	s.logger = zap.NewNop()
+	s.repository = &mocks.EquipmentStatusNameRepository{}
+	s.handler = NewEquipmentStatusName(s.logger)
+}
+
+func (s *EquipmentStatusNameTestSuite) TestStatus_PostStatus_RepoErr() {
+	t := s.T()
+	request := http.Request{}
+	ctx := request.Context()
+
+	statusName := "statusName"
+	data := eqStatusName.PostEquipmentStatusNameParams{
+		HTTPRequest: &request,
+		Name: &models.EquipmentStatusName{
+			Name: &statusName,
+		},
+	}
+	err := errors.New("test")
+	s.repository.On("Create", ctx, statusName).Return(nil, err)
+
+	handlerFunc := s.handler.PostEquipmentStatusNameFunc(s.repository)
+	access := "dummy access"
+	resp := handlerFunc.Handle(data, access)
+
+	responseRecorder := httptest.NewRecorder()
+	producer := runtime.JSONProducer()
+	resp.WriteResponse(responseRecorder, producer)
+	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	s.repository.AssertExpectations(t)
+}
+
+func (s *EquipmentStatusNameTestSuite) TestStatus_PostStatus_OK() {
+	t := s.T()
+	request := http.Request{}
+	ctx := request.Context()
+
+	statusName := "statusName"
+	data := eqStatusName.PostEquipmentStatusNameParams{
+		HTTPRequest: &request,
+		Name: &models.EquipmentStatusName{
+			Name: &statusName,
+		},
+	}
+	statusToReturn := &ent.EquipmentStatusName{
+		ID: 1,
+	}
+	s.repository.On("Create", ctx, statusName).Return(statusToReturn, nil)
+
+	handlerFunc := s.handler.PostEquipmentStatusNameFunc(s.repository)
+	access := "dummy access"
+	resp := handlerFunc.Handle(data, access)
+
+	responseRecorder := httptest.NewRecorder()
+	producer := runtime.JSONProducer()
+	resp.WriteResponse(responseRecorder, producer)
+	assert.Equal(t, http.StatusCreated, responseRecorder.Code)
+
+	responseStatus := models.SuccessEquipmentStatusNameOperationResponse{}
+	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseStatus)
+	if err != nil {
+		t.Errorf("Error unmarshalling response: %v", err)
+	}
+	assert.Equal(t, statusToReturn.ID, int(responseStatus.Data.ID))
+
+	s.repository.AssertExpectations(t)
+}
+
+func (s *EquipmentStatusNameTestSuite) TestStatus_ListEquipmentStatusNames_RepoErr() {
+	t := s.T()
+	request := http.Request{}
+	ctx := request.Context()
+
+	data := eqStatusName.ListEquipmentStatusNamesParams{
+		HTTPRequest: &request,
+	}
+	err := errors.New("test")
+	s.repository.On("GetAll", ctx).Return(nil, err)
+
+	handlerFunc := s.handler.ListEquipmentStatusNamesFunc(s.repository)
+	access := "dummy access"
+	resp := handlerFunc.Handle(data, access)
+
+	responseRecorder := httptest.NewRecorder()
+	producer := runtime.JSONProducer()
+	resp.WriteResponse(responseRecorder, producer)
+	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	s.repository.AssertExpectations(t)
+}
+
+func (s *EquipmentStatusNameTestSuite) TestStatus_ListEquipmentStatusNames_OK() {
+	t := s.T()
+	request := http.Request{}
+	ctx := request.Context()
+
+	data := eqStatusName.ListEquipmentStatusNamesParams{
+		HTTPRequest: &request,
+	}
+	var statusesToReturn []*ent.EquipmentStatusName
+	statusToReturn := &ent.EquipmentStatusName{
+		ID: 1,
+	}
+	statusesToReturn = append(statusesToReturn, statusToReturn)
+	s.repository.On("GetAll", ctx).Return(statusesToReturn, nil)
+
+	handlerFunc := s.handler.ListEquipmentStatusNamesFunc(s.repository)
+	access := "dummy access"
+	resp := handlerFunc.Handle(data, access)
+
+	responseRecorder := httptest.NewRecorder()
+	producer := runtime.JSONProducer()
+	resp.WriteResponse(responseRecorder, producer)
+	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+
+	var responseStatus []models.EquipmentStatusName
+	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseStatus)
+	if err != nil {
+		t.Errorf("Error unmarshalling response: %v", err)
+	}
+	assert.Equal(t, len(statusesToReturn), len(responseStatus))
+	assert.Equal(t, statusToReturn.ID, int(responseStatus[0].ID))
+
+	s.repository.AssertExpectations(t)
+}
+
+func (s *EquipmentStatusNameTestSuite) TestStatus_GetEquipmentStatusName_RepoErr() {
+	t := s.T()
+	request := http.Request{}
+	ctx := request.Context()
+
+	statusID := 1
+	data := eqStatusName.GetEquipmentStatusNameParams{
+		HTTPRequest: &request,
+		StatusID:    int64(statusID),
+	}
+	err := errors.New("test")
+	s.repository.On("Get", ctx, statusID).Return(nil, err)
+
+	handlerFunc := s.handler.GetEquipmentStatusNameFunc(s.repository)
+	access := "dummy access"
+	resp := handlerFunc.Handle(data, access)
+
+	responseRecorder := httptest.NewRecorder()
+	producer := runtime.JSONProducer()
+	resp.WriteResponse(responseRecorder, producer)
+	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	s.repository.AssertExpectations(t)
+}
+
+func (s *EquipmentStatusNameTestSuite) TestStatus_GetEquipmentStatusName_OK() {
+	t := s.T()
+	request := http.Request{}
+	ctx := request.Context()
+
+	statusID := 1
+	data := eqStatusName.GetEquipmentStatusNameParams{
+		HTTPRequest: &request,
+		StatusID:    int64(statusID),
+	}
+	statusToReturn := &ent.EquipmentStatusName{
+		ID: 1,
+	}
+	s.repository.On("Get", ctx, statusID).Return(statusToReturn, nil)
+
+	handlerFunc := s.handler.GetEquipmentStatusNameFunc(s.repository)
+	access := "dummy access"
+	resp := handlerFunc.Handle(data, access)
+
+	responseRecorder := httptest.NewRecorder()
+	producer := runtime.JSONProducer()
+	resp.WriteResponse(responseRecorder, producer)
+	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+
+	responseStatus := models.SuccessEquipmentStatusNameOperationResponse{}
+	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseStatus)
+	if err != nil {
+		t.Errorf("Error unmarshalling response: %v", err)
+	}
+	assert.Equal(t, statusToReturn.ID, int(responseStatus.Data.ID))
+
+	s.repository.AssertExpectations(t)
+}
+
+func (s *EquipmentStatusNameTestSuite) TestStatus_DeleteEquipmentStatusName_RepoErr() {
+	t := s.T()
+	request := http.Request{}
+	ctx := request.Context()
+
+	statusID := 1
+	data := eqStatusName.DeleteEquipmentStatusNameParams{
+		HTTPRequest: &request,
+		StatusID:    int64(statusID),
+	}
+	err := errors.New("test")
+	s.repository.On("Delete", ctx, statusID).Return(nil, err)
+
+	handlerFunc := s.handler.DeleteEquipmentStatusNameFunc(s.repository)
+	access := "dummy access"
+	resp := handlerFunc.Handle(data, access)
+
+	responseRecorder := httptest.NewRecorder()
+	producer := runtime.JSONProducer()
+	resp.WriteResponse(responseRecorder, producer)
+	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	s.repository.AssertExpectations(t)
+}
+
+func (s *EquipmentStatusNameTestSuite) TestStatus_DeleteEquipmentStatusName_OK() {
+	t := s.T()
+	request := http.Request{}
+	ctx := request.Context()
+
+	statusID := 1
+	data := eqStatusName.DeleteEquipmentStatusNameParams{
+		HTTPRequest: &request,
+		StatusID:    int64(statusID),
+	}
+	statusToReturn := &ent.EquipmentStatusName{
+		ID: 1,
+	}
+	s.repository.On("Delete", ctx, statusID).Return(statusToReturn, nil)
+
+	handlerFunc := s.handler.DeleteEquipmentStatusNameFunc(s.repository)
+	access := "dummy access"
+	resp := handlerFunc.Handle(data, access)
+
+	responseRecorder := httptest.NewRecorder()
+	producer := runtime.JSONProducer()
+	resp.WriteResponse(responseRecorder, producer)
+	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+
+	responseStatus := models.SuccessEquipmentStatusNameOperationResponse{}
+	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseStatus)
+	if err != nil {
+		t.Errorf("Error unmarshalling response: %v", err)
+	}
+	assert.Equal(t, statusToReturn.ID, int(responseStatus.Data.ID))
+
+	s.repository.AssertExpectations(t)
+}

--- a/internal/handlers/equipment_status_test.go
+++ b/internal/handlers/equipment_status_test.go
@@ -116,11 +116,9 @@ func (s *EquipmentStatusTestSuite) Test_Put_EquipmentStatusInRepairFunc_OK() {
 	userResult := ent.User{ID: 1}
 
 	s.equipmentStatusRepository.On(
-		"GetOrderAndUserByDates",
+		"GetOrderAndUserByEquipmentStatusID",
 		ctx,
 		int(*eqStatusModel.ID),
-		time.Time(*eqStatusModel.StartDate),
-		time.Time(*eqStatusModel.EndDate),
 	).Return(&orderResult, &userResult, nil)
 
 	comment := EQUIPMENT_UNDER_REPAIR_COMMENT_FOR_ORDER

--- a/internal/handlers/equipment_status_test.go
+++ b/internal/handlers/equipment_status_test.go
@@ -269,7 +269,6 @@ func (s *EquipmentStatusTestSuite) Test_Get_EquipmentStatusCheckDates_OK() {
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
 	assert.Equal(t, http.StatusOK, responseRecorder.Code)
-
 	s.equipmentStatusRepository.AssertExpectations(t)
 
 	actualEquipmentStatusResponse := &models.EquipmentStatusRepairConfirmationResponse{}
@@ -303,4 +302,124 @@ func (s *EquipmentStatusTestSuite) Test_Get_EquipmentStatusCheckDates_OK() {
 		t, userResult.Email,
 		*actualEquipmentStatusResponse.Data.UserEmail,
 	)
+
+	// add many dates to end dates, in order for the dates to go out of range
+	newEndDate := endDate.AddDate(0, 0, 20)
+	newStartDate := startDate.AddDate(0, 0, 20)
+	data.Name.EndDate = (*strfmt.DateTime)(&newEndDate)
+	data.Name.StartDate = (*strfmt.DateTime)(&newStartDate)
+	resp = handlerFunc(data, access)
+	responseRecorder = httptest.NewRecorder()
+	producer = runtime.JSONProducer()
+	resp.WriteResponse(responseRecorder, producer)
+	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	s.equipmentStatusRepository.AssertExpectations(t)
+
+	actualEquipmentStatusResponse = &models.EquipmentStatusRepairConfirmationResponse{}
+	err = json.Unmarshal(responseRecorder.Body.Bytes(), actualEquipmentStatusResponse)
+	if err != nil {
+		t.Errorf("unable to unmarshal response body: %v", err)
+	}
+
+	assert.Empty(t, actualEquipmentStatusResponse.Data)
+
+	// subtract many dates from start and end dates
+	newStartDate = startDate.AddDate(0, 0, -20)
+	newEndDate = endDate.AddDate(0, 0, -20)
+	data.Name.EndDate = (*strfmt.DateTime)(&newEndDate)
+	data.Name.StartDate = (*strfmt.DateTime)(&newStartDate)
+
+	resp = handlerFunc(data, access)
+	responseRecorder = httptest.NewRecorder()
+	producer = runtime.JSONProducer()
+	resp.WriteResponse(responseRecorder, producer)
+	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	s.equipmentStatusRepository.AssertExpectations(t)
+
+	actualEquipmentStatusResponse = &models.EquipmentStatusRepairConfirmationResponse{}
+	err = json.Unmarshal(responseRecorder.Body.Bytes(), actualEquipmentStatusResponse)
+	if err != nil {
+		t.Errorf("unable to unmarshal response body: %v", err)
+	}
+	assert.Empty(t, actualEquipmentStatusResponse.Data)
+
+	// add one date to end date, the start date does not change
+	newEndDate = endDate.AddDate(0, 0, 1)
+	newStartDate = startDate
+	data.Name.EndDate = (*strfmt.DateTime)(&newEndDate)
+	data.Name.StartDate = (*strfmt.DateTime)(&newStartDate)
+
+	resp = handlerFunc(data, access)
+	responseRecorder = httptest.NewRecorder()
+	producer = runtime.JSONProducer()
+	resp.WriteResponse(responseRecorder, producer)
+	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	s.equipmentStatusRepository.AssertExpectations(t)
+
+	actualEquipmentStatusResponse = &models.EquipmentStatusRepairConfirmationResponse{}
+	err = json.Unmarshal(responseRecorder.Body.Bytes(), actualEquipmentStatusResponse)
+	if err != nil {
+		t.Errorf("unable to unmarshal response body: %v", err)
+	}
+	assert.NotEmpty(t, actualEquipmentStatusResponse.Data)
+
+	// subtract one date from start date, the end date does not change
+	newStartDate = startDate.AddDate(0, 0, -1)
+	newEndDate = endDate
+	data.Name.EndDate = (*strfmt.DateTime)(&newEndDate)
+	data.Name.StartDate = (*strfmt.DateTime)(&newStartDate)
+
+	resp = handlerFunc(data, access)
+	responseRecorder = httptest.NewRecorder()
+	producer = runtime.JSONProducer()
+	resp.WriteResponse(responseRecorder, producer)
+	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	s.equipmentStatusRepository.AssertExpectations(t)
+
+	actualEquipmentStatusResponse = &models.EquipmentStatusRepairConfirmationResponse{}
+	err = json.Unmarshal(responseRecorder.Body.Bytes(), actualEquipmentStatusResponse)
+	if err != nil {
+		t.Errorf("unable to unmarshal response body: %v", err)
+	}
+	assert.NotEmpty(t, actualEquipmentStatusResponse)
+
+	// add one date to start and end dates
+	newStartDate = startDate.AddDate(0, 0, 1)
+	newEndDate = endDate.AddDate(0, 0, 1)
+	data.Name.EndDate = (*strfmt.DateTime)(&newEndDate)
+	data.Name.StartDate = (*strfmt.DateTime)(&newStartDate)
+
+	resp = handlerFunc(data, access)
+	responseRecorder = httptest.NewRecorder()
+	producer = runtime.JSONProducer()
+	resp.WriteResponse(responseRecorder, producer)
+	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	s.equipmentStatusRepository.AssertExpectations(t)
+
+	actualEquipmentStatusResponse = &models.EquipmentStatusRepairConfirmationResponse{}
+	err = json.Unmarshal(responseRecorder.Body.Bytes(), actualEquipmentStatusResponse)
+	if err != nil {
+		t.Errorf("unable to unmarshal response body: %v", err)
+	}
+	assert.NotEmpty(t, actualEquipmentStatusResponse)
+
+	// subtract one date to start and end dates
+	newStartDate = startDate.AddDate(0, 0, -1)
+	newEndDate = endDate.AddDate(0, 0, -1)
+	data.Name.EndDate = (*strfmt.DateTime)(&newEndDate)
+	data.Name.StartDate = (*strfmt.DateTime)(&newStartDate)
+
+	resp = handlerFunc(data, access)
+	responseRecorder = httptest.NewRecorder()
+	producer = runtime.JSONProducer()
+	resp.WriteResponse(responseRecorder, producer)
+	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	s.equipmentStatusRepository.AssertExpectations(t)
+
+	actualEquipmentStatusResponse = &models.EquipmentStatusRepairConfirmationResponse{}
+	err = json.Unmarshal(responseRecorder.Body.Bytes(), actualEquipmentStatusResponse)
+	if err != nil {
+		t.Errorf("unable to unmarshal response body: %v", err)
+	}
+	assert.NotEmpty(t, actualEquipmentStatusResponse)
 }

--- a/internal/handlers/equipment_status_test.go
+++ b/internal/handlers/equipment_status_test.go
@@ -2,25 +2,27 @@ package handlers
 
 import (
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
+
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent"
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/models"
+	eqStatus "git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi/operations/equipment_status"
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/pkg/domain"
+
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent/enttest"
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/mocks"
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi"
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi/operations"
 
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime"
-	_ "github.com/mattn/go-sqlite3"
+	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
-
-	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent"
-	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent/enttest"
-	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/mocks"
-	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/models"
-	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi"
-	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi/operations"
-	eqStatusName "git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi/operations/equipment_status_name"
 )
 
 func TestSetEquipmentStatusHandler(t *testing.T) {
@@ -34,270 +36,114 @@ func TestSetEquipmentStatusHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 	api := operations.NewBeAPI(swaggerSpec)
-	SetEquipmentStatusNameHandler(logger, api)
-	assert.NotEmpty(t, api.EquipmentStatusNamePostEquipmentStatusNameHandler)
-	assert.NotEmpty(t, api.EquipmentStatusNameGetEquipmentStatusNameHandler)
-	assert.NotEmpty(t, api.EquipmentStatusNameGetEquipmentStatusNameHandler)
-	assert.NotEmpty(t, api.EquipmentStatusNameDeleteEquipmentStatusNameHandler)
+	SetEquipmentStatusHandler(logger, api)
+	assert.NotEmpty(t, api.EquipmentStatusCheckEquipmentStatusHandler)
+	assert.NotEmpty(t, api.EquipmentStatusUpdateEquipmentStatusOnAvailableHandler)
+	assert.NotEmpty(t, api.EquipmentStatusUpdateEquipmentStatusOnUnavailableHandler)
+	assert.NotEmpty(t, api.EquipmentStatusUpdateRepairedEquipmentStatusDatesHandler)
 }
 
-type StatusTestSuite struct {
+type EquipmentStatusTestSuite struct {
 	suite.Suite
-	logger     *zap.Logger
-	repository *mocks.EquipmentStatusNameRepository
-	handler    *EquipmentStatusName
-}
-
-func ValidStatus(t *testing.T) *ent.EquipmentStatusName {
-	t.Helper()
-	return &ent.EquipmentStatusName{
-		ID:   1,
-		Name: "available",
-	}
-
+	logger                    *zap.Logger
+	equipmentStatusRepository *mocks.EquipmentStatusRepository
+	orderStatusRepository     *mocks.OrderStatusRepository
+	handler                   *EquipmentStatus
 }
 
 func TestStatusSuite(t *testing.T) {
-	suite.Run(t, new(StatusTestSuite))
+	suite.Run(t, new(EquipmentStatusTestSuite))
 }
 
-func (s *StatusTestSuite) SetupTest() {
+func (s *EquipmentStatusTestSuite) SetupTest() {
 	s.logger = zap.NewNop()
-	s.repository = &mocks.EquipmentStatusNameRepository{}
-	s.handler = NewEquipmentStatusName(s.logger)
+	s.equipmentStatusRepository = &mocks.EquipmentStatusRepository{}
+	s.orderStatusRepository = &mocks.OrderStatusRepository{}
+	s.handler = NewEquipmentStatus(s.logger)
 }
 
-func (s *StatusTestSuite) TestStatus_PostStatus_RepoErr() {
+func (s *EquipmentStatusTestSuite) Test_Put_EquipmentStatusInRepairFunc_OK() {
 	t := s.T()
 	request := http.Request{}
 	ctx := request.Context()
 
 	statusName := "statusName"
-	data := eqStatusName.PostEquipmentStatusNameParams{
-		HTTPRequest: &request,
-		Name: &models.EquipmentStatusName{
-			Name: &statusName,
+	timeNow := time.Now()
+	startDate := time.Date(2023, time.February, 14, 12, 34, 56, 0, time.UTC)
+	endDate := startDate.AddDate(0, 0, 10)
+
+	data := eqStatus.UpdateEquipmentStatusOnUnavailableParams{
+		HTTPRequest:       &request,
+		EquipmentstatusID: 1,
+		Name: &models.EquipmentStatusInRepairRequest{
+			EndDate:    (*strfmt.DateTime)(&endDate),
+			StartDate:  (*strfmt.DateTime)(&startDate),
+			StatusName: &statusName,
 		},
 	}
-	err := errors.New("test")
-	s.repository.On("Create", ctx, statusName).Return(nil, err)
 
-	handlerFunc := s.handler.PostEquipmentStatusNameFunc(s.repository)
-	access := "dummy access"
-	resp := handlerFunc.Handle(data, access)
+	// err := errors.New("test")
 
-	responseRecorder := httptest.NewRecorder()
-	producer := runtime.JSONProducer()
-	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
-	s.repository.AssertExpectations(t)
-}
-
-func (s *StatusTestSuite) TestStatus_PostStatus_OK() {
-	t := s.T()
-	request := http.Request{}
-	ctx := request.Context()
-
-	statusName := "statusName"
-	data := eqStatusName.PostEquipmentStatusNameParams{
-		HTTPRequest: &request,
-		Name: &models.EquipmentStatusName{
-			Name: &statusName,
-		},
+	eqStatusModel := models.EquipmentStatus{
+		StartDate:  (*strfmt.DateTime)(&startDate),
+		EndDate:    (*strfmt.DateTime)(&endDate),
+		StatusName: &statusName,
+		ID:         &data.EquipmentstatusID,
 	}
-	statusToReturn := &ent.EquipmentStatusName{
-		ID: 1,
+
+	eqStatusResponseModel := ent.EquipmentStatus{
+		ID:        int(data.EquipmentstatusID),
+		StartDate: startDate,
+		EndDate:   endDate,
 	}
-	s.repository.On("Create", ctx, statusName).Return(statusToReturn, nil)
 
-	handlerFunc := s.handler.PostEquipmentStatusNameFunc(s.repository)
+	s.equipmentStatusRepository.On("Update", ctx, &eqStatusModel).Return(&eqStatusResponseModel, nil)
+
+	orderResult := ent.Order{ID: 1}
+	userResult := ent.User{ID: 1}
+
+	s.equipmentStatusRepository.On(
+		"GetOrderAndUserByDates",
+		ctx,
+		int(*eqStatusModel.ID),
+		time.Time(*eqStatusModel.StartDate),
+		time.Time(*eqStatusModel.EndDate),
+	).Return(&orderResult, &userResult, nil)
+
+	comment := EQUIPMENT_UNDER_REPAIR_COMMENT_FOR_ORDER
+	orderID := int64(orderResult.ID)
+
+	orderModel := models.NewOrderStatus{
+		Comment:   &comment,
+		CreatedAt: (*strfmt.DateTime)(&timeNow),
+		OrderID:   &orderID,
+		Status:    &domain.OrderStatusRejected,
+	}
+
+	s.orderStatusRepository.On("UpdateStatus", ctx, userResult.ID, orderModel).Return(nil)
+
+	s.equipmentStatusRepository.On(
+		"GetEquipmentStatusByID",
+		ctx,
+		int(*eqStatusModel.ID),
+	).Return(&eqStatusResponseModel, nil)
+
+	handlerFunc := s.handler.PutEquipmentStatusInRepairFunc(
+		s.equipmentStatusRepository, s.orderStatusRepository,
+	)
+
 	access := "dummy access"
-	resp := handlerFunc.Handle(data, access)
-
+	resp := handlerFunc(data, access)
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
 	assert.Equal(t, http.StatusCreated, responseRecorder.Code)
+	s.equipmentStatusRepository.AssertExpectations(t)
 
-	responseStatus := models.SuccessEquipmentStatusNameOperationResponse{}
-	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseStatus)
+	actualEquipment := &models.EquipmentStatusRepairResponse{}
+	err := json.Unmarshal(responseRecorder.Body.Bytes(), actualEquipment)
 	if err != nil {
-		t.Errorf("Error unmarshalling response: %v", err)
+		t.Errorf("unable to unmarshal response body: %v", err)
 	}
-	assert.Equal(t, statusToReturn.ID, int(responseStatus.Data.ID))
-
-	s.repository.AssertExpectations(t)
-}
-
-func (s *StatusTestSuite) TestStatus_ListEquipmentStatusNames_RepoErr() {
-	t := s.T()
-	request := http.Request{}
-	ctx := request.Context()
-
-	data := eqStatusName.ListEquipmentStatusNamesParams{
-		HTTPRequest: &request,
-	}
-	err := errors.New("test")
-	s.repository.On("GetAll", ctx).Return(nil, err)
-
-	handlerFunc := s.handler.ListEquipmentStatusNamesFunc(s.repository)
-	access := "dummy access"
-	resp := handlerFunc.Handle(data, access)
-
-	responseRecorder := httptest.NewRecorder()
-	producer := runtime.JSONProducer()
-	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
-	s.repository.AssertExpectations(t)
-}
-
-func (s *StatusTestSuite) TestStatus_ListEquipmentStatusNames_OK() {
-	t := s.T()
-	request := http.Request{}
-	ctx := request.Context()
-
-	data := eqStatusName.ListEquipmentStatusNamesParams{
-		HTTPRequest: &request,
-	}
-	var statusesToReturn []*ent.EquipmentStatusName
-	statusToReturn := &ent.EquipmentStatusName{
-		ID: 1,
-	}
-	statusesToReturn = append(statusesToReturn, statusToReturn)
-	s.repository.On("GetAll", ctx).Return(statusesToReturn, nil)
-
-	handlerFunc := s.handler.ListEquipmentStatusNamesFunc(s.repository)
-	access := "dummy access"
-	resp := handlerFunc.Handle(data, access)
-
-	responseRecorder := httptest.NewRecorder()
-	producer := runtime.JSONProducer()
-	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
-
-	var responseStatus []models.EquipmentStatusName
-	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseStatus)
-	if err != nil {
-		t.Errorf("Error unmarshalling response: %v", err)
-	}
-	assert.Equal(t, len(statusesToReturn), len(responseStatus))
-	assert.Equal(t, statusToReturn.ID, int(responseStatus[0].ID))
-
-	s.repository.AssertExpectations(t)
-}
-
-func (s *StatusTestSuite) TestStatus_GetEquipmentStatusName_RepoErr() {
-	t := s.T()
-	request := http.Request{}
-	ctx := request.Context()
-
-	statusID := 1
-	data := eqStatusName.GetEquipmentStatusNameParams{
-		HTTPRequest: &request,
-		StatusID:    int64(statusID),
-	}
-	err := errors.New("test")
-	s.repository.On("Get", ctx, statusID).Return(nil, err)
-
-	handlerFunc := s.handler.GetEquipmentStatusNameFunc(s.repository)
-	access := "dummy access"
-	resp := handlerFunc.Handle(data, access)
-
-	responseRecorder := httptest.NewRecorder()
-	producer := runtime.JSONProducer()
-	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
-	s.repository.AssertExpectations(t)
-}
-
-func (s *StatusTestSuite) TestStatus_GetEquipmentStatusName_OK() {
-	t := s.T()
-	request := http.Request{}
-	ctx := request.Context()
-
-	statusID := 1
-	data := eqStatusName.GetEquipmentStatusNameParams{
-		HTTPRequest: &request,
-		StatusID:    int64(statusID),
-	}
-	statusToReturn := &ent.EquipmentStatusName{
-		ID: 1,
-	}
-	s.repository.On("Get", ctx, statusID).Return(statusToReturn, nil)
-
-	handlerFunc := s.handler.GetEquipmentStatusNameFunc(s.repository)
-	access := "dummy access"
-	resp := handlerFunc.Handle(data, access)
-
-	responseRecorder := httptest.NewRecorder()
-	producer := runtime.JSONProducer()
-	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
-
-	responseStatus := models.SuccessEquipmentStatusNameOperationResponse{}
-	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseStatus)
-	if err != nil {
-		t.Errorf("Error unmarshalling response: %v", err)
-	}
-	assert.Equal(t, statusToReturn.ID, int(responseStatus.Data.ID))
-
-	s.repository.AssertExpectations(t)
-}
-
-func (s *StatusTestSuite) TestStatus_DeleteEquipmentStatusName_RepoErr() {
-	t := s.T()
-	request := http.Request{}
-	ctx := request.Context()
-
-	statusID := 1
-	data := eqStatusName.DeleteEquipmentStatusNameParams{
-		HTTPRequest: &request,
-		StatusID:    int64(statusID),
-	}
-	err := errors.New("test")
-	s.repository.On("Delete", ctx, statusID).Return(nil, err)
-
-	handlerFunc := s.handler.DeleteEquipmentStatusNameFunc(s.repository)
-	access := "dummy access"
-	resp := handlerFunc.Handle(data, access)
-
-	responseRecorder := httptest.NewRecorder()
-	producer := runtime.JSONProducer()
-	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
-	s.repository.AssertExpectations(t)
-}
-
-func (s *StatusTestSuite) TestStatus_DeleteEquipmentStatusName_OK() {
-	t := s.T()
-	request := http.Request{}
-	ctx := request.Context()
-
-	statusID := 1
-	data := eqStatusName.DeleteEquipmentStatusNameParams{
-		HTTPRequest: &request,
-		StatusID:    int64(statusID),
-	}
-	statusToReturn := &ent.EquipmentStatusName{
-		ID: 1,
-	}
-	s.repository.On("Delete", ctx, statusID).Return(statusToReturn, nil)
-
-	handlerFunc := s.handler.DeleteEquipmentStatusNameFunc(s.repository)
-	access := "dummy access"
-	resp := handlerFunc.Handle(data, access)
-
-	responseRecorder := httptest.NewRecorder()
-	producer := runtime.JSONProducer()
-	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
-
-	responseStatus := models.SuccessEquipmentStatusNameOperationResponse{}
-	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseStatus)
-	if err != nil {
-		t.Errorf("Error unmarshalling response: %v", err)
-	}
-	assert.Equal(t, statusToReturn.ID, int(responseStatus.Data.ID))
-
-	s.repository.AssertExpectations(t)
+	// assert.Equal(t, equipmentToReturn.Name, *actualEquipment.Name)
 }

--- a/internal/handlers/equipment_status_test.go
+++ b/internal/handlers/equipment_status_test.go
@@ -185,6 +185,18 @@ func (s *EquipmentStatusTestSuite) Test_Put_EquipmentStatusInRepairFunc_OK() {
 		t, eqStatusResponseModel.Edges.EquipmentStatusName.Name,
 		*actualEquipmentStatusResponse.Data.StatusName,
 	)
+
+	// authentication successfully works only for manager, for operator should return 403 error
+	access = authentication.Auth{
+		Role: &authentication.Role{
+			Slug: authentication.OperatorSlug,
+		},
+	}
+	resp = handlerFunc(data, access)
+	responseRecorder = httptest.NewRecorder()
+	producer = runtime.JSONProducer()
+	resp.WriteResponse(responseRecorder, producer)
+	assert.Equal(t, http.StatusForbidden, responseRecorder.Code)
 }
 
 func (s *EquipmentStatusTestSuite) Test_Get_EquipmentStatusCheckDates_OK() {
@@ -419,6 +431,18 @@ func (s *EquipmentStatusTestSuite) Test_Get_EquipmentStatusCheckDates_OK() {
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
 	assert.NotEmpty(t, actualEquipmentStatusResponse)
+
+	// authentication successfully works only for manager, for operator should return 403 error
+	access = authentication.Auth{
+		Role: &authentication.Role{
+			Slug: authentication.OperatorSlug,
+		},
+	}
+	resp = handlerFunc(data, access)
+	responseRecorder = httptest.NewRecorder()
+	producer = runtime.JSONProducer()
+	resp.WriteResponse(responseRecorder, producer)
+	assert.Equal(t, http.StatusForbidden, responseRecorder.Code)
 }
 
 func (s *EquipmentStatusTestSuite) Test_Delete_EquipmentStatusFromRepairFunc_OK() {
@@ -514,6 +538,18 @@ func (s *EquipmentStatusTestSuite) Test_Delete_EquipmentStatusFromRepairFunc_OK(
 		t, eqStatusResponseModel.Edges.EquipmentStatusName.Name,
 		*actualEquipmentStatusResponse.Data.StatusName,
 	)
+
+	// authentication successfully works only for manager, for operator should return 403 error
+	access = authentication.Auth{
+		Role: &authentication.Role{
+			Slug: authentication.OperatorSlug,
+		},
+	}
+	resp = handlerFunc(data, access)
+	responseRecorder = httptest.NewRecorder()
+	producer = runtime.JSONProducer()
+	resp.WriteResponse(responseRecorder, producer)
+	assert.Equal(t, http.StatusForbidden, responseRecorder.Code)
 }
 
 func (s *EquipmentStatusTestSuite) Test_Patch_EquipmentStatusEditDatesFunc_OK() {
@@ -606,4 +642,16 @@ func (s *EquipmentStatusTestSuite) Test_Patch_EquipmentStatusEditDatesFunc_OK() 
 		t, updatedEqStatus.Edges.EquipmentStatusName.Name,
 		*actualEquipmentStatusResponse.Data.StatusName,
 	)
+
+	// authentication successfully works only for manager, for operator should return 403 error
+	access = authentication.Auth{
+		Role: &authentication.Role{
+			Slug: authentication.OperatorSlug,
+		},
+	}
+	resp = handlerFunc(data, access)
+	responseRecorder = httptest.NewRecorder()
+	producer = runtime.JSONProducer()
+	resp.WriteResponse(responseRecorder, producer)
+	assert.Equal(t, http.StatusForbidden, responseRecorder.Code)
 }

--- a/internal/repositories/equipment_status.go
+++ b/internal/repositories/equipment_status.go
@@ -92,11 +92,9 @@ func (r *equipmentStatusRepository) GetEquipmentStatusByID(
 		Only(ctx)
 }
 
-func (r *equipmentStatusRepository) GetOrderAndUserByDates(
+func (r *equipmentStatusRepository) GetOrderAndUserByEquipmentStatusID(
 	ctx context.Context,
-	equipmentStatusID int,
-	startDate,
-	endDate time.Time) (*ent.Order, *ent.User, error) {
+	equipmentStatusID int) (*ent.Order, *ent.User, error) {
 	tx, err := middlewares.TxFromContext(ctx)
 	if err != nil {
 		return nil, nil, err

--- a/internal/repositories/equipment_status.go
+++ b/internal/repositories/equipment_status.go
@@ -102,18 +102,6 @@ func (r *equipmentStatusRepository) GetOrderAndUserByDates(
 		return nil, nil, err
 	}
 
-	eqStatusResult, err := tx.EquipmentStatus.Query().Where(equipmentstatus.ID(equipmentStatusID)).
-		WithEquipmentStatusName().
-		Only(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if !eqStatusResult.EndDate.After(startDate) &&
-		eqStatusResult.StartDate.Before(endDate) {
-		return nil, nil, nil
-	}
-
 	orderResult, err := tx.Order.Query().
 		Where(order.HasEquipmentStatusWith(equipmentstatus.IDEQ(equipmentStatusID))).
 		Only(ctx)

--- a/internal/repositories/equipment_status.go
+++ b/internal/repositories/equipment_status.go
@@ -81,36 +81,41 @@ func (r *equipmentStatusRepository) GetEquipmentsStatusesByOrder(ctx context.Con
 }
 
 func (r *equipmentStatusRepository) GetOrderAndUserByDates(
-	ctx context.Context, id int, startDate, endDate time.Time) (*ent.Order, *ent.User, error) {
+	ctx context.Context,
+	id int,
+	startDate,
+	endDate time.Time) (*ent.EquipmentStatus, *ent.Order, *ent.User, error) {
 	tx, err := middlewares.TxFromContext(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	eqStatusResult, err := tx.EquipmentStatus.Query().Where(equipmentstatus.ID(id)).
+		WithEquipmentStatusName().
 		Only(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	if !eqStatusResult.EndDate.After(startDate) && eqStatusResult.StartDate.Before(endDate) {
-		return nil, nil, nil
+	if !eqStatusResult.EndDate.After(startDate) &&
+		eqStatusResult.StartDate.Before(endDate) {
+		return nil, nil, nil, nil
 	}
 
 	orderResult, err := tx.Order.Query().
 		Where(order.HasEquipmentStatusWith(equipmentstatus.IDEQ(id))).
 		Only(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	userResult, err := tx.User.Query().Where(user.HasOrderWith(order.IDEQ(id))).
 		Only(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	return orderResult, userResult, nil
+	return eqStatusResult, orderResult, userResult, nil
 }
 
 func (r *equipmentStatusRepository) HasStatusByPeriod(ctx context.Context, status string, eqID int,

--- a/pkg/domain/repositories.go
+++ b/pkg/domain/repositories.go
@@ -54,7 +54,7 @@ type EquipmentStatusRepository interface {
 	GetEquipmentsStatusesByOrder(ctx context.Context, orderID int) ([]*ent.EquipmentStatus, error)
 	HasStatusByPeriod(ctx context.Context, status string, eqID int, startDate, endDate time.Time) (bool, error)
 	Update(ctx context.Context, data *models.EquipmentStatus) (*ent.EquipmentStatus, error)
-	GetOrderAndUserByDates(ctx context.Context, id int, startDate, endDate time.Time) (*ent.Order, *ent.User, error)
+	GetOrderAndUserByEquipmentStatusID(ctx context.Context, id int) (*ent.Order, *ent.User, error)
 	GetEquipmentStatusByID(ctx context.Context, equipmentStatusID int) (*ent.EquipmentStatus, error)
 }
 

--- a/pkg/domain/repositories.go
+++ b/pkg/domain/repositories.go
@@ -54,7 +54,7 @@ type EquipmentStatusRepository interface {
 	GetEquipmentsStatusesByOrder(ctx context.Context, orderID int) ([]*ent.EquipmentStatus, error)
 	HasStatusByPeriod(ctx context.Context, status string, eqID int, startDate, endDate time.Time) (bool, error)
 	Update(ctx context.Context, data *models.EquipmentStatus) (*ent.EquipmentStatus, error)
-	GetOrderAndUserByDates(ctx context.Context, id int, startDate, endDate time.Time) (*ent.Order, *ent.User, error)
+	GetOrderAndUserByDates(ctx context.Context, id int, startDate, endDate time.Time) (*ent.EquipmentStatus, *ent.Order, *ent.User, error)
 }
 
 type EquipmentStatusNameRepository interface {

--- a/pkg/domain/repositories.go
+++ b/pkg/domain/repositories.go
@@ -54,6 +54,7 @@ type EquipmentStatusRepository interface {
 	GetEquipmentsStatusesByOrder(ctx context.Context, orderID int) ([]*ent.EquipmentStatus, error)
 	HasStatusByPeriod(ctx context.Context, status string, eqID int, startDate, endDate time.Time) (bool, error)
 	Update(ctx context.Context, data *models.EquipmentStatus) (*ent.EquipmentStatus, error)
+	GetOrderAndUserByDates(ctx context.Context, id int, startDate, endDate time.Time) (*ent.Order, *ent.User, error)
 }
 
 type EquipmentStatusNameRepository interface {

--- a/pkg/domain/repositories.go
+++ b/pkg/domain/repositories.go
@@ -54,7 +54,8 @@ type EquipmentStatusRepository interface {
 	GetEquipmentsStatusesByOrder(ctx context.Context, orderID int) ([]*ent.EquipmentStatus, error)
 	HasStatusByPeriod(ctx context.Context, status string, eqID int, startDate, endDate time.Time) (bool, error)
 	Update(ctx context.Context, data *models.EquipmentStatus) (*ent.EquipmentStatus, error)
-	GetOrderAndUserByDates(ctx context.Context, id int, startDate, endDate time.Time) (*ent.EquipmentStatus, *ent.Order, *ent.User, error)
+	GetOrderAndUserByDates(ctx context.Context, id int, startDate, endDate time.Time) (*ent.Order, *ent.User, error)
+	GetEquipmentStatusByID(ctx context.Context, equipmentStatusID int) (*ent.EquipmentStatus, error)
 }
 
 type EquipmentStatusNameRepository interface {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2173,7 +2173,7 @@ definitions:
       - data
     properties:
       data:
-        $ref: "#/definitions/EquipmentStatusRepair"
+        $ref: "#/definitions/EquipmentStatus"
   #EquipmentStatusRepairConfirmationResponse
   EquipmentStatusRepairConfirmationResponse:
     type: object
@@ -2210,25 +2210,6 @@ definitions:
         type: string
       order_id:
         type: integer
-  #EquipmentStatusRepair
-  EquipmentStatusRepair:
-    type: object
-    required:
-      - equipment_status_id
-      - status_name
-      - start_date
-      - end_date
-    properties:
-      equipment_status_id:
-        type: integer
-      status_name:
-        type: string
-      start_date:
-        type: string
-        format: date-time
-      end_date:
-        type: string
-        format: date-time
   #EquipmentStatus
   EquipmentStatus:
     type: object

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -324,14 +324,14 @@ paths:
           schema:
             $ref: "#/definitions/Error"
 
-  /equipmentstatus/remove_from_repair/{equipmentstatusId}:
+  /equipmentstatus/repaired/{equipmentstatusId}:
     parameters:
       - name: equipmentstatusId
         in: path
         required: true
         description: equipment status id
         type: integer
-    put:
+    delete:
       summary: Change equipment status on available by id.
       security:
         - Bearer: [ ]
@@ -354,13 +354,6 @@ paths:
           description: Unexpected error.
           schema:
             $ref: "#/definitions/Error"
-  /equipmentstatus/in_repair/{equipmentstatusId}:
-    parameters:
-      - name: equipmentstatusId
-        in: path
-        required: true
-        description: equipment status id
-        type: integer
     put:
       summary: Change equipment status on unavailable with start/end dates by id.
       security:
@@ -407,36 +400,29 @@ paths:
           description: Unexpected error.
           schema:
             $ref: "#/definitions/Error"
-  /equipmentstatus/edit_repaired/{equipmentstatusId}:
+    patch:
+      summary: Change repaired equipment status dates by id.
+      security:
+        - Bearer: [ ]
+      tags:
+        - EquipmentStatus
+      operationId: UpdateRepairedEquipmentStatusDates
       parameters:
-        - name: equipmentstatusId
-          in: path
+        - name: name
+          in: body
+          description: "Update repaired equipment status start/end dates"
           required: true
-          description: equipment status id
-          type: integer
-      put:
-        summary: Change repaired equipment status dates by id.
-        security:
-          - Bearer: [ ]
-        tags:
-          - EquipmentStatus
-        operationId: UpdateRepairedEquipmentStatusDates
-        parameters:
-          - name: name
-            in: body
-            description: "Update repaired equipment status start/end dates"
-            required: true
-            schema:
-              $ref: "#/definitions/EquipmentStatusEditDatesRequest"
-        responses:
-          200:
-            description: Repaired equipment status dates updated
-            schema:
-              $ref: "#/definitions/EquipmentStatusRepairResponse"
-          default:
-            description: Unexpected error.
-            schema:
-              $ref: "#/definitions/Error"
+          schema:
+            $ref: "#/definitions/EquipmentStatusEditDatesRequest"
+      responses:
+        200:
+          description: Repaired equipment status dates updated
+          schema:
+            $ref: "#/definitions/EquipmentStatusRepairResponse"
+        default:
+          description: Unexpected error.
+          schema:
+            $ref: "#/definitions/Error"
   /equipment/status_names:
     post:
       summary: Creating a new equipment status.

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -355,7 +355,29 @@ paths:
           description: Unexpected error.
           schema:
             $ref: "#/definitions/Error"
-
+    get:
+      summary: Check that equipment status has orders on provided dates.
+      security:
+        - Bearer: [ ]
+      tags:
+        - EquipmentStatus
+      operationId: CheckEquipmentStatus
+      parameters:
+        - name: name
+          in: body
+          description: "Check equipment status"
+          required: true
+          schema:
+            $ref: "#/definitions/EquipmentStatusUpdateRequest"
+      responses:
+        200:
+          description: Equipment checked
+          schema:
+            $ref: "#/definitions/EquipmentStatusUpdateConfirmationResponse"
+        default:
+          description: Unexpected error.
+          schema:
+            $ref: "#/definitions/Error"
   /equipment/status_names:
     post:
       summary: Creating a new equipment status.
@@ -2072,6 +2094,39 @@ definitions:
     properties:
       data:
         $ref: "#/definitions/EquipmentStatusUpdate"
+  #EquipmentStatusUpdateConfirmationResponse
+  EquipmentStatusUpdateConfirmationResponse:
+    type: object
+    required:
+      - data
+    properties:
+      data:
+        $ref: "#/definitions/EquipmentStatusUpdateConfirmation"
+  #EquipmentStatusUpdateConfirmation
+  EquipmentStatusUpdateConfirmation:
+    type: object
+    required:
+      - equipment_status_id
+      - status_name
+      - start_date
+      - end_date
+      - user_email
+      - order_id
+    properties:
+      equipment_status_id:
+        type: integer
+      status_name:
+        type: string
+      start_date:
+        type: string
+        format: date-time
+      end_date:
+        type: string
+        format: date-time
+      user_email:
+        type: string
+      order_id:
+        type: integer
   #EquipmentStatusUpdate
   EquipmentStatusUpdate:
     type: object
@@ -2091,8 +2146,6 @@ definitions:
       end_date:
         type: string
         format: date-time
-      comment:
-        type: string
       created_at:
         type: string
         format: date-time

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -324,33 +324,62 @@ paths:
           schema:
             $ref: "#/definitions/Error"
 
-
-  /equipmentstatus/{id}:
+  /equipmentstatus/remove_from_repair/{equipmentstatusId}:
     parameters:
-      - name: id
+      - name: equipmentstatusId
         in: path
         required: true
         description: equipment status id
         type: integer
     put:
-      summary: Edit equipment status by id.
+      summary: Change equipment status on available by id.
       security:
         - Bearer: [ ]
       tags:
         - EquipmentStatus
-      operationId: UpdateEquipmentStatus
+      operationId: UpdateEquipmentStatusOnAvailable
       parameters:
         - name: name
           in: body
-          description: "Update equipment status"
+          description: "Change equipment status on available"
           required: true
           schema:
-            $ref: "#/definitions/EquipmentStatusUpdateRequest"
+            $ref: "#/definitions/EquipmentStatusRemoveFromRepairRequest"
       responses:
         200:
-          description: Equipment updated
+          description: Equipment status updated on available
           schema:
-            $ref: "#/definitions/EquipmentStatusUpdateResponse"
+            $ref: "#/definitions/EquipmentStatusRepairResponse"
+        default:
+          description: Unexpected error.
+          schema:
+            $ref: "#/definitions/Error"
+  /equipmentstatus/in_repair/{equipmentstatusId}:
+    parameters:
+      - name: equipmentstatusId
+        in: path
+        required: true
+        description: equipment status id
+        type: integer
+    put:
+      summary: Change equipment status on unavailable with start/end dates by id.
+      security:
+        - Bearer: [ ]
+      tags:
+        - EquipmentStatus
+      operationId: UpdateEquipmentStatusOnUnavailable
+      parameters:
+        - name: name
+          in: body
+          description: "Update equipment status on unavailable"
+          required: true
+          schema:
+            $ref: "#/definitions/EquipmentStatusInRepairRequest"
+      responses:
+        200:
+          description: Equipment status updated on unavailable
+          schema:
+            $ref: "#/definitions/EquipmentStatusRepairResponse"
         default:
           description: Unexpected error.
           schema:
@@ -368,12 +397,12 @@ paths:
           description: "Check equipment status"
           required: true
           schema:
-            $ref: "#/definitions/EquipmentStatusUpdateRequest"
+            $ref: "#/definitions/EquipmentStatusInRepairRequest"
       responses:
         200:
           description: Equipment checked
           schema:
-            $ref: "#/definitions/EquipmentStatusUpdateConfirmationResponse"
+            $ref: "#/definitions/EquipmentStatusRepairConfirmationResponse"
         default:
           description: Unexpected error.
           schema:
@@ -2070,8 +2099,8 @@ definitions:
     properties:
       name:
         type: string
-  #EquipmentStatusUpdateRequest
-  EquipmentStatusUpdateRequest:
+  #EquipmentStatusInRepairRequest
+  EquipmentStatusInRepairRequest:
     type: object
     required:
       - status_name
@@ -2086,24 +2115,32 @@ definitions:
       end_date:
         type: string
         format: date-time
-  #EquipmentStatusUpdateResponse
-  EquipmentStatusUpdateResponse:
+  #EquipmentStatusRemoveFromRepairRequest
+  EquipmentStatusRemoveFromRepairRequest:
+    type: object
+    required:
+      - status_name
+    properties:
+      status_name:
+        type: string
+  #EquipmentStatusRepairResponse
+  EquipmentStatusRepairResponse:
     type: object
     required:
       - data
     properties:
       data:
-        $ref: "#/definitions/EquipmentStatusUpdate"
-  #EquipmentStatusUpdateConfirmationResponse
-  EquipmentStatusUpdateConfirmationResponse:
+        $ref: "#/definitions/EquipmentStatusRepair"
+  #EquipmentStatusRepairConfirmationResponse
+  EquipmentStatusRepairConfirmationResponse:
     type: object
     required:
       - data
     properties:
       data:
-        $ref: "#/definitions/EquipmentStatusUpdateConfirmation"
-  #EquipmentStatusUpdateConfirmation
-  EquipmentStatusUpdateConfirmation:
+        $ref: "#/definitions/EquipmentStatusRepairConfirmation"
+  #EquipmentStatusRepairConfirmation
+  EquipmentStatusRepairConfirmation:
     type: object
     required:
       - equipment_status_id
@@ -2127,16 +2164,16 @@ definitions:
         type: string
       order_id:
         type: integer
-  #EquipmentStatusUpdate
-  EquipmentStatusUpdate:
+  #EquipmentStatusRepair
+  EquipmentStatusRepair:
     type: object
     required:
-      - id
+      - equipment_status_id
       - status_name
       - start_date
       - end_date
     properties:
-      id:
+      equipment_status_id:
         type: integer
       status_name:
         type: string

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2132,9 +2132,6 @@ definitions:
   #EquipmentStatusEditDatesRequest
   EquipmentStatusEditDatesRequest:
     type: object
-    required:
-      - start_date
-      - end_date
     properties:
       start_date:
         type: string

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -325,6 +325,37 @@ paths:
             $ref: "#/definitions/Error"
 
 
+  /equipmentstatus/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: equipment status id
+        type: integer
+    put:
+      summary: Edit equipment status by id.
+      security:
+        - Bearer: [ ]
+      tags:
+        - EquipmentStatus
+      operationId: UpdateEquipmentStatus
+      parameters:
+        - name: name
+          in: body
+          description: "Update equipment status"
+          required: true
+          schema:
+            $ref: "#/definitions/EquipmentStatusUpdateRequest"
+      responses:
+        200:
+          description: Equipment updated
+          schema:
+            $ref: "#/definitions/EquipmentStatusUpdateResponse"
+        default:
+          description: Unexpected error.
+          schema:
+            $ref: "#/definitions/Error"
+
   /equipment/status_names:
     post:
       summary: Creating a new equipment status.
@@ -2017,6 +2048,41 @@ definitions:
     properties:
       name:
         type: string
+  #EquipmentStatusUpdateRequest
+  EquipmentStatusUpdateRequest:
+    type: object
+    required:
+      - status_name
+      - start_date
+      - end_date
+    properties:
+      status_name:
+        type: string
+      start_date:
+        type: string
+        format: date-time
+      end_date:
+        type: string
+        format: date-time
+  #EquipmentStatusUpdateResponse
+  EquipmentStatusUpdateResponse:
+    type: object
+    required:
+      - id
+      - status_name
+      - start_date
+      - end_date
+    properties:
+      id:
+        type: integer
+      status_name:
+        type: string
+      start_date:
+        type: string
+        format: date-time
+      end_date:
+        type: string
+        format: date-time
   #EquipmentStatus
   EquipmentStatus:
     type: object

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2068,6 +2068,14 @@ definitions:
   EquipmentStatusUpdateResponse:
     type: object
     required:
+      - data
+    properties:
+      data:
+        $ref: "#/definitions/EquipmentStatusUpdate"
+  #EquipmentStatusUpdate
+  EquipmentStatusUpdate:
+    type: object
+    required:
       - id
       - status_name
       - start_date
@@ -2081,6 +2089,11 @@ definitions:
         type: string
         format: date-time
       end_date:
+        type: string
+        format: date-time
+      comment:
+        type: string
+      created_at:
         type: string
         format: date-time
   #EquipmentStatus

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2187,6 +2187,7 @@ definitions:
     type: object
     required:
       - equipment_status_id
+      - equipment_id
       - status_name
       - start_date
       - end_date
@@ -2194,6 +2195,8 @@ definitions:
       - order_id
     properties:
       equipment_status_id:
+        type: integer
+      equipment_id:
         type: integer
       status_name:
         type: string

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -407,6 +407,36 @@ paths:
           description: Unexpected error.
           schema:
             $ref: "#/definitions/Error"
+  /equipmentstatus/edit_repaired/{equipmentstatusId}:
+      parameters:
+        - name: equipmentstatusId
+          in: path
+          required: true
+          description: equipment status id
+          type: integer
+      put:
+        summary: Change repaired equipment status dates by id.
+        security:
+          - Bearer: [ ]
+        tags:
+          - EquipmentStatus
+        operationId: UpdateRepairedEquipmentStatusDates
+        parameters:
+          - name: name
+            in: body
+            description: "Update repaired equipment status start/end dates"
+            required: true
+            schema:
+              $ref: "#/definitions/EquipmentStatusEditDatesRequest"
+        responses:
+          200:
+            description: Repaired equipment status dates updated
+            schema:
+              $ref: "#/definitions/EquipmentStatusRepairResponse"
+          default:
+            description: Unexpected error.
+            schema:
+              $ref: "#/definitions/Error"
   /equipment/status_names:
     post:
       summary: Creating a new equipment status.
@@ -2099,6 +2129,19 @@ definitions:
     properties:
       name:
         type: string
+  #EquipmentStatusEditDatesRequest
+  EquipmentStatusEditDatesRequest:
+    type: object
+    required:
+      - start_date
+      - end_date
+    properties:
+      start_date:
+        type: string
+        format: date-time
+      end_date:
+        type: string
+        format: date-time
   #EquipmentStatusInRepairRequest
   EquipmentStatusInRepairRequest:
     type: object

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2146,9 +2146,6 @@ definitions:
       end_date:
         type: string
         format: date-time
-      created_at:
-        type: string
-        format: date-time
   #EquipmentStatus
   EquipmentStatus:
     type: object


### PR DESCRIPTION
Implemented in this PR:
1.Manager can mark equipment items from available to unavailable status, for repairs.
2.Just manager have access rights for changing this status
3.Manager could determine and edit start/end dates of the period whet equipment item should be unavailable
4.Manager will be informed what orders and users are affected if equipment item has booked periods
5.If manager confirms the unavailable status, the order of this equipment item should be rejected
6.When the start/end date was set, it adds to the database as start_date-1, end_date+1

equipment_status_name file was renamed from equipment_status, because all request in this file refer to equipment_status_name database. This file doesn't contains any improvements.

[Feature-7342](https://jira.epam.com/jira/browse/EPMUII-7342)