### PR TITLE
Remove field maximumAmount for equipment registration form

### DIFF
--- a/er.html
+++ b/er.html
@@ -20,7 +20,6 @@ erDiagram
         int64 inventoryNumber
         string supplier
         string receiptDate
-        int64 maximumAmount
         int64 maximumDays
         string description
     }

--- a/go.sum
+++ b/go.sum
@@ -1238,6 +1238,7 @@ github.com/spf13/cobra v0.0.6/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHN
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
 github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t68Nk=
+github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
@@ -1853,7 +1854,7 @@ golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.7/go.mod h1:LGqMHiF4EqQNHR1JncWGqT5BVaXmza+X+BDGol+dOxo=
-golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
+golang.org/x/tools v0.1.13-0.20220804200503-81c7dc4e4efa h1:uKcci2q7Qtp6nMTC/AAvfNUAldFtJuHWV9/5QWiypts=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/ent/schema/equipment.go
+++ b/internal/ent/schema/equipment.go
@@ -23,7 +23,6 @@ func (Equipment) Fields() []ent.Field {
 		field.Int64("inventoryNumber").Optional(),
 		field.String("supplier").Default("unknown"),
 		field.String("receiptDate").Default("unknown"),
-		field.Int64("maximumAmount").Optional(),
 		field.Int64("maximumDays").Optional(),
 		field.String("description").Default("unknown"),
 	}

--- a/internal/handlers/equipment.go
+++ b/internal/handlers/equipment.go
@@ -260,7 +260,6 @@ func mapEquipmentResponse(eq *ent.Equipment) (*models.EquipmentResponse, error) 
 		InventoryNumber:  &eq.InventoryNumber,
 		Category:         &categoryID,
 		Subcategory:      subcategoryID,
-		MaximumAmount:    &eq.MaximumAmount,
 		MaximumDays:      &eq.MaximumDays,
 		Name:             &eq.Name,
 		ReceiptDate:      &eq.ReceiptDate,

--- a/internal/integration-tests/equipment/integration_test.go
+++ b/internal/integration-tests/equipment/integration_test.go
@@ -61,7 +61,6 @@ func TestIntegration_CreateEquipment(t *testing.T) {
 		assert.Equal(t, model.InventoryNumber, res.Payload.InventoryNumber)
 		assert.Equal(t, model.Category, res.Payload.Category)
 		//assert.Equal(t, location, *res.Payload.Location)
-		assert.Equal(t, model.MaximumAmount, res.Payload.MaximumAmount)
 		assert.Equal(t, model.MaximumDays, res.Payload.MaximumDays)
 		assert.Equal(t, model.Name, res.Payload.Name)
 		assert.Equal(t, model.PetKinds[0], res.Payload.PetKinds[0].ID)
@@ -193,7 +192,6 @@ func TestIntegration_GetEquipment(t *testing.T) {
 		assert.Equal(t, model.Description, res.Payload.Description)
 		assert.Equal(t, model.InventoryNumber, res.Payload.InventoryNumber)
 		assert.Equal(t, model.Category, res.Payload.Category)
-		assert.Equal(t, model.MaximumAmount, res.Payload.MaximumAmount)
 		assert.Equal(t, model.MaximumDays, res.Payload.MaximumDays)
 		assert.Equal(t, model.Name, res.Payload.Name)
 		//assert.Equal(t, model.Location, res.Payload.Location)
@@ -461,7 +459,6 @@ func setParameters(ctx context.Context, client *client.Be, auth runtime.ClientAu
 	}
 
 	location := int64(71)
-	amount := int64(1)
 	mdays := int64(10)
 	catName := "Том"
 	rDate := "2018"
@@ -511,7 +508,6 @@ func setParameters(ctx context.Context, client *client.Be, auth runtime.ClientAu
 		Category:         category.Payload.Data.ID,
 		Subcategory:      subCategoryInt64,
 		Location:         &location,
-		MaximumAmount:    &amount,
 		MaximumDays:      &mdays,
 		Name:             &catName,
 		NameSubstring:    "box",

--- a/internal/integration-tests/orders/order_test.go
+++ b/internal/integration-tests/orders/order_test.go
@@ -418,7 +418,6 @@ func setParameters(ctx context.Context, client *client.Be, auth runtime.ClientAu
 	}
 
 	location := int64(71)
-	amount := int64(1)
 	mdays := int64(10)
 	catName := "Том"
 	rDate := "2018"
@@ -468,7 +467,6 @@ func setParameters(ctx context.Context, client *client.Be, auth runtime.ClientAu
 		Category:         category.Payload.Data.ID,
 		Subcategory:      subCatInt64,
 		Location:         &location,
-		MaximumAmount:    &amount,
 		MaximumDays:      &mdays,
 		Name:             &catName,
 		NameSubstring:    "box",

--- a/internal/repositories/equipment.go
+++ b/internal/repositories/equipment.go
@@ -64,7 +64,6 @@ func (r *equipmentRepository) EquipmentsByFilter(ctx context.Context, filter mod
 			OptionalStringEquipment(filter.Title, equipment.FieldTitle),
 			OptionalBoolEquipment(filter.TechnicalIssues, equipment.FieldTechIssue),
 			OptionalStringEquipment(filter.Condition, equipment.FieldCondition),
-			OptionalIntEquipment(filter.MaximumAmount, equipment.FieldMaximumAmount),
 			OptionalIntEquipment(filter.MaximumDays, equipment.FieldMaximumDays),
 			equipment.HasPetKindsWith(OptionalIntsPetKind(filter.PetKinds, petkind.FieldID)),
 			equipment.HasPetSizeWith(OptionalIntsPetSize(filter.PetSize, petsize.FieldID)),
@@ -103,7 +102,6 @@ func (r *equipmentRepository) CreateEquipment(ctx context.Context, NewEquipment 
 		SetInventoryNumber(*NewEquipment.InventoryNumber).
 		SetSupplier(*NewEquipment.Supplier).
 		SetReceiptDate(*NewEquipment.ReceiptDate).
-		SetMaximumAmount(*NewEquipment.MaximumAmount).
 		SetMaximumDays(*NewEquipment.MaximumDays).
 		SetCategory(&ent.Category{ID: int(*NewEquipment.Category)}).
 		SetCurrentStatus(status).
@@ -220,7 +218,6 @@ func (r *equipmentRepository) EquipmentsByFilterTotal(ctx context.Context, filte
 			OptionalStringEquipment(filter.Title, equipment.FieldTitle),
 			OptionalBoolEquipment(filter.TechnicalIssues, equipment.FieldTechIssue),
 			OptionalStringEquipment(filter.Condition, equipment.FieldCondition),
-			OptionalIntEquipment(filter.MaximumAmount, equipment.FieldMaximumAmount),
 			OptionalIntEquipment(filter.MaximumDays, equipment.FieldMaximumDays),
 			equipment.HasPetKindsWith(OptionalIntsPetKind(filter.PetKinds, petkind.FieldID)),
 			equipment.HasPetSizeWith(OptionalIntsPetSize(filter.PetSize, petsize.FieldID)),
@@ -269,9 +266,6 @@ func (r *equipmentRepository) UpdateEquipmentByID(ctx context.Context, id int, e
 	}
 	if *eq.Category != 0 {
 		edit.SetCategory(&ent.Category{ID: int(*eq.Category)})
-	}
-	if *eq.MaximumAmount != 0 {
-		edit.SetMaximumAmount(*eq.MaximumAmount)
 	}
 	if *eq.MaximumDays != 0 {
 		edit.SetMaximumDays(*eq.MaximumDays)

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2600,7 +2600,6 @@ definitions:
       - inventoryNumber
       - supplier
       - receiptDate
-      - maximumAmount
       - maximumDays
       - location
       - description
@@ -2651,9 +2650,6 @@ definitions:
       receiptDate:
         type: string
         example: "2018"
-      maximumAmount:
-        type: integer
-        example: 3
       maximumDays:
         type: integer
         example: 30
@@ -2719,9 +2715,6 @@ definitions:
       receiptDate:
         type: string
         example: "2018"
-      maximumAmount:
-        type: integer
-        example: 3
       maximumDays:
         type: integer
         example: 30
@@ -2753,7 +2746,6 @@ definitions:
       - inventoryNumber
       - supplier
       - receiptDate
-      - maximumAmount
       - maximumDays
       - location
       - description
@@ -2802,9 +2794,6 @@ definitions:
       receiptDate:
         type: string
         example: "2018"
-      maximumAmount:
-        type: integer
-        example: 3
       maximumDays:
         type: integer
         example: 30


### PR DESCRIPTION
Field maximumAmount from equipment registration and editing froms is no longer relevant
Removed field maximumAmount  from EquipmentStatus, EquipmentStatusResponse, EquipmentFilter.
Removed filed maximumAmount  from unit tests

[Feature-7598](https://jira.epam.com/jira/browse/EPMUII-7598)