### PR TITLE
Add GET /equipment/unavailibility_periods

### DIFF
--- a/cmd/swagger/setup.go
+++ b/cmd/swagger/setup.go
@@ -66,6 +66,7 @@ func SetupAPI(entClient *ent.Client, lg *zap.Logger, conf *config.AppConfig) (*r
 	handlers.SetRoleHandler(lg, api)
 	handlers.SetEquipmentStatusNameHandler(lg, api)
 	handlers.SetEquipmentStatusHandler(lg, api)
+	handlers.SetEquipmentPeriodsHandler(lg, api)
 	handlers.SetUserHandler(lg, api, tokenManager, regConfirmService)
 	handlers.SetPetKindHandler(lg, api)
 	handlers.SetHealthHandler(lg, api)

--- a/internal/handlers/equipment_periods.go
+++ b/internal/handlers/equipment_periods.go
@@ -1,0 +1,38 @@
+package handlers
+
+import (
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi/operations"
+	eqPeriods "git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi/operations/equipment"
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/repositories"
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/pkg/domain"
+	"github.com/go-openapi/runtime/middleware"
+	"go.uber.org/zap"
+)
+
+func SetEquipmentPeriodsHandler(logger *zap.Logger, api *operations.BeAPI) {
+	equipmentStatusRepo := repositories.NewEquipmentStatusRepository()
+
+	equipmentPeriodsHandler := NewEquipmentPeriods(logger)
+	api.EquipmentGetUnavailabilityPeriodsByEquipmentIDHandler = equipmentPeriodsHandler.GetEquipmentUnavailableDatesFunc(equipmentStatusRepo)
+}
+
+type EquipmentPeriods struct {
+	logger *zap.Logger
+}
+
+func NewEquipmentPeriods(logger *zap.Logger) *EquipmentPeriods {
+	return &EquipmentPeriods{
+		logger: logger,
+	}
+}
+
+func (c EquipmentPeriods) GetEquipmentUnavailableDatesFunc(
+	eqStatusRepository domain.EquipmentStatusRepository,
+) eqPeriods.GetUnavailabilityPeriodsByEquipmentIDHandlerFunc {
+	return func(
+		s eqPeriods.GetUnavailabilityPeriodsByEquipmentIDParams,
+		access interface{},
+	) middleware.Responder {
+		return nil
+	}
+}

--- a/internal/handlers/equipment_periods_test.go
+++ b/internal/handlers/equipment_periods_test.go
@@ -1,0 +1,108 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent"
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent/enttest"
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/mocks"
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/models"
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi"
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi/operations"
+	eqPeriods "git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi/operations/equipment"
+	"github.com/go-openapi/loads"
+	"github.com/go-openapi/strfmt"
+
+	"github.com/go-openapi/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+)
+
+func TestSetEquipmentPeriodsHandler(t *testing.T) {
+	client := enttest.Open(t, "sqlite3", "file:eqstatushandler?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	logger := zap.NewNop()
+	swaggerSpec, err := loads.Analyzed(restapi.SwaggerJSON, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	api := operations.NewBeAPI(swaggerSpec)
+	SetEquipmentPeriodsHandler(logger, api)
+	assert.NotEmpty(t, api.EquipmentGetUnavailabilityPeriodsByEquipmentIDHandler)
+}
+
+type EquipmentPeriodsTestSuite struct {
+	suite.Suite
+	logger                    *zap.Logger
+	equipmentStatusRepository *mocks.EquipmentStatusRepository
+	handler                   *EquipmentPeriods
+}
+
+func TestEquipmentPeriodsSuite(t *testing.T) {
+	suite.Run(t, new(EquipmentPeriodsTestSuite))
+}
+
+func (s *EquipmentPeriodsTestSuite) SetupTest() {
+	s.logger = zap.NewNop()
+	s.equipmentStatusRepository = &mocks.EquipmentStatusRepository{}
+	s.handler = NewEquipmentPeriods(s.logger)
+}
+
+func (s *EquipmentPeriodsTestSuite) Test_Get_EquipmentUnavailableDatesFunc_OK() {
+	t := s.T()
+	request := http.Request{}
+	ctx := request.Context()
+
+	data := eqPeriods.GetUnavailabilityPeriodsByEquipmentIDParams{
+		HTTPRequest: &request,
+		EquipmentID: int64(1),
+	}
+
+	startDate := time.Date(2023, time.February, 14, 12, 34, 56, 0, time.UTC)
+	endDate := startDate.AddDate(0, 0, 10)
+	eqStatusResponse := ent.EquipmentStatus{
+		StartDate: startDate,
+		EndDate:   endDate,
+	}
+
+	s.equipmentStatusRepository.On(
+		"GetUnavailableEquipmentStatusByEquipmentID",
+		ctx, int(data.EquipmentID),
+	).Return(&eqStatusResponse, nil)
+
+	handlerFunc := s.handler.GetEquipmentUnavailableDatesFunc(
+		s.equipmentStatusRepository,
+	)
+	access := "dummy access"
+
+	resp := handlerFunc(data, access)
+	responseRecorder := httptest.NewRecorder()
+	producer := runtime.JSONProducer()
+	resp.WriteResponse(responseRecorder, producer)
+
+	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	s.equipmentStatusRepository.AssertExpectations(t)
+
+	actualResponse := &models.EquipmentUnavailabilityPeriodsResponse{}
+	err := json.Unmarshal(responseRecorder.Body.Bytes(), actualResponse)
+	if err != nil {
+		t.Errorf("unable to unmarshal response body: %v", err)
+	}
+
+	assert.Equal(
+		t, (*strfmt.DateTime)(&startDate),
+		actualResponse.Data.StartDate,
+	)
+
+	assert.Equal(
+		t, (*strfmt.DateTime)(&endDate),
+		actualResponse.Data.EndDate,
+	)
+}

--- a/internal/repositories/equipment_status.go
+++ b/internal/repositories/equipment_status.go
@@ -116,6 +116,19 @@ func (r *equipmentStatusRepository) GetOrderAndUserByEquipmentStatusID(
 	return orderResult, userResult, nil
 }
 
+func (r *equipmentStatusRepository) GetUnavailableEquipmentStatusByEquipmentID(
+	ctx context.Context, equipmentID int) (*ent.EquipmentStatus, error) {
+	tx, err := middlewares.TxFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return tx.EquipmentStatus.Query().
+		Where(equipmentstatus.HasEquipmentsWith(equipment.IDEQ(equipmentID))).
+		Where(equipmentstatus.HasEquipmentStatusNameWith(equipmentstatusname.IDEQ(4))).
+		Only(ctx)
+}
+
 func (r *equipmentStatusRepository) HasStatusByPeriod(ctx context.Context, status string, eqID int,
 	startDate, endDate time.Time) (bool, error) {
 	tx, err := middlewares.TxFromContext(ctx)

--- a/pkg/domain/repositories.go
+++ b/pkg/domain/repositories.go
@@ -56,6 +56,7 @@ type EquipmentStatusRepository interface {
 	Update(ctx context.Context, data *models.EquipmentStatus) (*ent.EquipmentStatus, error)
 	GetOrderAndUserByEquipmentStatusID(ctx context.Context, id int) (*ent.Order, *ent.User, error)
 	GetEquipmentStatusByID(ctx context.Context, equipmentStatusID int) (*ent.EquipmentStatus, error)
+	GetUnavailableEquipmentStatusByEquipmentID(ctx context.Context, equipmentID int) (*ent.EquipmentStatus, error)
 }
 
 type EquipmentStatusNameRepository interface {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -579,6 +579,30 @@ paths:
           description: Unexpected error.
           schema:
             $ref: "#/definitions/Error"
+  /equipment/unavailability_periods/{equipmentId}:
+    parameters:
+      - name: equipmentId
+        in: path
+        required: true
+        description: equipment id
+        type: integer
+    get:
+      summary: Get information about the unavailability periods of equipment by id.
+      security:
+        - Bearer: [ ]
+      tags:
+        - Equipment
+      operationId: GetUnavailabilityPeriodsByEquipmentID
+      responses:
+        200:
+          description: Success
+          schema:
+            $ref: "#/definitions/EquipmentUnavailabilityPeriodsResponse"
+        default:
+          description: Unexpected error.
+          schema:
+            $ref: "#/definitions/Error"
+
   /equipment/categories/{categoryId}:
     parameters:
       - name: categoryId
@@ -2165,6 +2189,14 @@ definitions:
     properties:
       data:
         $ref: "#/definitions/EquipmentStatusRepairConfirmation"
+  #EquipmentUnavailabilityPeriodsResponse
+  EquipmentUnavailabilityPeriodsResponse:
+    type: object
+    required:
+      - data
+    properties:
+      data:
+        $ref: "#/definitions/EquipmentUnavailabilityPeriods"
   #EquipmentStatusRepairConfirmation
   EquipmentStatusRepairConfirmation:
     type: object
@@ -2193,6 +2225,19 @@ definitions:
         type: string
       order_id:
         type: integer
+  #EquipmentUnavailabilityPeriods
+  EquipmentUnavailabilityPeriods:
+    type: object
+    required:
+      - start_date
+      - end_date
+    properties:
+      start_date:
+        type: string
+        format: date-time
+      end_date:
+        type: string
+        format: date-time
   #EquipmentStatus
   EquipmentStatus:
     type: object

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -602,7 +602,14 @@ paths:
           description: Unexpected error.
           schema:
             $ref: "#/definitions/Error"
-
+        404:
+          schema:
+            type: string
+          description: Not Found
+        default:
+          description: Unexpected error.
+          schema:
+            $ref: "#/definitions/Error"
   /equipment/categories/{categoryId}:
     parameters:
       - name: categoryId


### PR DESCRIPTION
Implemented new api to provide equipment unavailibility time periods
1) equipment_id - only one parameter
2) Returns start date, end date in response
3) Unit test for checking dates

[Feature-7207](https://jira.epam.com/jira/browse/EPMUII-7207)