### PR TITLE
assert -> require in unit tests

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1174,6 +1174,7 @@ github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
 github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t68Nk=
+github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
@@ -1748,6 +1749,7 @@ golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.7/go.mod h1:LGqMHiF4EqQNHR1JncWGqT5BVaXmza+X+BDGol+dOxo=
+golang.org/x/tools v0.1.13-0.20220804200503-81c7dc4e4efa h1:uKcci2q7Qtp6nMTC/AAvfNUAldFtJuHWV9/5QWiypts=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/authentication/auth_test.go
+++ b/internal/authentication/auth_test.go
@@ -3,7 +3,7 @@ package authentication
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAuth(t *testing.T) {
@@ -20,22 +20,22 @@ func TestAuth(t *testing.T) {
 	a = auth
 
 	b, err := IsAdmin(a)
-	assert.NoError(t, err)
-	assert.Equal(t, true, b)
+	require.NoError(t, err)
+	require.Equal(t, true, b)
 
 	b, err = IsManager(a)
-	assert.NoError(t, err)
-	assert.Equal(t, false, b)
+	require.NoError(t, err)
+	require.Equal(t, false, b)
 
 	b, err = IsOperator(a)
-	assert.NoError(t, err)
-	assert.Equal(t, false, b)
+	require.NoError(t, err)
+	require.Equal(t, false, b)
 
 	userID, err := GetUserId(a)
-	assert.NoError(t, err)
-	assert.Equal(t, 1, userID)
+	require.NoError(t, err)
+	require.Equal(t, 1, userID)
 
 	selectedAuth, err := GetAuth(a)
-	assert.NoError(t, err)
-	assert.Equal(t, &auth, selectedAuth)
+	require.NoError(t, err)
+	require.Equal(t, &auth, selectedAuth)
 }

--- a/internal/config/app_test.go
+++ b/internal/config/app_test.go
@@ -3,13 +3,13 @@ package config
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetAppConfig(t *testing.T) {
 	cfg, err := GetAppConfig("../..")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, "127.0.0.1", cfg.Server.Host)
-	assert.Equal(t, 8080, cfg.Server.Port)
+	require.Equal(t, "127.0.0.1", cfg.Server.Host)
+	require.Equal(t, 8080, cfg.Server.Port)
 }

--- a/internal/db/connection_test.go
+++ b/internal/db/connection_test.go
@@ -3,10 +3,10 @@ package db
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetDB(t *testing.T) {
 	_, _, err := GetDB("host=123")
-	assert.ErrorContains(t, err, "failed to ping sql connection: failed to connect")
+	require.ErrorContains(t, err, "failed to ping sql connection: failed to connect")
 }

--- a/internal/email/sender_impl_test.go
+++ b/internal/email/sender_impl_test.go
@@ -3,8 +3,8 @@ package email
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/config"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/mocks"
@@ -23,15 +23,15 @@ func TestSenderImpl_SendResetLink(t *testing.T) {
 
 	cl := mocks.NewSMTPClient(t)
 	cl.On("Send", mock.MatchedBy(func(d *domain.SendData) bool {
-		assert.Equal(t, conf.SenderFromName, d.FromName)
-		assert.Equal(t, conf.SenderFromAddress, d.FromAddr)
-		assert.Equal(t, email, d.ToAddr)
-		assert.Equal(t, "Password Reset", d.Subject)
+		require.Equal(t, conf.SenderFromName, d.FromName)
+		require.Equal(t, conf.SenderFromAddress, d.FromAddr)
+		require.Equal(t, email, d.ToAddr)
+		require.Equal(t, "Password Reset", d.Subject)
 		return true
 	})).Return(nil)
 
 	s := NewSenderSmtp(conf, cl)
-	assert.NoError(t, s.SendResetLink(email, name, "123"))
+	require.NoError(t, s.SendResetLink(email, name, "123"))
 
 	cl.AssertExpectations(t)
 }
@@ -48,15 +48,15 @@ func TestSenderImpl_SendNewPassword(t *testing.T) {
 
 	cl := mocks.NewSMTPClient(t)
 	cl.On("Send", mock.MatchedBy(func(d *domain.SendData) bool {
-		assert.Equal(t, conf.SenderFromName, d.FromName)
-		assert.Equal(t, conf.SenderFromAddress, d.FromAddr)
-		assert.Equal(t, email, d.ToAddr)
-		assert.Equal(t, "New Password", d.Subject)
+		require.Equal(t, conf.SenderFromName, d.FromName)
+		require.Equal(t, conf.SenderFromAddress, d.FromAddr)
+		require.Equal(t, email, d.ToAddr)
+		require.Equal(t, "New Password", d.Subject)
 		return true
 	})).Return(nil)
 
 	s := NewSenderSmtp(conf, cl)
-	assert.NoError(t, s.SendNewPassword(email, name, "123"))
+	require.NoError(t, s.SendNewPassword(email, name, "123"))
 
 	cl.AssertExpectations(t)
 }
@@ -73,15 +73,15 @@ func TestSenderImpl_SendRegistrationConfirmLink(t *testing.T) {
 
 	cl := mocks.NewSMTPClient(t)
 	cl.On("Send", mock.MatchedBy(func(d *domain.SendData) bool {
-		assert.Equal(t, conf.SenderFromName, d.FromName)
-		assert.Equal(t, conf.SenderFromAddress, d.FromAddr)
-		assert.Equal(t, email, d.ToAddr)
-		assert.Equal(t, "Registration confirmation", d.Subject)
+		require.Equal(t, conf.SenderFromName, d.FromName)
+		require.Equal(t, conf.SenderFromAddress, d.FromAddr)
+		require.Equal(t, email, d.ToAddr)
+		require.Equal(t, "Registration confirmation", d.Subject)
 		return true
 	})).Return(nil)
 
 	s := NewSenderSmtp(conf, cl)
-	assert.NoError(t, s.SendRegistrationConfirmLink(email, name, "123"))
+	require.NoError(t, s.SendRegistrationConfirmLink(email, name, "123"))
 
 	cl.AssertExpectations(t)
 }

--- a/internal/handlers/active_area_test.go
+++ b/internal/handlers/active_area_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime"
 	_ "github.com/mattn/go-sqlite3"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
@@ -39,7 +39,7 @@ func TestSetActiveAreaHandler(t *testing.T) {
 	}
 	api := operations.NewBeAPI(swaggerSpec)
 	SetActiveAreaHandler(logger, api)
-	assert.NotEmpty(t, api.ActiveAreasGetAllActiveAreasHandler)
+	require.NotEmpty(t, api.ActiveAreasGetAllActiveAreasHandler)
 }
 
 type ActiveAreaTestSuite struct {
@@ -100,7 +100,7 @@ func (s *ActiveAreaTestSuite) TestActiveArea_GetActiveAreasFunc_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.repository.AssertExpectations(t)
 }
 
@@ -131,15 +131,15 @@ func (s *ActiveAreaTestSuite) TestActiveArea_GetActiveAreasFunc_LimitGreaterThan
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	var responseAreas models.ListOfActiveAreas
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseAreas)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(s.areas), len(responseAreas.Items))
-	assert.Equal(t, len(s.areas), int(*responseAreas.Total))
+	require.Equal(t, len(s.areas), len(responseAreas.Items))
+	require.Equal(t, len(s.areas), int(*responseAreas.Total))
 	s.repository.AssertExpectations(t)
 }
 
@@ -170,16 +170,16 @@ func (s *ActiveAreaTestSuite) TestActiveArea_GetActiveAreasFunc_LimitLessThanTot
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	var responseAreas models.ListOfActiveAreas
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseAreas)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Greater(t, len(s.areas), len(responseAreas.Items))
-	assert.Equal(t, len(s.areas), int(*responseAreas.Total))
-	assert.Equal(t, int(limit), len(responseAreas.Items))
+	require.Greater(t, len(s.areas), len(responseAreas.Items))
+	require.Equal(t, len(s.areas), int(*responseAreas.Total))
+	require.Equal(t, int(limit), len(responseAreas.Items))
 	s.repository.AssertExpectations(t)
 }
 
@@ -210,16 +210,16 @@ func (s *ActiveAreaTestSuite) TestActiveArea_GetActiveAreasFunc_SecondPage() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	var responseAreas models.ListOfActiveAreas
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseAreas)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Greater(t, len(s.areas), len(responseAreas.Items))
-	assert.Equal(t, len(s.areas), int(*responseAreas.Total))
-	assert.GreaterOrEqual(t, int(limit), len(responseAreas.Items))
+	require.Greater(t, len(s.areas), len(responseAreas.Items))
+	require.Equal(t, len(s.areas), int(*responseAreas.Total))
+	require.GreaterOrEqual(t, int(limit), len(responseAreas.Items))
 	s.repository.AssertExpectations(t)
 }
 
@@ -245,15 +245,15 @@ func (s *ActiveAreaTestSuite) TestActiveArea_GetActiveAreasFunc_EmptyPaginationP
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	var responseAreas models.ListOfActiveAreas
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseAreas)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(s.areas), len(responseAreas.Items))
-	assert.Equal(t, len(s.areas), int(*responseAreas.Total))
+	require.Equal(t, len(s.areas), len(responseAreas.Items))
+	require.Equal(t, len(s.areas), int(*responseAreas.Total))
 	s.repository.AssertExpectations(t)
 }
 
@@ -284,16 +284,16 @@ func (s *ActiveAreaTestSuite) TestActiveArea_GetActiveAreasFunc_SeveralPages() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	var responseAreasFirstPage models.ListOfActiveAreas
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseAreasFirstPage)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Greater(t, len(s.areas), len(responseAreasFirstPage.Items))
-	assert.Equal(t, len(s.areas), int(*responseAreasFirstPage.Total))
-	assert.GreaterOrEqual(t, int(limit), len(responseAreasFirstPage.Items))
+	require.Greater(t, len(s.areas), len(responseAreasFirstPage.Items))
+	require.Equal(t, len(s.areas), int(*responseAreasFirstPage.Total))
+	require.GreaterOrEqual(t, int(limit), len(responseAreasFirstPage.Items))
 
 	offset = limit
 	s.repository.On("TotalActiveAreas", ctx).Return(5, nil)
@@ -304,19 +304,19 @@ func (s *ActiveAreaTestSuite) TestActiveArea_GetActiveAreasFunc_SeveralPages() {
 	responseRecorder = httptest.NewRecorder()
 	producer = runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	var responseAreasSecondPage models.ListOfActiveAreas
 	err = json.Unmarshal(responseRecorder.Body.Bytes(), &responseAreasSecondPage)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Greater(t, len(s.areas), len(responseAreasSecondPage.Items))
-	assert.Equal(t, len(s.areas), int(*responseAreasSecondPage.Total))
-	assert.GreaterOrEqual(t, int(limit), len(responseAreasFirstPage.Items))
+	require.Greater(t, len(s.areas), len(responseAreasSecondPage.Items))
+	require.Equal(t, len(s.areas), int(*responseAreasSecondPage.Total))
+	require.GreaterOrEqual(t, int(limit), len(responseAreasFirstPage.Items))
 
-	assert.Equal(t, len(s.areas), len(responseAreasFirstPage.Items)+len(responseAreasSecondPage.Items))
-	assert.False(t, areasDuplicated(t, responseAreasFirstPage.Items, responseAreasSecondPage.Items))
+	require.Equal(t, len(s.areas), len(responseAreasFirstPage.Items)+len(responseAreasSecondPage.Items))
+	require.False(t, areasDuplicated(t, responseAreasFirstPage.Items, responseAreasSecondPage.Items))
 	s.repository.AssertExpectations(t)
 }
 

--- a/internal/handlers/blocker_test.go
+++ b/internal/handlers/blocker_test.go
@@ -1,15 +1,17 @@
 package handlers
 
 import (
-	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/authentication"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/authentication"
+
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime"
 	_ "github.com/mattn/go-sqlite3"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
@@ -32,8 +34,8 @@ func TestSetBlockerHandler(t *testing.T) {
 	}
 	api := operations.NewBeAPI(swaggerSpec)
 	SetBlockerHandler(logger, api)
-	assert.NotEmpty(t, api.UsersBlockUserHandler)
-	assert.NotEmpty(t, api.UsersUnblockUserHandler)
+	require.NotEmpty(t, api.UsersBlockUserHandler)
+	require.NotEmpty(t, api.UsersUnblockUserHandler)
 }
 
 type BlockerTestSuite struct {
@@ -70,7 +72,7 @@ func (s *BlockerTestSuite) TestBlocker_BlockUserFunc_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 
 	s.blockerRepository.AssertExpectations(t)
 }
@@ -101,7 +103,7 @@ func (s *BlockerTestSuite) TestBlocker_BlockUserFunc_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.blockerRepository.AssertExpectations(t)
 }
 
@@ -122,7 +124,7 @@ func (s *BlockerTestSuite) TestBlocker_UnblockUserFunc_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.blockerRepository.AssertExpectations(t)
 }
 
@@ -151,6 +153,6 @@ func (s *BlockerTestSuite) TestBlocker_UnblockUserFunc_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.blockerRepository.AssertExpectations(t)
 }

--- a/internal/handlers/category_test.go
+++ b/internal/handlers/category_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime"
 	_ "github.com/mattn/go-sqlite3"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
@@ -40,11 +40,11 @@ func TestSetCategoryHandler(t *testing.T) {
 	}
 	api := operations.NewBeAPI(swaggerSpec)
 	SetCategoryHandler(logger, api)
-	assert.NotEmpty(t, api.CategoriesCreateNewCategoryHandler)
-	assert.NotEmpty(t, api.CategoriesGetCategoryByIDHandler)
-	assert.NotEmpty(t, api.CategoriesDeleteCategoryHandler)
-	assert.NotEmpty(t, api.CategoriesGetAllCategoriesHandler)
-	assert.NotEmpty(t, api.CategoriesUpdateCategoryHandler)
+	require.NotEmpty(t, api.CategoriesCreateNewCategoryHandler)
+	require.NotEmpty(t, api.CategoriesGetCategoryByIDHandler)
+	require.NotEmpty(t, api.CategoriesDeleteCategoryHandler)
+	require.NotEmpty(t, api.CategoriesGetAllCategoriesHandler)
+	require.NotEmpty(t, api.CategoriesUpdateCategoryHandler)
 }
 
 type CategoryTestSuite struct {
@@ -91,7 +91,7 @@ func (s *CategoryTestSuite) TestCategory_CreateCategory_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.repository.AssertExpectations(t)
 }
 
@@ -131,18 +131,18 @@ func (s *CategoryTestSuite) TestCategory_CreateCategory_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusCreated, responseRecorder.Code)
+	require.Equal(t, http.StatusCreated, responseRecorder.Code)
 
 	returnedCategory := models.CreateNewCategoryResponse{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &returnedCategory)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, categoryToReturn.ID, int(*returnedCategory.Data.ID))
-	assert.Equal(t, categoryToReturn.Name, *returnedCategory.Data.Name)
-	assert.Equal(t, categoryToReturn.MaxReservationTime, *returnedCategory.Data.MaxReservationTime)
-	assert.Equal(t, categoryToReturn.MaxReservationUnits, *returnedCategory.Data.MaxReservationUnits)
-	assert.Equal(t, categoryToReturn.HasSubcategory, *returnedCategory.Data.HasSubcategory)
+	require.Equal(t, categoryToReturn.ID, int(*returnedCategory.Data.ID))
+	require.Equal(t, categoryToReturn.Name, *returnedCategory.Data.Name)
+	require.Equal(t, categoryToReturn.MaxReservationTime, *returnedCategory.Data.MaxReservationTime)
+	require.Equal(t, categoryToReturn.MaxReservationUnits, *returnedCategory.Data.MaxReservationUnits)
+	require.Equal(t, categoryToReturn.HasSubcategory, *returnedCategory.Data.HasSubcategory)
 
 	s.repository.AssertExpectations(t)
 }
@@ -166,7 +166,7 @@ func (s *CategoryTestSuite) TestCategory_GetAllCategories_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 
 	s.repository.AssertExpectations(t)
 }
@@ -189,15 +189,15 @@ func (s *CategoryTestSuite) TestCategory_GetAllCategories_NotFound() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	var returnedCategories models.ListOfCategories
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &returnedCategories)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, 0, int(*returnedCategories.Total))
-	assert.Equal(t, 0, len(returnedCategories.Items))
+	require.Equal(t, 0, int(*returnedCategories.Total))
+	require.Equal(t, 0, len(returnedCategories.Items))
 
 	s.repository.AssertExpectations(t)
 }
@@ -234,15 +234,15 @@ func (s *CategoryTestSuite) TestCategory_GetAllCategories_EmptyParams() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	var returnedCategories models.ListOfCategories
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &returnedCategories)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(categoriesToReturn), int(*returnedCategories.Total))
-	assert.Equal(t, len(categoriesToReturn), len(returnedCategories.Items))
+	require.Equal(t, len(categoriesToReturn), int(*returnedCategories.Total))
+	require.Equal(t, len(categoriesToReturn), len(returnedCategories.Items))
 
 	s.repository.AssertExpectations(t)
 }
@@ -288,16 +288,16 @@ func (s *CategoryTestSuite) TestCategory_GetAllCategories_LimitGreaterThanTotal(
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	var returnedCategories models.ListOfCategories
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &returnedCategories)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(categoriesToReturn), int(*returnedCategories.Total))
-	assert.Equal(t, len(categoriesToReturn), len(returnedCategories.Items))
-	assert.GreaterOrEqual(t, int(limit), len(returnedCategories.Items))
+	require.Equal(t, len(categoriesToReturn), int(*returnedCategories.Total))
+	require.Equal(t, len(categoriesToReturn), len(returnedCategories.Items))
+	require.GreaterOrEqual(t, int(limit), len(returnedCategories.Items))
 
 	s.repository.AssertExpectations(t)
 }
@@ -343,16 +343,16 @@ func (s *CategoryTestSuite) TestCategory_GetAllCategories_LimitLessThanTotal() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	var returnedCategories models.ListOfCategories
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &returnedCategories)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(categoriesToReturn), int(*returnedCategories.Total))
-	assert.Greater(t, len(categoriesToReturn), len(returnedCategories.Items))
-	assert.GreaterOrEqual(t, int(limit), len(returnedCategories.Items))
+	require.Equal(t, len(categoriesToReturn), int(*returnedCategories.Total))
+	require.Greater(t, len(categoriesToReturn), len(returnedCategories.Items))
+	require.GreaterOrEqual(t, int(limit), len(returnedCategories.Items))
 
 	s.repository.AssertExpectations(t)
 }
@@ -399,17 +399,17 @@ func (s *CategoryTestSuite) TestCategory_GetAllCategories_SecondPage() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	var returnedCategories models.ListOfCategories
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &returnedCategories)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(categoriesToReturn), int(*returnedCategories.Total))
-	assert.Greater(t, len(categoriesToReturn), len(returnedCategories.Items))
-	assert.GreaterOrEqual(t, int(limit), len(returnedCategories.Items))
-	assert.Equal(t, len(categoriesToReturn)-int(offset), len(returnedCategories.Items))
+	require.Equal(t, len(categoriesToReturn), int(*returnedCategories.Total))
+	require.Greater(t, len(categoriesToReturn), len(returnedCategories.Items))
+	require.GreaterOrEqual(t, int(limit), len(returnedCategories.Items))
+	require.Equal(t, len(categoriesToReturn)-int(offset), len(returnedCategories.Items))
 
 	s.repository.AssertExpectations(t)
 }
@@ -456,16 +456,16 @@ func (s *CategoryTestSuite) TestCategory_GetAllCategories_SeveralPages() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	var firstPage models.ListOfCategories
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &firstPage)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(categoriesToReturn), int(*firstPage.Total))
-	assert.Greater(t, len(categoriesToReturn), len(firstPage.Items))
-	assert.Equal(t, int(limit), len(firstPage.Items))
+	require.Equal(t, len(categoriesToReturn), int(*firstPage.Total))
+	require.Greater(t, len(categoriesToReturn), len(firstPage.Items))
+	require.Equal(t, int(limit), len(firstPage.Items))
 
 	offset = limit
 	filter.Offset = filter.Limit
@@ -483,19 +483,19 @@ func (s *CategoryTestSuite) TestCategory_GetAllCategories_SeveralPages() {
 	responseRecorder = httptest.NewRecorder()
 	producer = runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	var secondPage models.ListOfCategories
 	err = json.Unmarshal(responseRecorder.Body.Bytes(), &secondPage)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(categoriesToReturn), int(*secondPage.Total))
-	assert.Greater(t, len(categoriesToReturn), len(secondPage.Items))
-	assert.GreaterOrEqual(t, int(limit), len(secondPage.Items))
-	assert.Equal(t, len(categoriesToReturn)-int(offset), len(secondPage.Items))
+	require.Equal(t, len(categoriesToReturn), int(*secondPage.Total))
+	require.Greater(t, len(categoriesToReturn), len(secondPage.Items))
+	require.GreaterOrEqual(t, int(limit), len(secondPage.Items))
+	require.Equal(t, len(categoriesToReturn)-int(offset), len(secondPage.Items))
 
-	assert.False(t, categoriesDuplicated(t, firstPage.Items, secondPage.Items))
+	require.False(t, categoriesDuplicated(t, firstPage.Items, secondPage.Items))
 	s.repository.AssertExpectations(t)
 }
 
@@ -519,7 +519,7 @@ func (s *CategoryTestSuite) TestCategory_GetCategoryByID_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 
 	s.repository.AssertExpectations(t)
 }
@@ -550,18 +550,18 @@ func (s *CategoryTestSuite) TestCategory_GetCategoryByID_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	returnedCategory := models.GetCategoryByIDResponse{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &returnedCategory)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, categoryToReturn.ID, int(*returnedCategory.Data.ID))
-	assert.Equal(t, categoryToReturn.Name, *returnedCategory.Data.Name)
-	assert.Equal(t, categoryToReturn.MaxReservationTime, *returnedCategory.Data.MaxReservationTime)
-	assert.Equal(t, categoryToReturn.MaxReservationUnits, *returnedCategory.Data.MaxReservationUnits)
-	assert.Equal(t, categoryToReturn.HasSubcategory, *returnedCategory.Data.HasSubcategory)
+	require.Equal(t, categoryToReturn.ID, int(*returnedCategory.Data.ID))
+	require.Equal(t, categoryToReturn.Name, *returnedCategory.Data.Name)
+	require.Equal(t, categoryToReturn.MaxReservationTime, *returnedCategory.Data.MaxReservationTime)
+	require.Equal(t, categoryToReturn.MaxReservationUnits, *returnedCategory.Data.MaxReservationUnits)
+	require.Equal(t, categoryToReturn.HasSubcategory, *returnedCategory.Data.HasSubcategory)
 
 	s.repository.AssertExpectations(t)
 }
@@ -586,7 +586,7 @@ func (s *CategoryTestSuite) TestCategory_DeleteCategory_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 
 	s.repository.AssertExpectations(t)
 }
@@ -610,7 +610,7 @@ func (s *CategoryTestSuite) TestCategory_DeleteCategory_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	s.repository.AssertExpectations(t)
 }
@@ -640,7 +640,7 @@ func (s *CategoryTestSuite) TestCategory_UpdateCategory_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 
 	s.repository.AssertExpectations(t)
 }
@@ -681,18 +681,18 @@ func (s *CategoryTestSuite) TestCategory_UpdateCategory_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	returnedCategory := models.UpdateCategoryResponse{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &returnedCategory)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, updatedCategory.ID, int(*returnedCategory.Data.ID))
-	assert.Equal(t, updatedCategory.Name, *returnedCategory.Data.Name)
-	assert.Equal(t, updatedCategory.MaxReservationTime, *returnedCategory.Data.MaxReservationTime)
-	assert.Equal(t, updatedCategory.MaxReservationUnits, *returnedCategory.Data.MaxReservationUnits)
-	assert.Equal(t, updatedCategory.HasSubcategory, *returnedCategory.Data.HasSubcategory)
+	require.Equal(t, updatedCategory.ID, int(*returnedCategory.Data.ID))
+	require.Equal(t, updatedCategory.Name, *returnedCategory.Data.Name)
+	require.Equal(t, updatedCategory.MaxReservationTime, *returnedCategory.Data.MaxReservationTime)
+	require.Equal(t, updatedCategory.MaxReservationUnits, *returnedCategory.Data.MaxReservationUnits)
+	require.Equal(t, updatedCategory.HasSubcategory, *returnedCategory.Data.HasSubcategory)
 
 	s.repository.AssertExpectations(t)
 }

--- a/internal/handlers/equipment_periods_test.go
+++ b/internal/handlers/equipment_periods_test.go
@@ -7,6 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-openapi/loads"
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/require"
+
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent/enttest"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/mocks"
@@ -14,11 +18,8 @@ import (
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi/operations"
 	eqPeriods "git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi/operations/equipment"
-	"github.com/go-openapi/loads"
-	"github.com/go-openapi/strfmt"
 
 	"github.com/go-openapi/runtime"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 )
@@ -35,7 +36,7 @@ func TestSetEquipmentPeriodsHandler(t *testing.T) {
 
 	api := operations.NewBeAPI(swaggerSpec)
 	SetEquipmentPeriodsHandler(logger, api)
-	assert.NotEmpty(t, api.EquipmentGetUnavailabilityPeriodsByEquipmentIDHandler)
+	require.NotEmpty(t, api.EquipmentGetUnavailabilityPeriodsByEquipmentIDHandler)
 }
 
 type EquipmentPeriodsTestSuite struct {
@@ -87,7 +88,7 @@ func (s *EquipmentPeriodsTestSuite) Test_Get_EquipmentUnavailableDatesFunc_OK() 
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
 
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.equipmentStatusRepository.AssertExpectations(t)
 
 	actualResponse := &models.EquipmentUnavailabilityPeriodsResponse{}
@@ -96,12 +97,12 @@ func (s *EquipmentPeriodsTestSuite) Test_Get_EquipmentUnavailableDatesFunc_OK() 
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
 
-	assert.Equal(
+	require.Equal(
 		t, (*strfmt.DateTime)(&startDate),
 		actualResponse.Data.StartDate,
 	)
 
-	assert.Equal(
+	require.Equal(
 		t, (*strfmt.DateTime)(&endDate),
 		actualResponse.Data.EndDate,
 	)

--- a/internal/handlers/equipment_status_name_test.go
+++ b/internal/handlers/equipment_status_name_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime"
 	_ "github.com/mattn/go-sqlite3"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
@@ -35,10 +35,10 @@ func TestSetEquipmentStatusNameHandler(t *testing.T) {
 	}
 	api := operations.NewBeAPI(swaggerSpec)
 	SetEquipmentStatusNameHandler(logger, api)
-	assert.NotEmpty(t, api.EquipmentStatusNamePostEquipmentStatusNameHandler)
-	assert.NotEmpty(t, api.EquipmentStatusNameGetEquipmentStatusNameHandler)
-	assert.NotEmpty(t, api.EquipmentStatusNameGetEquipmentStatusNameHandler)
-	assert.NotEmpty(t, api.EquipmentStatusNameDeleteEquipmentStatusNameHandler)
+	require.NotEmpty(t, api.EquipmentStatusNamePostEquipmentStatusNameHandler)
+	require.NotEmpty(t, api.EquipmentStatusNameGetEquipmentStatusNameHandler)
+	require.NotEmpty(t, api.EquipmentStatusNameGetEquipmentStatusNameHandler)
+	require.NotEmpty(t, api.EquipmentStatusNameDeleteEquipmentStatusNameHandler)
 }
 
 type EquipmentStatusNameTestSuite struct {
@@ -89,7 +89,7 @@ func (s *EquipmentStatusNameTestSuite) TestStatus_PostStatus_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.repository.AssertExpectations(t)
 }
 
@@ -117,14 +117,14 @@ func (s *EquipmentStatusNameTestSuite) TestStatus_PostStatus_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusCreated, responseRecorder.Code)
+	require.Equal(t, http.StatusCreated, responseRecorder.Code)
 
 	responseStatus := models.SuccessEquipmentStatusNameOperationResponse{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseStatus)
 	if err != nil {
 		t.Errorf("Error unmarshalling response: %v", err)
 	}
-	assert.Equal(t, statusToReturn.ID, int(responseStatus.Data.ID))
+	require.Equal(t, statusToReturn.ID, int(responseStatus.Data.ID))
 
 	s.repository.AssertExpectations(t)
 }
@@ -147,7 +147,7 @@ func (s *EquipmentStatusNameTestSuite) TestStatus_ListEquipmentStatusNames_RepoE
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.repository.AssertExpectations(t)
 }
 
@@ -173,15 +173,15 @@ func (s *EquipmentStatusNameTestSuite) TestStatus_ListEquipmentStatusNames_OK() 
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	var responseStatus []models.EquipmentStatusName
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseStatus)
 	if err != nil {
 		t.Errorf("Error unmarshalling response: %v", err)
 	}
-	assert.Equal(t, len(statusesToReturn), len(responseStatus))
-	assert.Equal(t, statusToReturn.ID, int(responseStatus[0].ID))
+	require.Equal(t, len(statusesToReturn), len(responseStatus))
+	require.Equal(t, statusToReturn.ID, int(responseStatus[0].ID))
 
 	s.repository.AssertExpectations(t)
 }
@@ -206,7 +206,7 @@ func (s *EquipmentStatusNameTestSuite) TestStatus_GetEquipmentStatusName_RepoErr
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.repository.AssertExpectations(t)
 }
 
@@ -232,14 +232,14 @@ func (s *EquipmentStatusNameTestSuite) TestStatus_GetEquipmentStatusName_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	responseStatus := models.SuccessEquipmentStatusNameOperationResponse{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseStatus)
 	if err != nil {
 		t.Errorf("Error unmarshalling response: %v", err)
 	}
-	assert.Equal(t, statusToReturn.ID, int(responseStatus.Data.ID))
+	require.Equal(t, statusToReturn.ID, int(responseStatus.Data.ID))
 
 	s.repository.AssertExpectations(t)
 }
@@ -264,7 +264,7 @@ func (s *EquipmentStatusNameTestSuite) TestStatus_DeleteEquipmentStatusName_Repo
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.repository.AssertExpectations(t)
 }
 
@@ -290,14 +290,14 @@ func (s *EquipmentStatusNameTestSuite) TestStatus_DeleteEquipmentStatusName_OK()
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	responseStatus := models.SuccessEquipmentStatusNameOperationResponse{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseStatus)
 	if err != nil {
 		t.Errorf("Error unmarshalling response: %v", err)
 	}
-	assert.Equal(t, statusToReturn.ID, int(responseStatus.Data.ID))
+	require.Equal(t, statusToReturn.ID, int(responseStatus.Data.ID))
 
 	s.repository.AssertExpectations(t)
 }

--- a/internal/handlers/equipment_status_test.go
+++ b/internal/handlers/equipment_status_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/authentication"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/models"
@@ -21,7 +23,6 @@ import (
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 )
@@ -38,10 +39,10 @@ func TestSetEquipmentStatusHandler(t *testing.T) {
 	}
 	api := operations.NewBeAPI(swaggerSpec)
 	SetEquipmentStatusHandler(logger, api)
-	assert.NotEmpty(t, api.EquipmentStatusCheckEquipmentStatusHandler)
-	assert.NotEmpty(t, api.EquipmentStatusUpdateEquipmentStatusOnAvailableHandler)
-	assert.NotEmpty(t, api.EquipmentStatusUpdateEquipmentStatusOnUnavailableHandler)
-	assert.NotEmpty(t, api.EquipmentStatusUpdateRepairedEquipmentStatusDatesHandler)
+	require.NotEmpty(t, api.EquipmentStatusCheckEquipmentStatusHandler)
+	require.NotEmpty(t, api.EquipmentStatusUpdateEquipmentStatusOnAvailableHandler)
+	require.NotEmpty(t, api.EquipmentStatusUpdateEquipmentStatusOnUnavailableHandler)
+	require.NotEmpty(t, api.EquipmentStatusUpdateRepairedEquipmentStatusDatesHandler)
 }
 
 type EquipmentStatusTestSuite struct {
@@ -153,7 +154,7 @@ func (s *EquipmentStatusTestSuite) Test_Put_EquipmentStatusInRepairFunc_OK() {
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
 
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	s.equipmentStatusRepository.AssertExpectations(t)
 	s.orderStatusRepository.AssertExpectations(t)
@@ -164,24 +165,24 @@ func (s *EquipmentStatusTestSuite) Test_Put_EquipmentStatusInRepairFunc_OK() {
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
 
-	assert.Equal(t, eqStatusModel.ID, actualEquipmentStatusResponse.Data.ID)
-	assert.Equal(
+	require.Equal(t, eqStatusModel.ID, actualEquipmentStatusResponse.Data.ID)
+	require.Equal(
 		t, int64(eqStatusResponseModel.Edges.Equipments.ID),
 		*actualEquipmentStatusResponse.Data.EquipmentID,
 	)
-	assert.Equal(
+	require.Equal(
 		t, (*strfmt.DateTime)(&endDate),
 		actualEquipmentStatusResponse.Data.EndDate,
 	)
-	assert.Equal(
+	require.Equal(
 		t, (*strfmt.DateTime)(&startDate),
 		actualEquipmentStatusResponse.Data.StartDate,
 	)
-	assert.Equal(
+	require.Equal(
 		t, (strfmt.DateTime)(timeNow),
 		actualEquipmentStatusResponse.Data.CreatedAt,
 	)
-	assert.Equal(
+	require.Equal(
 		t, eqStatusResponseModel.Edges.EquipmentStatusName.Name,
 		*actualEquipmentStatusResponse.Data.StatusName,
 	)
@@ -196,7 +197,7 @@ func (s *EquipmentStatusTestSuite) Test_Put_EquipmentStatusInRepairFunc_OK() {
 	responseRecorder = httptest.NewRecorder()
 	producer = runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusForbidden, responseRecorder.Code)
+	require.Equal(t, http.StatusForbidden, responseRecorder.Code)
 }
 
 func (s *EquipmentStatusTestSuite) Test_Get_EquipmentStatusCheckDates_OK() {
@@ -277,7 +278,7 @@ func (s *EquipmentStatusTestSuite) Test_Get_EquipmentStatusCheckDates_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.equipmentStatusRepository.AssertExpectations(t)
 
 	actualEquipmentStatusResponse := &models.EquipmentStatusRepairConfirmationResponse{}
@@ -286,28 +287,28 @@ func (s *EquipmentStatusTestSuite) Test_Get_EquipmentStatusCheckDates_OK() {
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
 
-	assert.Equal(t, data.EquipmentstatusID, *actualEquipmentStatusResponse.Data.EquipmentStatusID)
-	assert.Equal(
+	require.Equal(t, data.EquipmentstatusID, *actualEquipmentStatusResponse.Data.EquipmentStatusID)
+	require.Equal(
 		t, int64(eqStatusResponseModel.Edges.Equipments.ID),
 		*actualEquipmentStatusResponse.Data.EquipmentID,
 	)
-	assert.Equal(
+	require.Equal(
 		t, data.Name.EndDate,
 		actualEquipmentStatusResponse.Data.EndDate,
 	)
-	assert.Equal(
+	require.Equal(
 		t, data.Name.StartDate,
 		actualEquipmentStatusResponse.Data.StartDate,
 	)
-	assert.Equal(
+	require.Equal(
 		t, eqStatusResponseModel.Edges.EquipmentStatusName.Name,
 		*actualEquipmentStatusResponse.Data.StatusName,
 	)
-	assert.Equal(
+	require.Equal(
 		t, int64(orderResult.ID),
 		*actualEquipmentStatusResponse.Data.OrderID,
 	)
-	assert.Equal(
+	require.Equal(
 		t, userResult.Email,
 		*actualEquipmentStatusResponse.Data.UserEmail,
 	)
@@ -321,7 +322,7 @@ func (s *EquipmentStatusTestSuite) Test_Get_EquipmentStatusCheckDates_OK() {
 	responseRecorder = httptest.NewRecorder()
 	producer = runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.equipmentStatusRepository.AssertExpectations(t)
 
 	actualEquipmentStatusResponse = &models.EquipmentStatusRepairConfirmationResponse{}
@@ -330,7 +331,7 @@ func (s *EquipmentStatusTestSuite) Test_Get_EquipmentStatusCheckDates_OK() {
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
 
-	assert.Empty(t, actualEquipmentStatusResponse.Data)
+	require.Empty(t, actualEquipmentStatusResponse.Data)
 
 	// subtract many dates from start and end dates
 	newStartDate = startDate.AddDate(0, 0, -20)
@@ -342,7 +343,7 @@ func (s *EquipmentStatusTestSuite) Test_Get_EquipmentStatusCheckDates_OK() {
 	responseRecorder = httptest.NewRecorder()
 	producer = runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.equipmentStatusRepository.AssertExpectations(t)
 
 	actualEquipmentStatusResponse = &models.EquipmentStatusRepairConfirmationResponse{}
@@ -350,7 +351,7 @@ func (s *EquipmentStatusTestSuite) Test_Get_EquipmentStatusCheckDates_OK() {
 	if err != nil {
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
-	assert.Empty(t, actualEquipmentStatusResponse.Data)
+	require.Empty(t, actualEquipmentStatusResponse.Data)
 
 	// add one date to end date, the start date does not change
 	newEndDate = endDate.AddDate(0, 0, 1)
@@ -362,7 +363,7 @@ func (s *EquipmentStatusTestSuite) Test_Get_EquipmentStatusCheckDates_OK() {
 	responseRecorder = httptest.NewRecorder()
 	producer = runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.equipmentStatusRepository.AssertExpectations(t)
 
 	actualEquipmentStatusResponse = &models.EquipmentStatusRepairConfirmationResponse{}
@@ -370,7 +371,7 @@ func (s *EquipmentStatusTestSuite) Test_Get_EquipmentStatusCheckDates_OK() {
 	if err != nil {
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
-	assert.NotEmpty(t, actualEquipmentStatusResponse.Data)
+	require.NotEmpty(t, actualEquipmentStatusResponse.Data)
 
 	// subtract one date from start date, the end date does not change
 	newStartDate = startDate.AddDate(0, 0, -1)
@@ -382,7 +383,7 @@ func (s *EquipmentStatusTestSuite) Test_Get_EquipmentStatusCheckDates_OK() {
 	responseRecorder = httptest.NewRecorder()
 	producer = runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.equipmentStatusRepository.AssertExpectations(t)
 
 	actualEquipmentStatusResponse = &models.EquipmentStatusRepairConfirmationResponse{}
@@ -390,7 +391,7 @@ func (s *EquipmentStatusTestSuite) Test_Get_EquipmentStatusCheckDates_OK() {
 	if err != nil {
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
-	assert.NotEmpty(t, actualEquipmentStatusResponse)
+	require.NotEmpty(t, actualEquipmentStatusResponse)
 
 	// add one date to start and end dates
 	newStartDate = startDate.AddDate(0, 0, 1)
@@ -402,7 +403,7 @@ func (s *EquipmentStatusTestSuite) Test_Get_EquipmentStatusCheckDates_OK() {
 	responseRecorder = httptest.NewRecorder()
 	producer = runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.equipmentStatusRepository.AssertExpectations(t)
 
 	actualEquipmentStatusResponse = &models.EquipmentStatusRepairConfirmationResponse{}
@@ -410,7 +411,7 @@ func (s *EquipmentStatusTestSuite) Test_Get_EquipmentStatusCheckDates_OK() {
 	if err != nil {
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
-	assert.NotEmpty(t, actualEquipmentStatusResponse)
+	require.NotEmpty(t, actualEquipmentStatusResponse)
 
 	// subtract one date to start and end dates
 	newStartDate = startDate.AddDate(0, 0, -1)
@@ -422,7 +423,7 @@ func (s *EquipmentStatusTestSuite) Test_Get_EquipmentStatusCheckDates_OK() {
 	responseRecorder = httptest.NewRecorder()
 	producer = runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.equipmentStatusRepository.AssertExpectations(t)
 
 	actualEquipmentStatusResponse = &models.EquipmentStatusRepairConfirmationResponse{}
@@ -430,7 +431,7 @@ func (s *EquipmentStatusTestSuite) Test_Get_EquipmentStatusCheckDates_OK() {
 	if err != nil {
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
-	assert.NotEmpty(t, actualEquipmentStatusResponse)
+	require.NotEmpty(t, actualEquipmentStatusResponse)
 
 	// authentication successfully works only for manager, for operator should return 403 error
 	access = authentication.Auth{
@@ -442,7 +443,7 @@ func (s *EquipmentStatusTestSuite) Test_Get_EquipmentStatusCheckDates_OK() {
 	responseRecorder = httptest.NewRecorder()
 	producer = runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusForbidden, responseRecorder.Code)
+	require.Equal(t, http.StatusForbidden, responseRecorder.Code)
 }
 
 func (s *EquipmentStatusTestSuite) Test_Delete_EquipmentStatusFromRepairFunc_OK() {
@@ -506,7 +507,7 @@ func (s *EquipmentStatusTestSuite) Test_Delete_EquipmentStatusFromRepairFunc_OK(
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
 
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	s.equipmentStatusRepository.AssertExpectations(t)
 	s.orderStatusRepository.AssertExpectations(t)
@@ -517,24 +518,24 @@ func (s *EquipmentStatusTestSuite) Test_Delete_EquipmentStatusFromRepairFunc_OK(
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
 
-	assert.Equal(t, eqStatusModel.ID, actualEquipmentStatusResponse.Data.ID)
-	assert.Equal(
+	require.Equal(t, eqStatusModel.ID, actualEquipmentStatusResponse.Data.ID)
+	require.Equal(
 		t, int64(eqStatusResponseModel.Edges.Equipments.ID),
 		*actualEquipmentStatusResponse.Data.EquipmentID,
 	)
-	assert.Equal(
+	require.Equal(
 		t, (*strfmt.DateTime)(&addOneDayToCurrentEndDate),
 		actualEquipmentStatusResponse.Data.EndDate,
 	)
-	assert.Equal(
+	require.Equal(
 		t, (*strfmt.DateTime)(&timeNow),
 		actualEquipmentStatusResponse.Data.StartDate,
 	)
-	assert.Equal(
+	require.Equal(
 		t, (strfmt.DateTime)(timeNow),
 		actualEquipmentStatusResponse.Data.CreatedAt,
 	)
-	assert.Equal(
+	require.Equal(
 		t, eqStatusResponseModel.Edges.EquipmentStatusName.Name,
 		*actualEquipmentStatusResponse.Data.StatusName,
 	)
@@ -549,7 +550,7 @@ func (s *EquipmentStatusTestSuite) Test_Delete_EquipmentStatusFromRepairFunc_OK(
 	responseRecorder = httptest.NewRecorder()
 	producer = runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusForbidden, responseRecorder.Code)
+	require.Equal(t, http.StatusForbidden, responseRecorder.Code)
 }
 
 func (s *EquipmentStatusTestSuite) Test_Patch_EquipmentStatusEditDatesFunc_OK() {
@@ -614,7 +615,7 @@ func (s *EquipmentStatusTestSuite) Test_Patch_EquipmentStatusEditDatesFunc_OK() 
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
 
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	s.equipmentStatusRepository.AssertExpectations(t)
 	s.orderStatusRepository.AssertExpectations(t)
@@ -625,20 +626,20 @@ func (s *EquipmentStatusTestSuite) Test_Patch_EquipmentStatusEditDatesFunc_OK() 
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
 
-	assert.Equal(t, eqStatusModel.ID, actualEquipmentStatusResponse.Data.ID)
-	assert.Equal(
+	require.Equal(t, eqStatusModel.ID, actualEquipmentStatusResponse.Data.ID)
+	require.Equal(
 		t, int64(updatedEqStatus.Edges.Equipments.ID),
 		*actualEquipmentStatusResponse.Data.EquipmentID,
 	)
-	assert.Equal(
+	require.Equal(
 		t, (*strfmt.DateTime)(&updatedEqStatus.EndDate),
 		actualEquipmentStatusResponse.Data.EndDate,
 	)
-	assert.Equal(
+	require.Equal(
 		t, (*strfmt.DateTime)(&updatedEqStatus.StartDate),
 		actualEquipmentStatusResponse.Data.StartDate,
 	)
-	assert.Equal(
+	require.Equal(
 		t, updatedEqStatus.Edges.EquipmentStatusName.Name,
 		*actualEquipmentStatusResponse.Data.StatusName,
 	)
@@ -653,5 +654,5 @@ func (s *EquipmentStatusTestSuite) Test_Patch_EquipmentStatusEditDatesFunc_OK() 
 	responseRecorder = httptest.NewRecorder()
 	producer = runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusForbidden, responseRecorder.Code)
+	require.Equal(t, http.StatusForbidden, responseRecorder.Code)
 }

--- a/internal/handlers/equipment_test.go
+++ b/internal/handlers/equipment_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime"
 	_ "github.com/mattn/go-sqlite3"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
@@ -39,12 +39,12 @@ func TestSetEquipmentHandler(t *testing.T) {
 
 	//fileManager := &servicesmock.FileManager{}
 	SetEquipmentHandler(logger, api)
-	assert.NotEmpty(t, api.EquipmentCreateNewEquipmentHandler)
-	assert.NotEmpty(t, api.EquipmentGetEquipmentHandler)
-	assert.NotEmpty(t, api.EquipmentEditEquipmentHandler)
-	assert.NotEmpty(t, api.EquipmentDeleteEquipmentHandler)
-	assert.NotEmpty(t, api.EquipmentGetAllEquipmentHandler)
-	assert.NotEmpty(t, api.EquipmentFindEquipmentHandler)
+	require.NotEmpty(t, api.EquipmentCreateNewEquipmentHandler)
+	require.NotEmpty(t, api.EquipmentGetEquipmentHandler)
+	require.NotEmpty(t, api.EquipmentEditEquipmentHandler)
+	require.NotEmpty(t, api.EquipmentDeleteEquipmentHandler)
+	require.NotEmpty(t, api.EquipmentGetAllEquipmentHandler)
+	require.NotEmpty(t, api.EquipmentFindEquipmentHandler)
 }
 
 type EquipmentTestSuite struct {
@@ -113,7 +113,7 @@ func (s *EquipmentTestSuite) TestEquipment_PostEquipmentFunc_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.equipmentRepo.AssertExpectations(t)
 }
 
@@ -139,7 +139,7 @@ func (s *EquipmentTestSuite) TestEquipment_PostEquipmentFunc_RepoStatusErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.equipmentRepo.AssertExpectations(t)
 }
 
@@ -167,7 +167,7 @@ func (s *EquipmentTestSuite) TestEquipment_PostEquipmentFunc_MapErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.equipmentRepo.AssertExpectations(t)
 }
 
@@ -195,7 +195,7 @@ func (s *EquipmentTestSuite) TestEquipment_PostEquipmentFunc_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusCreated, responseRecorder.Code)
+	require.Equal(t, http.StatusCreated, responseRecorder.Code)
 	s.equipmentRepo.AssertExpectations(t)
 
 	actualEquipment := &models.Equipment{}
@@ -203,7 +203,7 @@ func (s *EquipmentTestSuite) TestEquipment_PostEquipmentFunc_OK() {
 	if err != nil {
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
-	assert.Equal(t, equipmentToReturn.Name, *actualEquipment.Name)
+	require.Equal(t, equipmentToReturn.Name, *actualEquipment.Name)
 }
 
 func (s *EquipmentTestSuite) TestEquipment_GetEquipmentFunc_RepoErr() {
@@ -226,7 +226,7 @@ func (s *EquipmentTestSuite) TestEquipment_GetEquipmentFunc_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.equipmentRepo.AssertExpectations(t)
 }
 
@@ -250,7 +250,7 @@ func (s *EquipmentTestSuite) TestEquipment_GetEquipmentFunc_MapErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.equipmentRepo.AssertExpectations(t)
 }
 
@@ -274,7 +274,7 @@ func (s *EquipmentTestSuite) TestEquipment_GetEquipmentFunc_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.equipmentRepo.AssertExpectations(t)
 
 	actualEquipment := &models.Equipment{}
@@ -282,7 +282,7 @@ func (s *EquipmentTestSuite) TestEquipment_GetEquipmentFunc_OK() {
 	if err != nil {
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
-	assert.Equal(t, equipmentToReturn.Name, *actualEquipment.Name)
+	require.Equal(t, equipmentToReturn.Name, *actualEquipment.Name)
 }
 
 func (s *EquipmentTestSuite) TestEquipment_DeleteEquipmentFunc_RepoErr() {
@@ -307,7 +307,7 @@ func (s *EquipmentTestSuite) TestEquipment_DeleteEquipmentFunc_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.equipmentRepo.AssertExpectations(t)
 }
 
@@ -333,7 +333,7 @@ func (s *EquipmentTestSuite) TestEquipment_DeleteEquipmentFunc_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.equipmentRepo.AssertExpectations(t)
 }
 
@@ -354,7 +354,7 @@ func (s *EquipmentTestSuite) TestEquipment_ListEquipmentFunc_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.equipmentRepo.AssertExpectations(t)
 }
 
@@ -380,9 +380,9 @@ func (s *EquipmentTestSuite) TestEquipment_ListEquipmentFunc_NotFound() {
 	if err != nil {
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
-	assert.Equal(t, 0, int(*responseEquipments.Total))
-	assert.Equal(t, 0, len(responseEquipments.Items))
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, 0, int(*responseEquipments.Total))
+	require.Equal(t, 0, len(responseEquipments.Items))
 	s.equipmentRepo.AssertExpectations(t)
 }
 
@@ -409,7 +409,7 @@ func (s *EquipmentTestSuite) TestEquipment_ListEquipmentFunc_MapErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.equipmentRepo.AssertExpectations(t)
 }
 
@@ -436,7 +436,7 @@ func (s *EquipmentTestSuite) TestEquipment_ListEquipmentFunc_EmptyPaginationPara
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.equipmentRepo.AssertExpectations(t)
 
 	var responseEquipments models.ListEquipment
@@ -444,8 +444,8 @@ func (s *EquipmentTestSuite) TestEquipment_ListEquipmentFunc_EmptyPaginationPara
 	if err != nil {
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
-	assert.Equal(t, 1, int(*responseEquipments.Total))
-	assert.Equal(t, equipmentToReturn[0].Name, *responseEquipments.Items[0].Name)
+	require.Equal(t, 1, int(*responseEquipments.Total))
+	require.Equal(t, equipmentToReturn[0].Name, *responseEquipments.Items[0].Name)
 }
 
 func (s *EquipmentTestSuite) TestEquipment_ListEquipmentFunc_LimitGreaterThanTotal() {
@@ -475,7 +475,7 @@ func (s *EquipmentTestSuite) TestEquipment_ListEquipmentFunc_LimitGreaterThanTot
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.equipmentRepo.AssertExpectations(t)
 
 	var responseEquipments models.ListEquipment
@@ -483,8 +483,8 @@ func (s *EquipmentTestSuite) TestEquipment_ListEquipmentFunc_LimitGreaterThanTot
 	if err != nil {
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
-	assert.Equal(t, 1, int(*responseEquipments.Total))
-	assert.Equal(t, equipmentToReturn[0].Name, *responseEquipments.Items[0].Name)
+	require.Equal(t, 1, int(*responseEquipments.Total))
+	require.Equal(t, equipmentToReturn[0].Name, *responseEquipments.Items[0].Name)
 }
 
 func (s *EquipmentTestSuite) TestEquipment_ListEquipmentFunc_LimitLessThanTotal() {
@@ -520,7 +520,7 @@ func (s *EquipmentTestSuite) TestEquipment_ListEquipmentFunc_LimitLessThanTotal(
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.equipmentRepo.AssertExpectations(t)
 
 	var responseEquipments models.ListEquipment
@@ -528,11 +528,11 @@ func (s *EquipmentTestSuite) TestEquipment_ListEquipmentFunc_LimitLessThanTotal(
 	if err != nil {
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
-	assert.Greater(t, len(equipmentToReturn), len(responseEquipments.Items))
-	assert.Equal(t, len(equipmentToReturn), int(*responseEquipments.Total))
-	assert.Equal(t, int(limit), len(responseEquipments.Items))
+	require.Greater(t, len(equipmentToReturn), len(responseEquipments.Items))
+	require.Equal(t, len(equipmentToReturn), int(*responseEquipments.Total))
+	require.Equal(t, int(limit), len(responseEquipments.Items))
 	for _, item := range responseEquipments.Items {
-		assert.True(t, containsEquipment(t, equipmentToReturn, item))
+		require.True(t, containsEquipment(t, equipmentToReturn, item))
 	}
 }
 
@@ -569,7 +569,7 @@ func (s *EquipmentTestSuite) TestEquipment_ListEquipmentFunc_SecondPage() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.equipmentRepo.AssertExpectations(t)
 
 	var responseEquipments models.ListEquipment
@@ -577,11 +577,11 @@ func (s *EquipmentTestSuite) TestEquipment_ListEquipmentFunc_SecondPage() {
 	if err != nil {
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
-	assert.Greater(t, len(equipmentToReturn), len(responseEquipments.Items))
-	assert.Equal(t, len(equipmentToReturn), int(*responseEquipments.Total))
-	assert.Equal(t, 2, len(responseEquipments.Items))
+	require.Greater(t, len(equipmentToReturn), len(responseEquipments.Items))
+	require.Equal(t, len(equipmentToReturn), int(*responseEquipments.Total))
+	require.Equal(t, 2, len(responseEquipments.Items))
 	for _, item := range responseEquipments.Items {
-		assert.True(t, containsEquipment(t, equipmentToReturn, item))
+		require.True(t, containsEquipment(t, equipmentToReturn, item))
 	}
 }
 
@@ -618,7 +618,7 @@ func (s *EquipmentTestSuite) TestEquipment_ListEquipmentFunc_SeveralPages() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.equipmentRepo.AssertExpectations(t)
 
 	var responseFirstPage models.ListEquipment
@@ -626,11 +626,11 @@ func (s *EquipmentTestSuite) TestEquipment_ListEquipmentFunc_SeveralPages() {
 	if err != nil {
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
-	assert.Greater(t, len(equipmentToReturn), len(responseFirstPage.Items))
-	assert.Equal(t, len(equipmentToReturn), int(*responseFirstPage.Total))
-	assert.Equal(t, 3, len(responseFirstPage.Items))
+	require.Greater(t, len(equipmentToReturn), len(responseFirstPage.Items))
+	require.Equal(t, len(equipmentToReturn), int(*responseFirstPage.Total))
+	require.Equal(t, 3, len(responseFirstPage.Items))
 	for _, item := range responseFirstPage.Items {
-		assert.True(t, containsEquipment(t, equipmentToReturn, item))
+		require.True(t, containsEquipment(t, equipmentToReturn, item))
 	}
 
 	offset = limit
@@ -641,7 +641,7 @@ func (s *EquipmentTestSuite) TestEquipment_ListEquipmentFunc_SeveralPages() {
 	responseRecorder = httptest.NewRecorder()
 	producer = runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.equipmentRepo.AssertExpectations(t)
 
 	var responseSecondPage models.ListEquipment
@@ -649,15 +649,15 @@ func (s *EquipmentTestSuite) TestEquipment_ListEquipmentFunc_SeveralPages() {
 	if err != nil {
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
-	assert.Greater(t, len(equipmentToReturn), len(responseSecondPage.Items))
-	assert.Equal(t, len(equipmentToReturn), int(*responseSecondPage.Total))
-	assert.Equal(t, 2, len(responseSecondPage.Items))
+	require.Greater(t, len(equipmentToReturn), len(responseSecondPage.Items))
+	require.Equal(t, len(equipmentToReturn), int(*responseSecondPage.Total))
+	require.Equal(t, 2, len(responseSecondPage.Items))
 	for _, item := range responseSecondPage.Items {
-		assert.True(t, containsEquipment(t, equipmentToReturn, item))
+		require.True(t, containsEquipment(t, equipmentToReturn, item))
 	}
 
-	assert.Equal(t, len(equipmentToReturn), len(responseFirstPage.Items)+len(responseSecondPage.Items))
-	assert.False(t, equipmentsDuplicated(t, responseFirstPage.Items, responseSecondPage.Items))
+	require.Equal(t, len(equipmentToReturn), len(responseFirstPage.Items)+len(responseSecondPage.Items))
+	require.False(t, equipmentsDuplicated(t, responseFirstPage.Items, responseSecondPage.Items))
 }
 
 func (s *EquipmentTestSuite) TestEquipment_FindEquipmentFunc_RepoErr() {
@@ -682,7 +682,7 @@ func (s *EquipmentTestSuite) TestEquipment_FindEquipmentFunc_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.equipmentRepo.AssertExpectations(t)
 }
 
@@ -707,15 +707,15 @@ func (s *EquipmentTestSuite) TestEquipment_FindEquipmentFunc_NoResult() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	var responseEquipments models.ListEquipment
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseEquipments)
 	if err != nil {
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
-	assert.Equal(t, 0, int(*responseEquipments.Total))
-	assert.Equal(t, 0, len(responseEquipments.Items))
+	require.Equal(t, 0, int(*responseEquipments.Total))
+	require.Equal(t, 0, len(responseEquipments.Items))
 	s.equipmentRepo.AssertExpectations(t)
 }
 
@@ -748,7 +748,7 @@ func (s *EquipmentTestSuite) TestEquipment_FindEquipmentFunc_MapErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.equipmentRepo.AssertExpectations(t)
 }
 
@@ -785,7 +785,7 @@ func (s *EquipmentTestSuite) TestEquipment_FindEquipmentFunc_EmptyPaginationPara
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.equipmentRepo.AssertExpectations(t)
 
 	var responseEquipments models.ListEquipment
@@ -793,10 +793,10 @@ func (s *EquipmentTestSuite) TestEquipment_FindEquipmentFunc_EmptyPaginationPara
 	if err != nil {
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
-	assert.Equal(t, 2, int(*responseEquipments.Total))
-	assert.Equal(t, 2, len(responseEquipments.Items))
-	assert.Equal(t, equipmentToReturn[0].Name, *responseEquipments.Items[0].Name)
-	assert.Equal(t, equipmentToReturn[1].Name, *responseEquipments.Items[1].Name)
+	require.Equal(t, 2, int(*responseEquipments.Total))
+	require.Equal(t, 2, len(responseEquipments.Items))
+	require.Equal(t, equipmentToReturn[0].Name, *responseEquipments.Items[0].Name)
+	require.Equal(t, equipmentToReturn[1].Name, *responseEquipments.Items[1].Name)
 }
 
 func (s *EquipmentTestSuite) TestEquipment_FindEquipmentFunc_LimitGreaterThanTotal() {
@@ -837,7 +837,7 @@ func (s *EquipmentTestSuite) TestEquipment_FindEquipmentFunc_LimitGreaterThanTot
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.equipmentRepo.AssertExpectations(t)
 
 	var actualEquipment models.ListEquipment
@@ -845,9 +845,9 @@ func (s *EquipmentTestSuite) TestEquipment_FindEquipmentFunc_LimitGreaterThanTot
 	if err != nil {
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
-	assert.Equal(t, 2, int(*actualEquipment.Total))
-	assert.Equal(t, 2, len(actualEquipment.Items))
-	assert.Equal(t, equipmentToReturn[0].Name, *actualEquipment.Items[0].Name)
+	require.Equal(t, 2, int(*actualEquipment.Total))
+	require.Equal(t, 2, len(actualEquipment.Items))
+	require.Equal(t, equipmentToReturn[0].Name, *actualEquipment.Items[0].Name)
 }
 
 func (s *EquipmentTestSuite) TestEquipment_FindEquipmentFunc_LimitLessThanTotal() {
@@ -888,7 +888,7 @@ func (s *EquipmentTestSuite) TestEquipment_FindEquipmentFunc_LimitLessThanTotal(
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.equipmentRepo.AssertExpectations(t)
 
 	var actualEquipment models.ListEquipment
@@ -896,10 +896,10 @@ func (s *EquipmentTestSuite) TestEquipment_FindEquipmentFunc_LimitLessThanTotal(
 	if err != nil {
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
-	assert.Equal(t, 3, int(*actualEquipment.Total))
-	assert.Equal(t, 2, len(actualEquipment.Items))
+	require.Equal(t, 3, int(*actualEquipment.Total))
+	require.Equal(t, 2, len(actualEquipment.Items))
 	for _, item := range actualEquipment.Items {
-		assert.True(t, containsEquipment(t, equipmentToReturn, item))
+		require.True(t, containsEquipment(t, equipmentToReturn, item))
 	}
 }
 
@@ -940,7 +940,7 @@ func (s *EquipmentTestSuite) TestEquipment_FindEquipmentFunc_SecondPage() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.equipmentRepo.AssertExpectations(t)
 
 	var responseEquipments models.ListEquipment
@@ -948,11 +948,11 @@ func (s *EquipmentTestSuite) TestEquipment_FindEquipmentFunc_SecondPage() {
 	if err != nil {
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
-	assert.Greater(t, len(equipmentToReturn), len(responseEquipments.Items))
-	assert.Equal(t, len(equipmentToReturn), int(*responseEquipments.Total))
-	assert.Equal(t, 2, len(responseEquipments.Items))
+	require.Greater(t, len(equipmentToReturn), len(responseEquipments.Items))
+	require.Equal(t, len(equipmentToReturn), int(*responseEquipments.Total))
+	require.Equal(t, 2, len(responseEquipments.Items))
 	for _, item := range responseEquipments.Items {
-		assert.True(t, containsEquipment(t, equipmentToReturn, item))
+		require.True(t, containsEquipment(t, equipmentToReturn, item))
 	}
 }
 
@@ -982,7 +982,7 @@ func (s *EquipmentTestSuite) TestEquipment_EditEquipmentFunc_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.equipmentRepo.AssertExpectations(t)
 }
 
@@ -1012,7 +1012,7 @@ func (s *EquipmentTestSuite) TestEquipment_EditEquipmentFunc_MapErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.equipmentRepo.AssertExpectations(t)
 }
 
@@ -1042,14 +1042,14 @@ func (s *EquipmentTestSuite) TestEquipment_EditEquipmentFunc_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	var responseEquipment models.Equipment
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseEquipment)
 	if err != nil {
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
-	assert.Equal(t, equipmentToReturn.Name, *responseEquipment.Name)
+	require.Equal(t, equipmentToReturn.Name, *responseEquipment.Name)
 
 	s.equipmentRepo.AssertExpectations(t)
 }

--- a/internal/handlers/order_status_test.go
+++ b/internal/handlers/order_status_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 	_ "github.com/mattn/go-sqlite3"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
@@ -44,11 +43,11 @@ func TestSetOrderStatusHandler(t *testing.T) {
 	}
 	api := operations.NewBeAPI(swaggerSpec)
 	SetOrderStatusHandler(logger, api)
-	assert.NotEmpty(t, api.OrdersGetOrdersByStatusHandler)
-	assert.NotEmpty(t, api.OrdersGetOrdersByDateAndStatusHandler)
-	assert.NotEmpty(t, api.OrdersAddNewOrderStatusHandler)
-	assert.NotEmpty(t, api.OrdersGetFullOrderHistoryHandler)
-	assert.NotEmpty(t, api.OrdersGetAllStatusNamesHandler)
+	require.NotEmpty(t, api.OrdersGetOrdersByStatusHandler)
+	require.NotEmpty(t, api.OrdersGetOrdersByDateAndStatusHandler)
+	require.NotEmpty(t, api.OrdersAddNewOrderStatusHandler)
+	require.NotEmpty(t, api.OrdersGetFullOrderHistoryHandler)
+	require.NotEmpty(t, api.OrdersGetAllStatusNamesHandler)
 }
 
 type OrderStatusTestSuite struct {
@@ -150,14 +149,14 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetAllOrderStatusNames_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	expectedStatuses := make([]models.OrderStatusName, count)
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &expectedStatuses)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, int64(id), *expectedStatuses[0].ID)
-	assert.Equal(t, statusName, *expectedStatuses[0].Name)
+	require.Equal(t, int64(id), *expectedStatuses[0].ID)
+	require.Equal(t, statusName, *expectedStatuses[0].Name)
 }
 
 func (s *OrderStatusTestSuite) TestOrderStatus_GetAllOrderStatusNames_RepoErr() {
@@ -174,7 +173,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetAllOrderStatusNames_RepoErr() 
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 }
 
 func (s *OrderStatusTestSuite) TestOrderStatus_GetAllOrderStatusNames_MapError() {
@@ -192,7 +191,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetAllOrderStatusNames_MapError()
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 }
 
 func (s *OrderStatusTestSuite) TestOrderStatus_OrderStatusesHistory_RepoErr() {
@@ -213,7 +212,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_OrderStatusesHistory_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.orderStatusRepository.AssertExpectations(t)
 }
 
@@ -235,7 +234,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_OrderStatusesHistory_CantAccess()
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.orderStatusRepository.AssertExpectations(t)
 }
 
@@ -266,7 +265,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_OrderStatusesHistory_CantAccess_H
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusForbidden, responseRecorder.Code)
+	require.Equal(t, http.StatusForbidden, responseRecorder.Code)
 	s.orderStatusRepository.AssertExpectations(t)
 }
 
@@ -298,7 +297,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_OrderStatusesHistory_EmptyHistory
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusNotFound, responseRecorder.Code)
+	require.Equal(t, http.StatusNotFound, responseRecorder.Code)
 	s.orderStatusRepository.AssertExpectations(t)
 }
 
@@ -333,7 +332,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_OrderStatusesHistory_MapError() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.orderStatusRepository.AssertExpectations(t)
 }
 
@@ -382,19 +381,19 @@ func (s *OrderStatusTestSuite) TestOrderStatus_OrderStatusesHistory_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	response := &models.OrderStatuses{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), response)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, count, len(*response))
-	assert.Equal(t, history[0].ID, int(*(*response)[0].ID))
-	assert.Equal(t, history[0].Comment, *(*response)[0].Comment)
-	assert.Equal(t, strfmt.DateTime(history[0].CurrentDate).String(), (*response)[0].CreatedAt.String())
-	assert.Equal(t, history[0].Edges.OrderStatusName.Status, *(*response)[0].Status)
-	assert.Equal(t, history[0].Edges.Users.Login, *(*response)[0].ChangedBy.Name)
-	assert.Equal(t, history[0].Edges.Users.ID, int(*(*response)[0].ChangedBy.ID))
+	require.Equal(t, count, len(*response))
+	require.Equal(t, history[0].ID, int(*(*response)[0].ID))
+	require.Equal(t, history[0].Comment, *(*response)[0].Comment)
+	require.Equal(t, strfmt.DateTime(history[0].CurrentDate).String(), (*response)[0].CreatedAt.String())
+	require.Equal(t, history[0].Edges.OrderStatusName.Status, *(*response)[0].Status)
+	require.Equal(t, history[0].Edges.Users.Login, *(*response)[0].ChangedBy.Name)
+	require.Equal(t, history[0].Edges.Users.ID, int(*(*response)[0].ChangedBy.ID))
 	s.orderStatusRepository.AssertExpectations(t)
 }
 
@@ -422,7 +421,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_AddNewStatusToOrder_EmptyData() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusBadRequest, responseRecorder.Code)
+	require.Equal(t, http.StatusBadRequest, responseRecorder.Code)
 }
 
 func (s *OrderStatusTestSuite) TestOrderStatus_AddNewStatusToOrder_NoAccess() {
@@ -476,7 +475,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_AddNewStatusToOrder_NoAccess() {
 		responseRecorder := httptest.NewRecorder()
 		producer := runtime.JSONProducer()
 		resp.WriteResponse(responseRecorder, producer)
-		assert.Equal(t, http.StatusForbidden, responseRecorder.Code)
+		require.Equal(t, http.StatusForbidden, responseRecorder.Code)
 	}
 }
 
@@ -518,7 +517,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_AddNewStatusToOrder_RepoError() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.orderStatusRepository.AssertExpectations(t)
 }
 
@@ -564,7 +563,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_AddNewStatusToOrder_InReviewToApp
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.orderStatusRepository.AssertExpectations(t)
 }
 
@@ -614,7 +613,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_AddNewStatusToOrder_InReviewToRej
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.orderStatusRepository.AssertExpectations(t)
 }
 
@@ -677,7 +676,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_AddNewStatusToOrder_OperatorInPro
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.orderStatusRepository.AssertExpectations(t)
 }
 
@@ -740,7 +739,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_AddNewStatusToOrder_OperatorOverd
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.orderStatusRepository.AssertExpectations(t)
 }
 
@@ -787,7 +786,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_AddNewStatusToOrder_OperatorAppro
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.orderStatusRepository.AssertExpectations(t)
 }
 
@@ -850,7 +849,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_AddNewStatusToOrder_ManagerInProg
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.orderStatusRepository.AssertExpectations(t)
 }
 
@@ -913,7 +912,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_AddNewStatusToOrder_ManagerOverdu
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.orderStatusRepository.AssertExpectations(t)
 }
 
@@ -976,7 +975,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_AddNewStatusToOrder_ManagerPrepar
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.orderStatusRepository.AssertExpectations(t)
 }
 
@@ -1039,7 +1038,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_AddNewStatusToOrder_ManagerApprov
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.orderStatusRepository.AssertExpectations(t)
 }
 
@@ -1088,10 +1087,10 @@ func (s *OrderStatusTestSuite) TestOrderStatus_AddNewStatusToOrder_ApprovedToPre
 	response := models.Error{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &response)
 	require.NoError(t, err)
-	assert.NotEmpty(t, response)
-	assert.NotEmpty(t, response.Data)
-	assert.Contains(t, response.Data.Message, "equipment IDs don't have correspondent status: [1]")
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.NotEmpty(t, response)
+	require.NotEmpty(t, response.Data)
+	require.Contains(t, response.Data.Message, "equipment IDs don't have correspondent status: [1]")
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.orderStatusRepository.AssertExpectations(t)
 }
 
@@ -1158,7 +1157,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_AddNewStatusToOrder_PreparedToByO
 		responseRecorder := httptest.NewRecorder()
 		producer := runtime.JSONProducer()
 		resp.WriteResponse(responseRecorder, producer)
-		assert.Equal(t, http.StatusOK, responseRecorder.Code)
+		require.Equal(t, http.StatusOK, responseRecorder.Code)
 		s.orderStatusRepository.AssertExpectations(t)
 	}
 }
@@ -1190,10 +1189,10 @@ func (s *OrderStatusTestSuite) TestOrderStatus_AddNewStatusToOrder_AccessErr() {
 	response := models.Error{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &response)
 	require.NoError(t, err)
-	assert.NotEmpty(t, response)
-	assert.NotEmpty(t, response.Data)
-	assert.Contains(t, response.Data.Message, "Can't get authorization")
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.NotEmpty(t, response)
+	require.NotEmpty(t, response.Data)
+	require.Contains(t, response.Data.Message, "Can't get authorization")
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.orderStatusRepository.AssertExpectations(t)
 }
 
@@ -1222,7 +1221,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByStatus_NoAccess() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusForbidden, responseRecorder.Code)
+	require.Equal(t, http.StatusForbidden, responseRecorder.Code)
 }
 
 func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByStatus_AccessErr() {
@@ -1243,10 +1242,10 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByStatus_AccessErr() {
 	response := models.Error{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &response)
 	require.NoError(t, err)
-	assert.NotEmpty(t, response)
-	assert.NotEmpty(t, response.Data)
-	assert.Contains(t, response.Data.Message, "Can't get authorization")
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.NotEmpty(t, response)
+	require.NotEmpty(t, response.Data)
+	require.Contains(t, response.Data.Message, "Can't get authorization")
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 }
 
 func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByStatus_RepoErr() {
@@ -1278,7 +1277,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByStatus_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 }
 
 func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByStatus_EmptyResult() {
@@ -1310,14 +1309,14 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByStatus_EmptyResult() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	responseOrders := models.OrderList{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseOrders)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, 0, int(*responseOrders.Total))
+	require.Equal(t, 0, int(*responseOrders.Total))
 	s.orderFilterRepository.AssertExpectations(t)
 }
 
@@ -1358,7 +1357,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByStatus_MapErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.orderFilterRepository.AssertExpectations(t)
 }
 
@@ -1401,16 +1400,16 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByStatus_EmptyPagination
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	responseOrders := models.OrderList{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseOrders)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(ordersToReturn), int(*responseOrders.Total))
-	assert.Equal(t, len(ordersToReturn), len(responseOrders.Items))
+	require.Equal(t, len(ordersToReturn), int(*responseOrders.Total))
+	require.Equal(t, len(ordersToReturn), len(responseOrders.Items))
 	for _, o := range responseOrders.Items {
-		assert.True(t, containsOrder(t, ordersToReturn, o))
+		require.True(t, containsOrder(t, ordersToReturn, o))
 	}
 	s.orderFilterRepository.AssertExpectations(t)
 }
@@ -1467,16 +1466,16 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByStatus_LimitGreaterTha
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	responseOrders := models.OrderList{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseOrders)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(ordersByStatus), int(*responseOrders.Total))
-	assert.GreaterOrEqual(t, int(limit), len(responseOrders.Items))
+	require.Equal(t, len(ordersByStatus), int(*responseOrders.Total))
+	require.GreaterOrEqual(t, int(limit), len(responseOrders.Items))
 	for _, o := range responseOrders.Items {
-		assert.True(t, containsOrder(t, ordersByStatus, o))
+		require.True(t, containsOrder(t, ordersByStatus, o))
 	}
 	s.orderFilterRepository.AssertExpectations(t)
 }
@@ -1533,17 +1532,17 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByStatus_LimitLessThanTo
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	responseOrders := models.OrderList{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseOrders)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(ordersByStatus), int(*responseOrders.Total))
-	assert.GreaterOrEqual(t, int(limit), len(responseOrders.Items))
-	assert.Greater(t, len(ordersByStatus), len(responseOrders.Items))
+	require.Equal(t, len(ordersByStatus), int(*responseOrders.Total))
+	require.GreaterOrEqual(t, int(limit), len(responseOrders.Items))
+	require.Greater(t, len(ordersByStatus), len(responseOrders.Items))
 	for _, o := range responseOrders.Items {
-		assert.True(t, containsOrder(t, ordersByStatus, o))
+		require.True(t, containsOrder(t, ordersByStatus, o))
 	}
 	s.orderFilterRepository.AssertExpectations(t)
 }
@@ -1600,18 +1599,18 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByStatus_SecondPage() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	responseOrders := models.OrderList{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseOrders)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(ordersByStatus), int(*responseOrders.Total))
-	assert.GreaterOrEqual(t, int(limit), len(responseOrders.Items))
-	assert.Equal(t, len(ordersByStatus)-int(offset), len(responseOrders.Items))
-	assert.Greater(t, len(ordersByStatus), len(responseOrders.Items))
+	require.Equal(t, len(ordersByStatus), int(*responseOrders.Total))
+	require.GreaterOrEqual(t, int(limit), len(responseOrders.Items))
+	require.Equal(t, len(ordersByStatus)-int(offset), len(responseOrders.Items))
+	require.Greater(t, len(ordersByStatus), len(responseOrders.Items))
 	for _, o := range responseOrders.Items {
-		assert.True(t, containsOrder(t, ordersByStatus, o))
+		require.True(t, containsOrder(t, ordersByStatus, o))
 	}
 	s.orderFilterRepository.AssertExpectations(t)
 }
@@ -1668,16 +1667,16 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByStatus_SeveralPages() 
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	firstPage := models.OrderList{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &firstPage)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(ordersByStatus), int(*firstPage.Total))
-	assert.Equal(t, int(limit), len(firstPage.Items))
+	require.Equal(t, len(ordersByStatus), int(*firstPage.Total))
+	require.Equal(t, int(limit), len(firstPage.Items))
 	for _, o := range firstPage.Items {
-		assert.True(t, containsOrder(t, ordersByStatus, o))
+		require.True(t, containsOrder(t, ordersByStatus, o))
 	}
 
 	offset = limit
@@ -1699,21 +1698,21 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByStatus_SeveralPages() 
 	responseRecorder = httptest.NewRecorder()
 	producer = runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	secondPage := models.OrderList{}
 	err = json.Unmarshal(responseRecorder.Body.Bytes(), &secondPage)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(ordersByStatus), int(*secondPage.Total))
-	assert.GreaterOrEqual(t, int(limit), len(secondPage.Items))
-	assert.Equal(t, len(ordersByStatus)-int(offset), len(secondPage.Items))
-	assert.Greater(t, len(ordersByStatus), len(secondPage.Items))
+	require.Equal(t, len(ordersByStatus), int(*secondPage.Total))
+	require.GreaterOrEqual(t, int(limit), len(secondPage.Items))
+	require.Equal(t, len(ordersByStatus)-int(offset), len(secondPage.Items))
+	require.Greater(t, len(ordersByStatus), len(secondPage.Items))
 	for _, o := range secondPage.Items {
-		assert.True(t, containsOrder(t, ordersByStatus, o))
+		require.True(t, containsOrder(t, ordersByStatus, o))
 	}
 
-	assert.False(t, ordersDuplicated(t, firstPage.Items, secondPage.Items))
+	require.False(t, ordersDuplicated(t, firstPage.Items, secondPage.Items))
 	s.orderFilterRepository.AssertExpectations(t)
 }
 
@@ -1740,7 +1739,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByPeriodAndStatus_NoAcce
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusForbidden, responseRecorder.Code)
+	require.Equal(t, http.StatusForbidden, responseRecorder.Code)
 	s.orderFilterRepository.AssertExpectations(t)
 }
 
@@ -1760,10 +1759,10 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByPeriodAndStatus_Access
 	response := models.Error{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &response)
 	require.NoError(t, err)
-	assert.NotEmpty(t, response)
-	assert.NotEmpty(t, response.Data)
-	assert.Contains(t, response.Data.Message, "Can't get authorization")
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.NotEmpty(t, response)
+	require.NotEmpty(t, response.Data)
+	require.Contains(t, response.Data.Message, "Can't get authorization")
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 }
 
 func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByPeriodAndStatus_RepoErr() {
@@ -1798,7 +1797,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByPeriodAndStatus_RepoEr
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.orderFilterRepository.AssertExpectations(t)
 }
 
@@ -1834,14 +1833,14 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByPeriodAndStatus_EmptyR
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	responseOrders := models.OrderList{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseOrders)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, 0, int(*responseOrders.Total))
-	assert.Equal(t, 0, len(responseOrders.Items))
+	require.Equal(t, 0, int(*responseOrders.Total))
+	require.Equal(t, 0, len(responseOrders.Items))
 	s.orderFilterRepository.AssertExpectations(t)
 }
 
@@ -1886,7 +1885,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByPeriodAndStatus_MapErr
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.orderFilterRepository.AssertExpectations(t)
 }
 
@@ -1933,7 +1932,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByPeriodAndStatus_EmptyP
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.orderFilterRepository.AssertExpectations(t)
 }
 
@@ -1993,16 +1992,16 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByPeriodAndStatus_LimitG
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	responseOrders := models.OrderList{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseOrders)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(ordersByStatus), int(*responseOrders.Total))
-	assert.GreaterOrEqual(t, int(limit), len(responseOrders.Items))
+	require.Equal(t, len(ordersByStatus), int(*responseOrders.Total))
+	require.GreaterOrEqual(t, int(limit), len(responseOrders.Items))
 	for _, o := range responseOrders.Items {
-		assert.True(t, containsOrder(t, ordersByStatus, o))
+		require.True(t, containsOrder(t, ordersByStatus, o))
 	}
 	s.orderFilterRepository.AssertExpectations(t)
 }
@@ -2063,17 +2062,17 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByPeriodAndStatus_LimitL
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	responseOrders := models.OrderList{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseOrders)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(ordersByStatus), int(*responseOrders.Total))
-	assert.GreaterOrEqual(t, int(limit), len(responseOrders.Items))
-	assert.Greater(t, len(ordersByStatus), len(responseOrders.Items))
+	require.Equal(t, len(ordersByStatus), int(*responseOrders.Total))
+	require.GreaterOrEqual(t, int(limit), len(responseOrders.Items))
+	require.Greater(t, len(ordersByStatus), len(responseOrders.Items))
 	for _, o := range responseOrders.Items {
-		assert.True(t, containsOrder(t, ordersByStatus, o))
+		require.True(t, containsOrder(t, ordersByStatus, o))
 	}
 	s.orderFilterRepository.AssertExpectations(t)
 }
@@ -2134,18 +2133,18 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByPeriodAndStatus_Second
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	responseOrders := models.OrderList{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseOrders)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(ordersByStatus), int(*responseOrders.Total))
-	assert.GreaterOrEqual(t, int(limit), len(responseOrders.Items))
-	assert.Equal(t, len(ordersByStatus)-int(offset), len(responseOrders.Items))
-	assert.Greater(t, len(ordersByStatus), len(responseOrders.Items))
+	require.Equal(t, len(ordersByStatus), int(*responseOrders.Total))
+	require.GreaterOrEqual(t, int(limit), len(responseOrders.Items))
+	require.Equal(t, len(ordersByStatus)-int(offset), len(responseOrders.Items))
+	require.Greater(t, len(ordersByStatus), len(responseOrders.Items))
 	for _, o := range responseOrders.Items {
-		assert.True(t, containsOrder(t, ordersByStatus, o))
+		require.True(t, containsOrder(t, ordersByStatus, o))
 	}
 	s.orderFilterRepository.AssertExpectations(t)
 }
@@ -2206,16 +2205,16 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByPeriodAndStatus_Severa
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	firstPage := models.OrderList{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &firstPage)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(ordersByStatus), int(*firstPage.Total))
-	assert.Equal(t, int(limit), len(firstPage.Items))
+	require.Equal(t, len(ordersByStatus), int(*firstPage.Total))
+	require.Equal(t, int(limit), len(firstPage.Items))
 	for _, o := range firstPage.Items {
-		assert.True(t, containsOrder(t, ordersByStatus, o))
+		require.True(t, containsOrder(t, ordersByStatus, o))
 	}
 
 	offset = limit
@@ -2239,20 +2238,20 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByPeriodAndStatus_Severa
 	responseRecorder = httptest.NewRecorder()
 	producer = runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	secondPage := models.OrderList{}
 	err = json.Unmarshal(responseRecorder.Body.Bytes(), &secondPage)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(ordersByStatus), int(*secondPage.Total))
-	assert.GreaterOrEqual(t, int(limit), len(secondPage.Items))
-	assert.Equal(t, len(ordersByStatus)-int(offset), len(secondPage.Items))
-	assert.Greater(t, len(ordersByStatus), len(secondPage.Items))
+	require.Equal(t, len(ordersByStatus), int(*secondPage.Total))
+	require.GreaterOrEqual(t, int(limit), len(secondPage.Items))
+	require.Equal(t, len(ordersByStatus)-int(offset), len(secondPage.Items))
+	require.Greater(t, len(ordersByStatus), len(secondPage.Items))
 	for _, o := range secondPage.Items {
-		assert.True(t, containsOrder(t, ordersByStatus, o))
+		require.True(t, containsOrder(t, ordersByStatus, o))
 	}
 
-	assert.False(t, ordersDuplicated(t, firstPage.Items, secondPage.Items))
+	require.False(t, ordersDuplicated(t, firstPage.Items, secondPage.Items))
 	s.orderFilterRepository.AssertExpectations(t)
 }

--- a/internal/handlers/order_test.go
+++ b/internal/handlers/order_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 	_ "github.com/mattn/go-sqlite3"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
@@ -42,9 +42,9 @@ func TestSetOrderHandler(t *testing.T) {
 	}
 	api := operations.NewBeAPI(swaggerSpec)
 	SetOrderHandler(logger, api)
-	assert.NotEmpty(t, api.OrdersGetAllOrdersHandler)
-	assert.NotEmpty(t, api.OrdersCreateOrderHandler)
-	assert.NotEmpty(t, api.OrdersUpdateOrderHandler)
+	require.NotEmpty(t, api.OrdersGetAllOrdersHandler)
+	require.NotEmpty(t, api.OrdersCreateOrderHandler)
+	require.NotEmpty(t, api.OrdersUpdateOrderHandler)
 }
 
 func orderWithNoEdges() *ent.Order {
@@ -117,7 +117,7 @@ func (s *orderTestSuite) TestOrder_ListOrder_AccessErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.orderRepository.AssertExpectations(t)
 }
 
@@ -138,7 +138,7 @@ func (s *orderTestSuite) TestOrder_ListOrder_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.orderRepository.AssertExpectations(t)
 }
 
@@ -166,7 +166,7 @@ func (s *orderTestSuite) TestOrder_ListOrder_MapErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.orderRepository.AssertExpectations(t)
 }
 
@@ -186,15 +186,15 @@ func (s *orderTestSuite) TestOrder_ListOrder_NotFound() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	var response models.OrderList
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &response)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, 0, int(*response.Total))
-	assert.Equal(t, 0, len(response.Items))
+	require.Equal(t, 0, int(*response.Total))
+	require.Equal(t, 0, len(response.Items))
 	s.orderRepository.AssertExpectations(t)
 }
 
@@ -223,17 +223,17 @@ func (s *orderTestSuite) TestOrder_ListOrder_EmptyParams() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	var response models.OrderList
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &response)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(orderList), int(*response.Total))
-	assert.GreaterOrEqual(t, limit, len(response.Items))
+	require.Equal(t, len(orderList), int(*response.Total))
+	require.GreaterOrEqual(t, limit, len(response.Items))
 	for _, item := range response.Items {
-		assert.True(t, containsOrder(t, orderList, item))
+		require.True(t, containsOrder(t, orderList, item))
 	}
 	s.orderRepository.AssertExpectations(t)
 }
@@ -270,17 +270,17 @@ func (s *orderTestSuite) TestOrder_ListOrder_LimitGreaterThanTotal() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	var response models.OrderList
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &response)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(orderList), int(*response.Total))
-	assert.GreaterOrEqual(t, int(limit), len(response.Items))
+	require.Equal(t, len(orderList), int(*response.Total))
+	require.GreaterOrEqual(t, int(limit), len(response.Items))
 	for _, item := range response.Items {
-		assert.True(t, containsOrder(t, orderList, item))
+		require.True(t, containsOrder(t, orderList, item))
 	}
 
 	s.orderRepository.AssertExpectations(t)
@@ -320,17 +320,17 @@ func (s *orderTestSuite) TestOrder_ListOrder_LimitLessThanTotal() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	var response models.OrderList
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &response)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(orderList), int(*response.Total))
-	assert.GreaterOrEqual(t, int(limit), len(response.Items))
+	require.Equal(t, len(orderList), int(*response.Total))
+	require.GreaterOrEqual(t, int(limit), len(response.Items))
 	for _, item := range response.Items {
-		assert.True(t, containsOrder(t, orderList, item))
+		require.True(t, containsOrder(t, orderList, item))
 	}
 
 	s.orderRepository.AssertExpectations(t)
@@ -370,17 +370,17 @@ func (s *orderTestSuite) TestOrder_ListOrder_SecondPage() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	var response models.OrderList
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &response)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(orderList), int(*response.Total))
-	assert.Equal(t, len(orderList)-int(offset), len(response.Items))
+	require.Equal(t, len(orderList), int(*response.Total))
+	require.Equal(t, len(orderList)-int(offset), len(response.Items))
 	for _, item := range response.Items {
-		assert.True(t, containsOrder(t, orderList, item))
+		require.True(t, containsOrder(t, orderList, item))
 	}
 
 	s.orderRepository.AssertExpectations(t)
@@ -420,17 +420,17 @@ func (s *orderTestSuite) TestOrder_ListOrder_SeveralPages() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	var firstPage models.OrderList
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &firstPage)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(orderList), int(*firstPage.Total))
-	assert.Equal(t, int(limit), len(firstPage.Items))
+	require.Equal(t, len(orderList), int(*firstPage.Total))
+	require.Equal(t, int(limit), len(firstPage.Items))
 	for _, item := range firstPage.Items {
-		assert.True(t, containsOrder(t, orderList, item))
+		require.True(t, containsOrder(t, orderList, item))
 	}
 
 	offset = limit
@@ -450,20 +450,20 @@ func (s *orderTestSuite) TestOrder_ListOrder_SeveralPages() {
 	responseRecorder = httptest.NewRecorder()
 	producer = runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	var secondPage models.OrderList
 	err = json.Unmarshal(responseRecorder.Body.Bytes(), &secondPage)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(orderList), int(*secondPage.Total))
-	assert.Equal(t, len(orderList)-int(offset), len(secondPage.Items))
+	require.Equal(t, len(orderList), int(*secondPage.Total))
+	require.Equal(t, len(orderList)-int(offset), len(secondPage.Items))
 	for _, item := range secondPage.Items {
-		assert.True(t, containsOrder(t, orderList, item))
+		require.True(t, containsOrder(t, orderList, item))
 	}
 
-	assert.False(t, ordersDuplicated(t, firstPage.Items, secondPage.Items))
+	require.False(t, ordersDuplicated(t, firstPage.Items, secondPage.Items))
 	s.orderRepository.AssertExpectations(t)
 }
 
@@ -481,7 +481,7 @@ func (s *orderTestSuite) TestOrder_CreateOrder_AccessErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.orderRepository.AssertExpectations(t)
 }
 
@@ -517,7 +517,7 @@ func (s *orderTestSuite) TestOrder_CreateOrder_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.orderRepository.AssertExpectations(t)
 }
 
@@ -567,7 +567,7 @@ func (s *orderTestSuite) TestOrder_CreateOrder_MapErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.orderRepository.AssertExpectations(t)
 }
 
@@ -604,13 +604,13 @@ func (s *orderTestSuite) TestOrder_CreateOrder_NoAvailableEquipments() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	responseOrder := models.Order{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseOrder)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Empty(t, responseOrder)
+	require.Empty(t, responseOrder)
 
 	s.orderRepository.AssertExpectations(t)
 }
@@ -661,13 +661,13 @@ func (s *orderTestSuite) TestOrder_CreateOrder_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusCreated, responseRecorder.Code)
+	require.Equal(t, http.StatusCreated, responseRecorder.Code)
 	responseOrder := models.Order{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseOrder)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, orderToReturn.ID, int(*responseOrder.ID))
+	require.Equal(t, orderToReturn.ID, int(*responseOrder.ID))
 
 	s.orderRepository.AssertExpectations(t)
 }
@@ -686,7 +686,7 @@ func (s *orderTestSuite) TestOrder_UpdateOrder_AccessErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.orderRepository.AssertExpectations(t)
 }
 
@@ -722,7 +722,7 @@ func (s *orderTestSuite) TestOrder_UpdateOrder_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.orderRepository.AssertExpectations(t)
 }
 
@@ -758,7 +758,7 @@ func (s *orderTestSuite) TestOrder_UpdateOrder_MapErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.orderRepository.AssertExpectations(t)
 }
 
@@ -794,14 +794,14 @@ func (s *orderTestSuite) TestOrder_UpdateOrder_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	responseOrder := models.Order{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseOrder)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, orderToReturn.ID, int(*responseOrder.ID))
+	require.Equal(t, orderToReturn.ID, int(*responseOrder.ID))
 
 	s.orderRepository.AssertExpectations(t)
 }

--- a/internal/handlers/password_reset_test.go
+++ b/internal/handlers/password_reset_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime"
 	_ "github.com/mattn/go-sqlite3"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
@@ -37,8 +37,8 @@ func TestSetPasswordResetHandler(t *testing.T) {
 
 	SetPasswordResetHandler(logger, api, passwordService)
 
-	assert.NotNil(t, api.PasswordResetGetPasswordResetLinkHandler)
-	assert.NotNil(t, api.PasswordResetSendLinkByLoginHandler)
+	require.NotNil(t, api.PasswordResetGetPasswordResetLinkHandler)
+	require.NotNil(t, api.PasswordResetSendLinkByLoginHandler)
 }
 
 type PasswordResetHandlerTestSuite struct {
@@ -75,7 +75,7 @@ func (s *PasswordResetHandlerTestSuite) TestPasswordResetHandler_GetPasswordRese
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.passwordService.AssertExpectations(t)
 }
 
@@ -94,7 +94,7 @@ func (s *PasswordResetHandlerTestSuite) TestPasswordResetHandler_GetPasswordRese
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.passwordService.AssertExpectations(t)
 }
 
@@ -111,7 +111,7 @@ func (s *PasswordResetHandlerTestSuite) TestPasswordResetHandler_SendLinkByLogin
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusBadRequest, responseRecorder.Code)
+	require.Equal(t, http.StatusBadRequest, responseRecorder.Code)
 	s.passwordService.AssertExpectations(t)
 }
 
@@ -131,7 +131,7 @@ func (s *PasswordResetHandlerTestSuite) TestPasswordResetHandler_GSendLinkByLogi
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.passwordService.AssertExpectations(t)
 }
 
@@ -150,6 +150,6 @@ func (s *PasswordResetHandlerTestSuite) TestPasswordResetHandler_GSendLinkByLogi
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.passwordService.AssertExpectations(t)
 }

--- a/internal/handlers/pet_kind_test.go
+++ b/internal/handlers/pet_kind_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime"
 	_ "github.com/mattn/go-sqlite3"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
@@ -35,11 +35,11 @@ func TestSetPetKindHandler(t *testing.T) {
 	}
 	api := operations.NewBeAPI(swaggerSpec)
 	SetPetKindHandler(logger, api)
-	assert.NotEmpty(t, api.PetKindGetAllPetKindsHandler)
-	assert.NotEmpty(t, api.PetKindEditPetKindHandler)
-	assert.NotEmpty(t, api.PetKindDeletePetKindHandler)
-	assert.NotEmpty(t, api.PetKindCreateNewPetKindHandler)
-	assert.NotEmpty(t, api.PetKindGetPetKindHandler)
+	require.NotEmpty(t, api.PetKindGetAllPetKindsHandler)
+	require.NotEmpty(t, api.PetKindEditPetKindHandler)
+	require.NotEmpty(t, api.PetKindDeletePetKindHandler)
+	require.NotEmpty(t, api.PetKindCreateNewPetKindHandler)
+	require.NotEmpty(t, api.PetKindGetPetKindHandler)
 }
 
 type PetKindTestSuite struct {
@@ -109,7 +109,7 @@ func (s *PetKindTestSuite) TestPetKind_CreatePetKindFunc_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusCreated, responseRecorder.Code)
+	require.Equal(t, http.StatusCreated, responseRecorder.Code)
 	s.petKindRepo.AssertExpectations(t)
 
 	actualPetKind := ent.PetKind{}
@@ -119,7 +119,7 @@ func (s *PetKindTestSuite) TestPetKind_CreatePetKindFunc_OK() {
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
 	eq := isEqualPetKind(t, petKindToReturn, &actualPetKind)
-	assert.Equal(t, true, eq)
+	require.Equal(t, true, eq)
 }
 
 func (s *PetKindTestSuite) TestPetKind_CreatePetKindFunc_ErrFromRepo() {
@@ -145,7 +145,7 @@ func (s *PetKindTestSuite) TestPetKind_CreatePetKindFunc_ErrFromRepo() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.petKindRepo.AssertExpectations(t)
 }
 
@@ -172,7 +172,7 @@ func (s *PetKindTestSuite) TestPetKind_CreatePetKindFunc_ErrRespNil() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.petKindRepo.AssertExpectations(t)
 }
 
@@ -195,7 +195,7 @@ func (s *PetKindTestSuite) TestPetKind_GetAllPetKindFunc_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.petKindRepo.AssertExpectations(t)
 
 	actualPetKind := []*ent.PetKind{}
@@ -206,7 +206,7 @@ func (s *PetKindTestSuite) TestPetKind_GetAllPetKindFunc_OK() {
 	}
 	for i := 0; i < 10; i++ {
 		eq := isEqualPetKind(t, petKindToReturn[i], actualPetKind[i])
-		assert.Equal(t, true, eq)
+		require.Equal(t, true, eq)
 	}
 }
 
@@ -227,7 +227,7 @@ func (s *PetKindTestSuite) TestPetKind_GetAllPetKindFunc_ErrFromRepo() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.petKindRepo.AssertExpectations(t)
 }
 
@@ -247,7 +247,7 @@ func (s *PetKindTestSuite) TestPetKind_GetAllPetKindFunc_ErrRespNil() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.petKindRepo.AssertExpectations(t)
 }
 
@@ -270,7 +270,7 @@ func (s *PetKindTestSuite) TestPetKind_DeletePetKindFunc_Err() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.petKindRepo.AssertExpectations(t)
 }
 
@@ -291,7 +291,7 @@ func (s *PetKindTestSuite) TestPetKind_DeletePetKindFunc_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.petKindRepo.AssertExpectations(t)
 }
 
@@ -313,7 +313,7 @@ func (s *PetKindTestSuite) TestPetKind_GetPetKindByIDFunc_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.petKindRepo.AssertExpectations(t)
 
 	actualPetKind := ent.PetKind{}
@@ -323,7 +323,7 @@ func (s *PetKindTestSuite) TestPetKind_GetPetKindByIDFunc_OK() {
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
 	eq := isEqualPetKind(t, petKindToReturn, &actualPetKind)
-	assert.Equal(t, true, eq)
+	require.Equal(t, true, eq)
 }
 
 func (s *PetKindTestSuite) TestPetKind_GetPetKindByIDFunc_ErrFromRepo() {
@@ -345,7 +345,7 @@ func (s *PetKindTestSuite) TestPetKind_GetPetKindByIDFunc_ErrFromRepo() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.petKindRepo.AssertExpectations(t)
 }
 
@@ -366,7 +366,7 @@ func (s *PetKindTestSuite) TestPetKind_GetPetKindByIDFunc_ErrRespNil() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.petKindRepo.AssertExpectations(t)
 }
 
@@ -393,7 +393,7 @@ func (s *PetKindTestSuite) TestPetKind_EditPetKindFunc_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.petKindRepo.AssertExpectations(t)
 
 	actualPetKind := ent.PetKind{}
@@ -403,7 +403,7 @@ func (s *PetKindTestSuite) TestPetKind_EditPetKindFunc_OK() {
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
 	eq := isEqualPetKind(t, petKindToReturn, &actualPetKind)
-	assert.Equal(t, true, eq)
+	require.Equal(t, true, eq)
 }
 
 func (s *PetKindTestSuite) TestPetKind_EditPetKindFunc_ErrRespNil() {
@@ -426,7 +426,7 @@ func (s *PetKindTestSuite) TestPetKind_EditPetKindFunc_ErrRespNil() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.petKindRepo.AssertExpectations(t)
 }
 
@@ -451,6 +451,6 @@ func (s *PetKindTestSuite) TestPetKind_EditPetKindFunc_ErrFromRepo() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.petKindRepo.AssertExpectations(t)
 }

--- a/internal/handlers/pet_size_test.go
+++ b/internal/handlers/pet_size_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime"
 	_ "github.com/mattn/go-sqlite3"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
@@ -36,11 +36,11 @@ func TestSetPetSizeHandler(t *testing.T) {
 	}
 	api := operations.NewBeAPI(swaggerSpec)
 	SetPetSizeHandler(logger, api)
-	assert.NotEmpty(t, api.PetSizeGetAllPetSizeHandler)
-	assert.NotEmpty(t, api.PetSizeEditPetSizeHandler)
-	assert.NotEmpty(t, api.PetSizeCreateNewPetSizeHandler)
-	assert.NotEmpty(t, api.PetSizeDeletePetSizeHandler)
-	assert.NotEmpty(t, api.PetSizeGetPetSizeHandler)
+	require.NotEmpty(t, api.PetSizeGetAllPetSizeHandler)
+	require.NotEmpty(t, api.PetSizeEditPetSizeHandler)
+	require.NotEmpty(t, api.PetSizeCreateNewPetSizeHandler)
+	require.NotEmpty(t, api.PetSizeDeletePetSizeHandler)
+	require.NotEmpty(t, api.PetSizeGetPetSizeHandler)
 
 }
 
@@ -123,7 +123,7 @@ func (s *PetSizeTestSuite) TestPetSize_CreatePetSizeFunc_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusCreated, responseRecorder.Code)
+	require.Equal(t, http.StatusCreated, responseRecorder.Code)
 	s.petSizeRepo.AssertExpectations(t)
 
 	actualPetSize := ent.PetSize{}
@@ -133,7 +133,7 @@ func (s *PetSizeTestSuite) TestPetSize_CreatePetSizeFunc_OK() {
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
 	eq := isEqual(t, petSizeToReturn, &actualPetSize)
-	assert.Equal(t, true, eq)
+	require.Equal(t, true, eq)
 }
 
 func (s *PetSizeTestSuite) TestPetSize_CreatePetSizeFunc_ErrFromRepo() {
@@ -168,7 +168,7 @@ func (s *PetSizeTestSuite) TestPetSize_CreatePetSizeFunc_ErrFromRepo() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.petSizeRepo.AssertExpectations(t)
 }
 
@@ -197,7 +197,7 @@ func (s *PetSizeTestSuite) TestPetSize_CreatePetSizeFunc_ErrRespGetAll() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.petSizeRepo.AssertExpectations(t)
 }
 
@@ -233,7 +233,7 @@ func (s *PetSizeTestSuite) TestPetSize_CreatePetSizeFunc_ErrRespNil() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.petSizeRepo.AssertExpectations(t)
 }
 
@@ -256,7 +256,7 @@ func (s *PetSizeTestSuite) TestPetSize_GetAllPetSizeFunc_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.petSizeRepo.AssertExpectations(t)
 
 	actualPetSize := []*ent.PetSize{}
@@ -267,7 +267,7 @@ func (s *PetSizeTestSuite) TestPetSize_GetAllPetSizeFunc_OK() {
 	}
 	for i := 0; i < 10; i++ {
 		eq := isEqual(t, petSizeToReturn[i], actualPetSize[i])
-		assert.Equal(t, true, eq)
+		require.Equal(t, true, eq)
 	}
 }
 
@@ -288,7 +288,7 @@ func (s *PetSizeTestSuite) TestPetSize_GetAllPetSizeFunc_ErrFromRepo() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.petSizeRepo.AssertExpectations(t)
 }
 
@@ -308,7 +308,7 @@ func (s *PetSizeTestSuite) TestPetSize_GetAllPetSizeFunc_ErrRespNil() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.petSizeRepo.AssertExpectations(t)
 }
 
@@ -331,7 +331,7 @@ func (s *PetSizeTestSuite) TestPetSize_DeletePetSizeFunc_Err() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.petSizeRepo.AssertExpectations(t)
 }
 
@@ -352,7 +352,7 @@ func (s *PetSizeTestSuite) TestPetSize_DeletePetSizeFunc_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.petSizeRepo.AssertExpectations(t)
 }
 
@@ -374,7 +374,7 @@ func (s *PetSizeTestSuite) TestPetSize_GetPetSizeByIDFunc_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.petSizeRepo.AssertExpectations(t)
 
 	actualPetSize := ent.PetSize{}
@@ -384,7 +384,7 @@ func (s *PetSizeTestSuite) TestPetSize_GetPetSizeByIDFunc_OK() {
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
 	eq := isEqual(t, petSizeToReturn, &actualPetSize)
-	assert.Equal(t, true, eq)
+	require.Equal(t, true, eq)
 }
 
 func (s *PetSizeTestSuite) TestPetSize_GetPetSizeByIDFunc_ErrFromRepo() {
@@ -406,7 +406,7 @@ func (s *PetSizeTestSuite) TestPetSize_GetPetSizeByIDFunc_ErrFromRepo() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.petSizeRepo.AssertExpectations(t)
 }
 
@@ -427,7 +427,7 @@ func (s *PetSizeTestSuite) TestPetSize_GetPetSizeByIDFunc_ErrRespNil() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.petSizeRepo.AssertExpectations(t)
 }
 
@@ -456,7 +456,7 @@ func (s *PetSizeTestSuite) TestPetSize_EditPetSizeFunc_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.petSizeRepo.AssertExpectations(t)
 
 	actualPetSize := ent.PetSize{}
@@ -466,7 +466,7 @@ func (s *PetSizeTestSuite) TestPetSize_EditPetSizeFunc_OK() {
 		t.Errorf("unable to unmarshal response body: %v", err)
 	}
 	eq := isEqual(t, petSizeToReturn, &actualPetSize)
-	assert.Equal(t, true, eq)
+	require.Equal(t, true, eq)
 }
 
 func (s *PetSizeTestSuite) TestPetSize_EditPetSizeFunc_ErrRespNil() {
@@ -491,7 +491,7 @@ func (s *PetSizeTestSuite) TestPetSize_EditPetSizeFunc_ErrRespNil() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.petSizeRepo.AssertExpectations(t)
 }
 
@@ -518,6 +518,6 @@ func (s *PetSizeTestSuite) TestPetSize_EditPetSizeFunc_ErrFromRepo() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.petSizeRepo.AssertExpectations(t)
 }

--- a/internal/handlers/photo_test.go
+++ b/internal/handlers/photo_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime"
 	_ "github.com/mattn/go-sqlite3"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
@@ -42,10 +42,10 @@ func TestSetPhotoHandler(t *testing.T) {
 	api := operations.NewBeAPI(swaggerSpec)
 
 	SetPhotoHandler(logger, api)
-	assert.NotEmpty(t, api.PhotosCreateNewPhotoHandler)
-	assert.NotEmpty(t, api.PhotosGetPhotoHandler)
-	assert.NotEmpty(t, api.PhotosDeletePhotoHandler)
-	assert.NotEmpty(t, api.PhotosDownloadPhotoHandler)
+	require.NotEmpty(t, api.PhotosCreateNewPhotoHandler)
+	require.NotEmpty(t, api.PhotosGetPhotoHandler)
+	require.NotEmpty(t, api.PhotosDeletePhotoHandler)
+	require.NotEmpty(t, api.PhotosDownloadPhotoHandler)
 }
 
 type PhotoTestSuite struct {
@@ -89,16 +89,16 @@ func (s *PhotoTestSuite) TestPhoto_CreatePhoto_EmptyFile() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusBadRequest, responseRecorder.Code)
+	require.Equal(t, http.StatusBadRequest, responseRecorder.Code)
 
 	response := models.Error{}
 	err = json.Unmarshal(responseRecorder.Body.Bytes(), &response)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NotEmpty(t, response)
-	assert.NotEmpty(t, response.Data)
-	assert.Equal(t, "File is empty", response.Data.Message)
+	require.NotEmpty(t, response)
+	require.NotEmpty(t, response.Data)
+	require.Equal(t, "File is empty", response.Data.Message)
 
 	s.repository.AssertExpectations(t)
 }
@@ -132,16 +132,16 @@ func (s *PhotoTestSuite) TestPhoto_CreatePhoto_WrongMimeType() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusBadRequest, responseRecorder.Code)
+	require.Equal(t, http.StatusBadRequest, responseRecorder.Code)
 
 	response := models.Error{}
 	err = json.Unmarshal(responseRecorder.Body.Bytes(), &response)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NotEmpty(t, response)
-	assert.NotEmpty(t, response.Data)
-	assert.Containsf(t, response.Data.Message, "Wrong file format", "returned wrong error")
+	require.NotEmpty(t, response)
+	require.NotEmpty(t, response.Data)
+	require.Containsf(t, response.Data.Message, "Wrong file format", "returned wrong error")
 
 	s.repository.AssertExpectations(t)
 }
@@ -186,15 +186,15 @@ func (s *PhotoTestSuite) TestPhoto_CreatePhoto_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusCreated, responseRecorder.Code)
+	require.Equal(t, http.StatusCreated, responseRecorder.Code)
 
 	returnedPhoto := models.CreateNewPhotoResponse{}
 	err = json.Unmarshal(responseRecorder.Body.Bytes(), &returnedPhoto)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NotEmpty(t, returnedPhoto.Data.ID)
-	assert.NotEmpty(t, returnedPhoto.Data.FileName)
+	require.NotEmpty(t, returnedPhoto.Data.ID)
+	require.NotEmpty(t, returnedPhoto.Data.FileName)
 
 	s.repository.AssertExpectations(t)
 }
@@ -225,10 +225,10 @@ func (s *PhotoTestSuite) TestPhoto_GetPhoto_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
-	assert.Equal(t, "image/jpg", responseRecorder.Header().Get("Content-Type"))
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, "image/jpg", responseRecorder.Header().Get("Content-Type"))
 
-	assert.Equal(t, []byte{1, 1, 1}, responseRecorder.Body.Bytes())
+	require.Equal(t, []byte{1, 1, 1}, responseRecorder.Body.Bytes())
 
 	s.repository.AssertExpectations(t)
 }
@@ -254,17 +254,17 @@ func (s *PhotoTestSuite) TestPhoto_GetPhoto_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
-	assert.Equal(t, "application/json", responseRecorder.Header().Get("Content-Type"))
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, "application/json", responseRecorder.Header().Get("Content-Type"))
 
 	response := models.Error{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &response)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NotEmpty(t, response)
-	assert.NotEmpty(t, response.Data)
-	assert.Equal(t, errorToReturn.Error(), response.Data.Message)
+	require.NotEmpty(t, response)
+	require.NotEmpty(t, response.Data)
+	require.Equal(t, errorToReturn.Error(), response.Data.Message)
 
 	s.repository.AssertExpectations(t)
 }
@@ -296,10 +296,10 @@ func (s *PhotoTestSuite) TestPhoto_DownloadPhoto_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
-	assert.Equal(t, "application/octet-stream", responseRecorder.Header().Get("Content-Type"))
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, "application/octet-stream", responseRecorder.Header().Get("Content-Type"))
 
-	assert.Equal(t, bytesToReturn, responseRecorder.Body.Bytes())
+	require.Equal(t, bytesToReturn, responseRecorder.Body.Bytes())
 
 	s.repository.AssertExpectations(t)
 }
@@ -325,16 +325,16 @@ func (s *PhotoTestSuite) TestPhoto_DeletePhoto_NotExists() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 
 	response := models.Error{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &response)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NotEmpty(t, response)
-	assert.NotEmpty(t, response.Data)
-	assert.Equal(t, errorToReturn.Error(), response.Data.Message)
+	require.NotEmpty(t, response)
+	require.NotEmpty(t, response.Data)
+	require.Equal(t, errorToReturn.Error(), response.Data.Message)
 
 	s.repository.AssertExpectations(t)
 }
@@ -364,7 +364,7 @@ func (s *PhotoTestSuite) TestPhoto_DeletePhoto_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.repository.AssertExpectations(t)
 }
 

--- a/internal/handlers/registration_confirm_test.go
+++ b/internal/handlers/registration_confirm_test.go
@@ -7,13 +7,13 @@ import (
 	"testing"
 
 	"github.com/go-openapi/loads"
+	"github.com/stretchr/testify/require"
 
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/mocks"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi/operations"
 
 	"github.com/go-openapi/runtime"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
@@ -31,8 +31,8 @@ func TestSetRegistrationHandler(t *testing.T) {
 	regConfService := &mocks.RegistrationConfirmService{}
 	api := operations.NewBeAPI(swaggerSpec)
 	SetRegistrationHandler(logger, api, regConfService)
-	assert.NotEmpty(t, api.RegistrationConfirmSendRegistrationConfirmLinkByLoginHandler)
-	assert.NotEmpty(t, api.RegistrationConfirmVerifyRegistrationConfirmTokenHandler)
+	require.NotEmpty(t, api.RegistrationConfirmSendRegistrationConfirmLinkByLoginHandler)
+	require.NotEmpty(t, api.RegistrationConfirmVerifyRegistrationConfirmTokenHandler)
 }
 
 type RegistrationConfirmHandlerTestSuite struct {
@@ -69,7 +69,7 @@ func (s *RegistrationConfirmHandlerTestSuite) TestRegistrationConfirmHandler_Sen
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.regConfirmService.AssertExpectations(t)
 }
 
@@ -86,7 +86,7 @@ func (s *RegistrationConfirmHandlerTestSuite) TestRegistrationConfirmHandler_Sen
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusBadRequest, responseRecorder.Code)
+	require.Equal(t, http.StatusBadRequest, responseRecorder.Code)
 	s.regConfirmService.AssertExpectations(t)
 }
 
@@ -106,7 +106,7 @@ func (s *RegistrationConfirmHandlerTestSuite) TestRegistrationConfirmHandler_Sen
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.regConfirmService.AssertExpectations(t)
 }
 
@@ -125,7 +125,7 @@ func (s *RegistrationConfirmHandlerTestSuite) TestRegistrationConfirmHandler_Ver
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.regConfirmService.AssertExpectations(t)
 }
 
@@ -145,6 +145,6 @@ func (s *RegistrationConfirmHandlerTestSuite) TestRegistrationConfirmHandler_Ver
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.regConfirmService.AssertExpectations(t)
 }

--- a/internal/handlers/role_test.go
+++ b/internal/handlers/role_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
@@ -34,7 +34,7 @@ func TestSetRoleHandler(t *testing.T) {
 	}
 	api := operations.NewBeAPI(swaggerSpec)
 	SetRoleHandler(logger, api)
-	assert.NotEmpty(t, api.RolesGetRolesHandler)
+	require.NotEmpty(t, api.RolesGetRolesHandler)
 }
 
 type RoleTestSuite struct {
@@ -72,7 +72,7 @@ func (s *RoleTestSuite) TestRole_GetRoles_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.repository.AssertExpectations(t)
 }
 
@@ -98,14 +98,14 @@ func (s *RoleTestSuite) TestRole_GetRoles_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	var responseRoles []models.Role
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseRoles)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(rolesToReturn), len(responseRoles))
-	assert.Equal(t, roleToReturn.ID, int(*responseRoles[0].ID))
+	require.Equal(t, len(rolesToReturn), len(responseRoles))
+	require.Equal(t, roleToReturn.ID, int(*responseRoles[0].ID))
 	s.repository.AssertExpectations(t)
 }

--- a/internal/handlers/subcategory_test.go
+++ b/internal/handlers/subcategory_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
@@ -35,11 +35,11 @@ func TestSetSubcategoryHandler(t *testing.T) {
 	}
 	api := operations.NewBeAPI(swaggerSpec)
 	SetSubcategoryHandler(logger, api)
-	assert.NotEmpty(t, api.SubcategoriesCreateNewSubcategoryHandler)
-	assert.NotEmpty(t, api.SubcategoriesGetSubcategoryByIDHandler)
-	assert.NotEmpty(t, api.SubcategoriesDeleteSubcategoryHandler)
-	assert.NotEmpty(t, api.SubcategoriesListSubcategoriesByCategoryIDHandler)
-	assert.NotEmpty(t, api.SubcategoriesUpdateSubcategoryHandler)
+	require.NotEmpty(t, api.SubcategoriesCreateNewSubcategoryHandler)
+	require.NotEmpty(t, api.SubcategoriesGetSubcategoryByIDHandler)
+	require.NotEmpty(t, api.SubcategoriesDeleteSubcategoryHandler)
+	require.NotEmpty(t, api.SubcategoriesListSubcategoriesByCategoryIDHandler)
+	require.NotEmpty(t, api.SubcategoriesUpdateSubcategoryHandler)
 }
 
 type SubcategoryTestSuite struct {
@@ -89,7 +89,7 @@ func (s *SubcategoryTestSuite) TestSubcategory_CreateSubcategory_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.repository.AssertExpectations(t)
 }
 
@@ -123,17 +123,17 @@ func (s *SubcategoryTestSuite) TestSubcategory_CreateSubcategory_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusCreated, responseRecorder.Code)
+	require.Equal(t, http.StatusCreated, responseRecorder.Code)
 
 	returnedSubcategory := models.SubcategoryResponse{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &returnedSubcategory)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, subcategoryToReturn.ID, int(*returnedSubcategory.Data.ID))
-	assert.Equal(t, subcategoryToReturn.Name, *returnedSubcategory.Data.Name)
-	assert.Equal(t, subcategoryToReturn.MaxReservationTime, *returnedSubcategory.Data.MaxReservationTime)
-	assert.Equal(t, subcategoryToReturn.MaxReservationUnits, *returnedSubcategory.Data.MaxReservationUnits)
+	require.Equal(t, subcategoryToReturn.ID, int(*returnedSubcategory.Data.ID))
+	require.Equal(t, subcategoryToReturn.Name, *returnedSubcategory.Data.Name)
+	require.Equal(t, subcategoryToReturn.MaxReservationTime, *returnedSubcategory.Data.MaxReservationTime)
+	require.Equal(t, subcategoryToReturn.MaxReservationUnits, *returnedSubcategory.Data.MaxReservationUnits)
 
 	s.repository.AssertExpectations(t)
 }
@@ -160,7 +160,7 @@ func (s *SubcategoryTestSuite) TestSubcategory_GetAllSubcategories_RepoErr() {
 	returnedSubcategory := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(returnedSubcategory, producer)
-	assert.Equal(t, http.StatusInternalServerError, returnedSubcategory.Code)
+	require.Equal(t, http.StatusInternalServerError, returnedSubcategory.Code)
 
 	s.repository.AssertExpectations(t)
 }
@@ -186,14 +186,14 @@ func (s *SubcategoryTestSuite) TestSubcategory_GetAllSubcategories_NotFound() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	returnedSubcategory := models.ListOfSubcategories{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &returnedSubcategory)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Empty(t, returnedSubcategory)
+	require.Empty(t, returnedSubcategory)
 
 	s.repository.AssertExpectations(t)
 }
@@ -224,14 +224,14 @@ func (s *SubcategoryTestSuite) TestSubcategory_GetAllSubcategories_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	returnedSubcategory := models.ListOfSubcategories{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &returnedSubcategory)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(subcategoriesToReturn), len(returnedSubcategory))
+	require.Equal(t, len(subcategoriesToReturn), len(returnedSubcategory))
 
 	s.repository.AssertExpectations(t)
 }
@@ -257,7 +257,7 @@ func (s *SubcategoryTestSuite) TestSubcategory_GetSubcategoryByID_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 
 	s.repository.AssertExpectations(t)
 }
@@ -283,18 +283,18 @@ func (s *SubcategoryTestSuite) TestSubcategory_GetSubcategoryByID_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	returnedSubcategory := models.SubcategoryResponse{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &returnedSubcategory)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, subcatToReturn.ID, int(*returnedSubcategory.Data.ID))
-	assert.Equal(t, subcatToReturn.Name, *returnedSubcategory.Data.Name)
-	assert.Equal(t, subcatToReturn.MaxReservationTime, *returnedSubcategory.Data.MaxReservationTime)
-	assert.Equal(t, subcatToReturn.MaxReservationUnits, *returnedSubcategory.Data.MaxReservationUnits)
-	assert.Equal(t, subcatToReturn.Edges.Category.ID, int(*returnedSubcategory.Data.Category))
+	require.Equal(t, subcatToReturn.ID, int(*returnedSubcategory.Data.ID))
+	require.Equal(t, subcatToReturn.Name, *returnedSubcategory.Data.Name)
+	require.Equal(t, subcatToReturn.MaxReservationTime, *returnedSubcategory.Data.MaxReservationTime)
+	require.Equal(t, subcatToReturn.MaxReservationUnits, *returnedSubcategory.Data.MaxReservationUnits)
+	require.Equal(t, subcatToReturn.Edges.Category.ID, int(*returnedSubcategory.Data.Category))
 	s.repository.AssertExpectations(t)
 }
 
@@ -318,7 +318,7 @@ func (s *SubcategoryTestSuite) TestSubcategory_DeleteSubcategory_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 
 	s.repository.AssertExpectations(t)
 }
@@ -342,7 +342,7 @@ func (s *SubcategoryTestSuite) TestSubcategory_DeleteSubcategory_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	s.repository.AssertExpectations(t)
 }
@@ -373,7 +373,7 @@ func (s *SubcategoryTestSuite) TestSubcategory_UpdateSubcategory_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 
 	s.repository.AssertExpectations(t)
 }
@@ -405,17 +405,17 @@ func (s *SubcategoryTestSuite) TestSubcategory_UpdateSubcategory_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	returnedSubcategory := models.SubcategoryResponse{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &returnedSubcategory)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, updatedSubcategory.ID, int(*returnedSubcategory.Data.ID))
-	assert.Equal(t, updatedSubcategory.MaxReservationUnits, *returnedSubcategory.Data.MaxReservationUnits)
-	assert.Equal(t, updatedSubcategory.MaxReservationTime, *returnedSubcategory.Data.MaxReservationTime)
-	assert.Equal(t, updatedSubcategory.Edges.Category.ID, int(*returnedSubcategory.Data.Category))
+	require.Equal(t, updatedSubcategory.ID, int(*returnedSubcategory.Data.ID))
+	require.Equal(t, updatedSubcategory.MaxReservationUnits, *returnedSubcategory.Data.MaxReservationUnits)
+	require.Equal(t, updatedSubcategory.MaxReservationTime, *returnedSubcategory.Data.MaxReservationTime)
+	require.Equal(t, updatedSubcategory.Edges.Category.ID, int(*returnedSubcategory.Data.Category))
 
 	s.repository.AssertExpectations(t)
 }

--- a/internal/handlers/user_test.go
+++ b/internal/handlers/user_test.go
@@ -12,7 +12,7 @@ import (
 	"entgo.io/ent/entc/integration/ent/user"
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
@@ -42,15 +42,15 @@ func TestSetUserHandler(t *testing.T) {
 	registrationConfirm := &mocks.RegistrationConfirmService{}
 	SetUserHandler(logger, api, tokenManager, registrationConfirm)
 
-	assert.NotEmpty(t, api.UsersLoginHandler)
-	assert.NotEmpty(t, api.UsersRefreshHandler)
-	assert.NotEmpty(t, api.UsersPostUserHandler)
-	assert.NotEmpty(t, api.UsersGetCurrentUserHandler)
-	assert.NotEmpty(t, api.UsersPatchUserHandler)
-	assert.NotEmpty(t, api.UsersGetUserHandler)
-	assert.NotEmpty(t, api.UsersGetAllUsersHandler)
-	assert.NotEmpty(t, api.UsersAssignRoleToUserHandler)
-	assert.NotEmpty(t, api.UsersDeleteUserHandler)
+	require.NotEmpty(t, api.UsersLoginHandler)
+	require.NotEmpty(t, api.UsersRefreshHandler)
+	require.NotEmpty(t, api.UsersPostUserHandler)
+	require.NotEmpty(t, api.UsersGetCurrentUserHandler)
+	require.NotEmpty(t, api.UsersPatchUserHandler)
+	require.NotEmpty(t, api.UsersGetUserHandler)
+	require.NotEmpty(t, api.UsersGetAllUsersHandler)
+	require.NotEmpty(t, api.UsersAssignRoleToUserHandler)
+	require.NotEmpty(t, api.UsersDeleteUserHandler)
 }
 
 type UserTestSuite struct {
@@ -96,7 +96,7 @@ func (s *UserTestSuite) TestUser_LoginUserFunc_InternalErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.service.AssertExpectations(t)
 }
 
@@ -122,7 +122,7 @@ func (s *UserTestSuite) TestUser_LoginUserFunc_UnauthorizedErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusUnauthorized, responseRecorder.Code)
+	require.Equal(t, http.StatusUnauthorized, responseRecorder.Code)
 	s.service.AssertExpectations(t)
 }
 
@@ -149,15 +149,15 @@ func (s *UserTestSuite) TestUser_LoginUserFunc_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	var tokenPair models.TokenPair
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &tokenPair)
 	if err != nil {
 		t.Errorf("unable to unmarshal response: %v", err)
 	}
-	assert.Equal(t, accessToken, *tokenPair.AccessToken)
-	assert.Equal(t, refreshToken, *tokenPair.RefreshToken)
+	require.Equal(t, accessToken, *tokenPair.AccessToken)
+	require.Equal(t, refreshToken, *tokenPair.RefreshToken)
 
 	s.service.AssertExpectations(t)
 }
@@ -184,7 +184,7 @@ func (s *UserTestSuite) TestUser_PostUserFunc_LoginExistErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusExpectationFailed, responseRecorder.Code)
+	require.Equal(t, http.StatusExpectationFailed, responseRecorder.Code)
 	s.userRepository.AssertExpectations(t)
 }
 
@@ -210,7 +210,7 @@ func (s *UserTestSuite) TestUser_PostUserFunc_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.userRepository.AssertExpectations(t)
 }
 
@@ -241,7 +241,7 @@ func (s *UserTestSuite) TestUser_PostUserFunc_RegConfirmErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusCreated, responseRecorder.Code)
+	require.Equal(t, http.StatusCreated, responseRecorder.Code)
 	s.userRepository.AssertExpectations(t)
 }
 
@@ -271,7 +271,7 @@ func (s *UserTestSuite) TestUser_PostUserFunc_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusCreated, responseRecorder.Code)
+	require.Equal(t, http.StatusCreated, responseRecorder.Code)
 	s.userRepository.AssertExpectations(t)
 }
 
@@ -294,7 +294,7 @@ func (s *UserTestSuite) TestUser_Refresh_InvalidToken_InvalidToken() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusBadRequest, responseRecorder.Code)
+	require.Equal(t, http.StatusBadRequest, responseRecorder.Code)
 	s.service.AssertExpectations(t)
 }
 
@@ -318,7 +318,7 @@ func (s *UserTestSuite) TestUser_Refresh_InvalidToken_ServiceErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.service.AssertExpectations(t)
 }
 
@@ -342,13 +342,13 @@ func (s *UserTestSuite) TestUser_Refresh_InvalidToken_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	responseToken := &models.AccessToken{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), responseToken)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, newToken, *responseToken.AccessToken)
+	require.Equal(t, newToken, *responseToken.AccessToken)
 
 	s.service.AssertExpectations(t)
 }
@@ -366,7 +366,7 @@ func (s *UserTestSuite) TestUser_GetUserFunc_AccessErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusUnauthorized, responseRecorder.Code)
+	require.Equal(t, http.StatusUnauthorized, responseRecorder.Code)
 
 	s.userRepository.AssertExpectations(t)
 }
@@ -390,7 +390,7 @@ func (s *UserTestSuite) TestUser_GetUserFunc_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 
 	s.userRepository.AssertExpectations(t)
 }
@@ -414,7 +414,7 @@ func (s *UserTestSuite) TestUser_GetUserFunc_MapErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 
 	s.userRepository.AssertExpectations(t)
 }
@@ -443,7 +443,7 @@ func (s *UserTestSuite) TestUser_GetUserFunc_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	s.userRepository.AssertExpectations(t)
 }
@@ -467,7 +467,7 @@ func (s *UserTestSuite) TestUser_PatchUser_AccessErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusUnauthorized, responseRecorder.Code)
+	require.Equal(t, http.StatusUnauthorized, responseRecorder.Code)
 
 	s.userRepository.AssertExpectations(t)
 }
@@ -495,7 +495,7 @@ func (s *UserTestSuite) TestUser_PatchUser_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 
 	s.userRepository.AssertExpectations(t)
 }
@@ -522,7 +522,7 @@ func (s *UserTestSuite) TestUser_PatchUser_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusNoContent, responseRecorder.Code)
+	require.Equal(t, http.StatusNoContent, responseRecorder.Code)
 
 	s.userRepository.AssertExpectations(t)
 }
@@ -542,7 +542,7 @@ func (s *UserTestSuite) TestUser_AssignRoleToUserFunc_AccessErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 
 	s.userRepository.AssertExpectations(t)
 }
@@ -575,7 +575,7 @@ func (s *UserTestSuite) TestUser_AssignRoleToUserFunc_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 
 	s.userRepository.AssertExpectations(t)
 }
@@ -607,7 +607,7 @@ func (s *UserTestSuite) TestUser_AssignRoleToUserFunc_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	s.userRepository.AssertExpectations(t)
 }
@@ -629,7 +629,7 @@ func (s *UserTestSuite) TestUser_GetUsersList_RepositoryErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 
 	s.userRepository.AssertExpectations(t)
 }
@@ -661,7 +661,7 @@ func (s *UserTestSuite) TestUser_GetUsersList_MapErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 
 	s.userRepository.AssertExpectations(t)
 }
@@ -682,15 +682,15 @@ func (s *UserTestSuite) TestUser_GetUsersList_NotFound() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	responseUsers := &models.GetListUsers{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), responseUsers)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, 0, int(*responseUsers.Total))
-	assert.Equal(t, 0, len(responseUsers.Items))
+	require.Equal(t, 0, int(*responseUsers.Total))
+	require.Equal(t, 0, len(responseUsers.Items))
 	s.userRepository.AssertExpectations(t)
 }
 
@@ -719,15 +719,15 @@ func (s *UserTestSuite) TestUser_GetUsersList_EmptyParams() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	responseUsers := &models.GetListUsers{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), responseUsers)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(usersToReturn), int(*responseUsers.Total))
-	assert.Equal(t, len(usersToReturn), len(responseUsers.Items))
+	require.Equal(t, len(usersToReturn), int(*responseUsers.Total))
+	require.Equal(t, len(usersToReturn), len(responseUsers.Items))
 
 	s.userRepository.AssertExpectations(t)
 }
@@ -763,16 +763,16 @@ func (s *UserTestSuite) TestUser_GetUsersList_LimitGreaterThanTotal() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	responseUsers := &models.GetListUsers{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), responseUsers)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(usersToReturn), int(*responseUsers.Total))
-	assert.Equal(t, len(usersToReturn), len(responseUsers.Items))
-	assert.GreaterOrEqual(t, int(limit), len(responseUsers.Items))
+	require.Equal(t, len(usersToReturn), int(*responseUsers.Total))
+	require.Equal(t, len(usersToReturn), len(responseUsers.Items))
+	require.GreaterOrEqual(t, int(limit), len(responseUsers.Items))
 
 	s.userRepository.AssertExpectations(t)
 }
@@ -811,16 +811,16 @@ func (s *UserTestSuite) TestUser_GetUsersList_LimitLessThanTotal() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	responseUsers := &models.GetListUsers{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), responseUsers)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(usersToReturn), int(*responseUsers.Total))
-	assert.Greater(t, len(usersToReturn), len(responseUsers.Items))
-	assert.GreaterOrEqual(t, int(limit), len(responseUsers.Items))
+	require.Equal(t, len(usersToReturn), int(*responseUsers.Total))
+	require.Greater(t, len(usersToReturn), len(responseUsers.Items))
+	require.GreaterOrEqual(t, int(limit), len(responseUsers.Items))
 
 	s.userRepository.AssertExpectations(t)
 }
@@ -859,17 +859,17 @@ func (s *UserTestSuite) TestUser_GetUsersList_SecondPage() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	responseUsers := &models.GetListUsers{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), responseUsers)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(usersToReturn), int(*responseUsers.Total))
-	assert.Greater(t, len(usersToReturn), len(responseUsers.Items))
-	assert.GreaterOrEqual(t, int(limit), len(responseUsers.Items))
-	assert.Equal(t, len(usersToReturn)-int(offset), len(responseUsers.Items))
+	require.Equal(t, len(usersToReturn), int(*responseUsers.Total))
+	require.Greater(t, len(usersToReturn), len(responseUsers.Items))
+	require.GreaterOrEqual(t, int(limit), len(responseUsers.Items))
+	require.Equal(t, len(usersToReturn)-int(offset), len(responseUsers.Items))
 
 	s.userRepository.AssertExpectations(t)
 }
@@ -908,15 +908,15 @@ func (s *UserTestSuite) TestUser_GetUsersList_SeveralPages() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	firstPage := &models.GetListUsers{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), firstPage)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(usersToReturn), int(*firstPage.Total))
-	assert.Equal(t, int(limit), len(firstPage.Items))
+	require.Equal(t, len(usersToReturn), int(*firstPage.Total))
+	require.Equal(t, int(limit), len(firstPage.Items))
 
 	offset = limit
 	data = users.GetAllUsersParams{
@@ -934,19 +934,19 @@ func (s *UserTestSuite) TestUser_GetUsersList_SeveralPages() {
 	responseRecorder = httptest.NewRecorder()
 	producer = runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	secondPage := &models.GetListUsers{}
 	err = json.Unmarshal(responseRecorder.Body.Bytes(), secondPage)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(usersToReturn), int(*secondPage.Total))
-	assert.Greater(t, len(usersToReturn), len(secondPage.Items))
-	assert.GreaterOrEqual(t, int(limit), len(secondPage.Items))
-	assert.Equal(t, len(usersToReturn)-int(offset), len(secondPage.Items))
+	require.Equal(t, len(usersToReturn), int(*secondPage.Total))
+	require.Greater(t, len(usersToReturn), len(secondPage.Items))
+	require.GreaterOrEqual(t, int(limit), len(secondPage.Items))
+	require.Equal(t, len(usersToReturn)-int(offset), len(secondPage.Items))
 
-	assert.False(t, usersDuplicated(t, firstPage.Items, secondPage.Items))
+	require.False(t, usersDuplicated(t, firstPage.Items, secondPage.Items))
 	s.userRepository.AssertExpectations(t)
 }
 
@@ -969,7 +969,7 @@ func (s *UserTestSuite) TestUser_GetUserById_RepoErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 
 	s.userRepository.AssertExpectations(t)
 }
@@ -995,7 +995,7 @@ func (s *UserTestSuite) TestUser_GetUserById_MapErr() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 
 	s.userRepository.AssertExpectations(t)
 }
@@ -1025,14 +1025,14 @@ func (s *UserTestSuite) TestUser_GetUserById_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
 	responseUsers := &models.UserInfo{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), responseUsers)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, user.ID, int(*responseUsers.ID))
+	require.Equal(t, user.ID, int(*responseUsers.ID))
 
 	s.userRepository.AssertExpectations(t)
 }
@@ -1052,7 +1052,7 @@ func (s *UserTestSuite) TestUser_DeleteUserFunc_Err() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	s.userRepository.AssertExpectations(t)
 }
 
@@ -1089,7 +1089,7 @@ func (s *UserTestSuite) TestUser_DeleteUserFunc_OK() {
 	responseRecorder := httptest.NewRecorder()
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	s.userRepository.AssertExpectations(t)
 }
 

--- a/internal/logger/setup_test.go
+++ b/internal/logger/setup_test.go
@@ -3,11 +3,11 @@ package logger
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGet(t *testing.T) {
 	l, err := Get()
-	assert.NoError(t, err)
-	assert.NotNil(t, l)
+	require.NoError(t, err)
+	require.NotNil(t, l)
 }

--- a/internal/middlewares/bearer_auth_test.go
+++ b/internal/middlewares/bearer_auth_test.go
@@ -3,7 +3,7 @@ package middlewares
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/authentication"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/logger"
@@ -21,11 +21,11 @@ func TestBearerAuthenticateFunc(t *testing.T) {
 	f := BearerAuthenticateFunc("123", l)
 
 	i, err := f(testJWT)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	auth := i.(authentication.Auth)
-	assert.Equal(t, 1, auth.Id)
-	assert.Equal(t, "login", auth.Login)
-	assert.Equal(t, 2, auth.Role.Id)
-	assert.Equal(t, "administrator", auth.Role.Slug)
+	require.Equal(t, 1, auth.Id)
+	require.Equal(t, "login", auth.Login)
+	require.Equal(t, 2, auth.Role.Id)
+	require.Equal(t, "administrator", auth.Role.Slug)
 }

--- a/internal/overdue/overdue_test.go
+++ b/internal/overdue/overdue_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	_ "github.com/mattn/go-sqlite3"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -97,8 +96,8 @@ func (s *CheckupTestSuite) TestCheckup_Success_PartialUpdate() {
 
 	require.Equal(t, 1, observedLogs.Len())
 	firstLog := observedLogs.All()[0]
-	assert.Equal(t, "Updated Statuses to Overdue", firstLog.Message)
-	assert.Equal(t, firstLog.Context[0], zap.Ints("order id", updated))
+	require.Equal(t, "Updated Statuses to Overdue", firstLog.Message)
+	require.Equal(t, firstLog.Context[0], zap.Ints("order id", updated))
 	s.orderFilterRepo.AssertExpectations(t)
 	s.orderStatusRepo.AssertExpectations(t)
 	s.eqStatusRepo.AssertExpectations(t)
@@ -119,7 +118,7 @@ func (s *CheckupTestSuite) TestCheckup_EmptyListOfOrders() {
 
 	require.Equal(t, 1, observedLogs.Len())
 	firstLog := observedLogs.All()[0]
-	assert.Equal(t, "Order list with in progress status is empty", firstLog.Message)
+	require.Equal(t, "Order list with in progress status is empty", firstLog.Message)
 	s.orderFilterRepo.AssertExpectations(t)
 	s.orderStatusRepo.AssertExpectations(t)
 	s.eqStatusRepo.AssertExpectations(t)
@@ -141,7 +140,7 @@ func (s *CheckupTestSuite) TestCheckup_OrderFilter_RepoErr() {
 
 	require.Equal(t, 1, observedLogs.Len())
 	firstLog := observedLogs.All()[0]
-	assert.Equal(t, "Error while ordering by status", firstLog.Message)
+	require.Equal(t, "Error while ordering by status", firstLog.Message)
 	s.orderFilterRepo.AssertExpectations(t)
 	s.orderStatusRepo.AssertExpectations(t)
 	s.eqStatusRepo.AssertExpectations(t)
@@ -225,7 +224,7 @@ func (s *CheckupTestSuite) TestCheckup_OrderStatus_RepoErr() {
 
 	require.Equal(t, 1, observedLogs.Len())
 	firstLog := observedLogs.All()[0]
-	assert.Equal(t, "Error while updating status to overdue", firstLog.Message)
+	require.Equal(t, "Error while updating status to overdue", firstLog.Message)
 	s.orderFilterRepo.AssertExpectations(t)
 	s.orderStatusRepo.AssertExpectations(t)
 	s.eqStatusRepo.AssertExpectations(t)
@@ -282,7 +281,7 @@ func (s *CheckupTestSuite) TestCheckup_EquipmentsStatuses_RepoErr() {
 
 	require.Equal(t, 1, observedLogs.Len())
 	firstLog := observedLogs.All()[0]
-	assert.Equal(t, "Error while updating status to overdue", firstLog.Message)
+	require.Equal(t, "Error while updating status to overdue", firstLog.Message)
 	s.orderFilterRepo.AssertExpectations(t)
 	s.orderStatusRepo.AssertExpectations(t)
 	s.eqStatusRepo.AssertExpectations(t)
@@ -338,7 +337,7 @@ func (s *CheckupTestSuite) TestCheckup_EquipmentsStatuses_UpdateRepoErr() {
 
 	require.Equal(t, 1, observedLogs.Len())
 	firstLog := observedLogs.All()[0]
-	assert.Equal(t, "Error while updating status to overdue", firstLog.Message)
+	require.Equal(t, "Error while updating status to overdue", firstLog.Message)
 	s.orderFilterRepo.AssertExpectations(t)
 	s.orderStatusRepo.AssertExpectations(t)
 	s.eqStatusRepo.AssertExpectations(t)
@@ -369,7 +368,7 @@ func (s *CheckupTestSuite) TestPeriodicalCheckup_EmptyListOfOrders() {
 
 	require.GreaterOrEqual(t, observedLogs.Len(), 1)
 	firstLog := observedLogs.All()[0]
-	assert.Equal(t, "Order list with in progress status is empty", firstLog.Message)
+	require.Equal(t, "Order list with in progress status is empty", firstLog.Message)
 	s.orderFilterRepo.AssertExpectations(t)
 	s.orderStatusRepo.AssertExpectations(t)
 	s.eqStatusRepo.AssertExpectations(t)

--- a/internal/repositories/active_area_test.go
+++ b/internal/repositories/active_area_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent"
@@ -72,12 +72,12 @@ func (s *ActiveAreasSuite) TestActiveAreaRepository_AllActiveAreasEmptyOrderBy()
 	orderColumn := activearea.FieldName
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	activeAreas, err := s.repository.AllActiveAreas(ctx, limit, offset, orderBy, orderColumn)
-	assert.Error(t, err)
-	assert.NoError(t, tx.Rollback())
-	assert.Nil(t, activeAreas)
+	require.Error(t, err)
+	require.NoError(t, tx.Rollback())
+	require.Nil(t, activeAreas)
 }
 
 func (s *ActiveAreasSuite) TestActiveAreaRepository_AllActiveAreasEmptyOrderColumn() {
@@ -88,12 +88,12 @@ func (s *ActiveAreasSuite) TestActiveAreaRepository_AllActiveAreasEmptyOrderColu
 	orderColumn := ""
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	activeAreas, err := s.repository.AllActiveAreas(ctx, limit, offset, orderBy, orderColumn)
-	assert.Error(t, err)
-	assert.NoError(t, tx.Rollback())
-	assert.Nil(t, activeAreas)
+	require.Error(t, err)
+	require.NoError(t, tx.Rollback())
+	require.Nil(t, activeAreas)
 }
 
 func (s *ActiveAreasSuite) TestActiveAreaRepository_AllActiveAreasOrderByNameDesc() {
@@ -104,18 +104,18 @@ func (s *ActiveAreasSuite) TestActiveAreaRepository_AllActiveAreasOrderByNameDes
 	orderColumn := activearea.FieldName
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	activeAreas, err := s.repository.AllActiveAreas(ctx, limit, offset, orderBy, orderColumn)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.activeAreas), len(activeAreas))
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.activeAreas), len(activeAreas))
 	prevAreaName := "zzzzzzzzzzzzzzzzzzzzzzzzz"
 	for _, value := range activeAreas {
-		assert.True(t, mapContainsArea(t, value.Name, s.activeAreas))
-		assert.GreaterOrEqual(t, prevAreaName, value.Name)
+		require.True(t, mapContainsArea(t, value.Name, s.activeAreas))
+		require.GreaterOrEqual(t, prevAreaName, value.Name)
 		prevAreaName = value.Name
 	}
 }
@@ -128,18 +128,18 @@ func (s *ActiveAreasSuite) TestActiveAreaRepository_AllActiveAreasOrderByIDDesc(
 	orderColumn := activearea.FieldID
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	activeAreas, err := s.repository.AllActiveAreas(ctx, limit, offset, orderBy, orderColumn)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.activeAreas), len(activeAreas))
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.activeAreas), len(activeAreas))
 	prevAreaID := math.MaxInt
 	for _, value := range activeAreas {
-		assert.True(t, mapContainsArea(t, value.Name, s.activeAreas))
-		assert.Less(t, value.ID, prevAreaID)
+		require.True(t, mapContainsArea(t, value.Name, s.activeAreas))
+		require.Less(t, value.ID, prevAreaID)
 		prevAreaID = value.ID
 	}
 }
@@ -152,18 +152,18 @@ func (s *ActiveAreasSuite) TestActiveAreaRepository_AllActiveAreasOrderByNameAsc
 	orderColumn := activearea.FieldName
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	activeAreas, err := s.repository.AllActiveAreas(ctx, limit, offset, orderBy, orderColumn)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.activeAreas), len(activeAreas))
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.activeAreas), len(activeAreas))
 	prevAreaName := ""
 	for _, value := range activeAreas {
-		assert.True(t, mapContainsArea(t, value.Name, s.activeAreas))
-		assert.LessOrEqual(t, prevAreaName, value.Name)
+		require.True(t, mapContainsArea(t, value.Name, s.activeAreas))
+		require.LessOrEqual(t, prevAreaName, value.Name)
 		prevAreaName = value.Name
 	}
 }
@@ -176,18 +176,18 @@ func (s *ActiveAreasSuite) TestActiveAreaRepository_AllActiveAreasOrderByIDAsc()
 	orderColumn := activearea.FieldID
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	activeAreas, err := s.repository.AllActiveAreas(ctx, limit, offset, orderBy, orderColumn)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.activeAreas), len(activeAreas))
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.activeAreas), len(activeAreas))
 	prevAreaID := 0
 	for _, value := range activeAreas {
-		assert.True(t, mapContainsArea(t, value.Name, s.activeAreas))
-		assert.Greater(t, value.ID, prevAreaID)
+		require.True(t, mapContainsArea(t, value.Name, s.activeAreas))
+		require.Greater(t, value.ID, prevAreaID)
 		prevAreaID = value.ID
 	}
 }
@@ -200,14 +200,14 @@ func (s *ActiveAreasSuite) TestActiveAreaRepository_LimitActiveAreas() {
 	orderColumn := activearea.FieldName
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	activeAreas, err := s.repository.AllActiveAreas(ctx, limit, offset, orderBy, orderColumn)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.GreaterOrEqual(t, limit, len(activeAreas))
+	require.NoError(t, tx.Commit())
+	require.GreaterOrEqual(t, limit, len(activeAreas))
 }
 
 func (s *ActiveAreasSuite) TestActiveAreaRepository_OffsetActiveAreas() {
@@ -218,28 +218,28 @@ func (s *ActiveAreasSuite) TestActiveAreaRepository_OffsetActiveAreas() {
 	orderColumn := activearea.FieldName
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	activeAreas, err := s.repository.AllActiveAreas(ctx, limit, offset, orderBy, orderColumn)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.activeAreas)-offset, len(activeAreas))
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.activeAreas)-offset, len(activeAreas))
 }
 
 func (s *ActiveAreasSuite) TestActiveAreaRepository_TotalActiveAreas() {
 	t := s.T()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	totalAreas, err := s.repository.TotalActiveAreas(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.activeAreas), totalAreas)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.activeAreas), totalAreas)
 }
 
 func mapContainsArea(t *testing.T, value string, m map[int]string) bool {

--- a/internal/repositories/blocker_test.go
+++ b/internal/repositories/blocker_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent"
@@ -54,45 +54,45 @@ func (s *blockerTestSuite) TestBlockerRepository_SetIsBlockedUser_SetTrue() {
 	t := s.T()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	err = s.repository.SetIsBlockedUser(ctx, s.user.ID, true)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
 	updatedUser, err := s.client.User.Get(ctx, s.user.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.True(t, updatedUser.IsBlocked)
+	require.True(t, updatedUser.IsBlocked)
 }
 
 func (s *blockerTestSuite) TestBlockerRepository_SetIsBlockedUser_SetFalse() {
 	t := s.T()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	err = s.repository.SetIsBlockedUser(ctx, s.user.ID, false)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
 	updatedUser, err := s.client.User.Get(ctx, s.user.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.False(t, updatedUser.IsBlocked)
+	require.False(t, updatedUser.IsBlocked)
 }
 
 func (s *blockerTestSuite) TestBlockerRepository_SetIsBlockedUser_NoUser() {
 	t := s.T()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	err = s.client.User.DeleteOneID(s.user.ID).Exec(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 	err = s.repository.SetIsBlockedUser(ctx, s.user.ID, false)
-	assert.Error(t, err)
-	assert.NoError(t, tx.Rollback())
+	require.Error(t, err)
+	require.NoError(t, tx.Rollback())
 }

--- a/internal/repositories/category_test.go
+++ b/internal/repositories/category_test.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent"
@@ -114,26 +114,26 @@ func (s *categoryRepositorySuite) TestCategoryRepository_CreateCategory() {
 	}
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	createdCategory, err := s.repository.CreateCategory(ctx, newCategory)
-	assert.NoError(t, err)
-	assert.Equal(t, name, createdCategory.Name)
-	assert.Equal(t, maxReservationTime, createdCategory.MaxReservationTime)
-	assert.Equal(t, maxReservationUnits, createdCategory.MaxReservationUnits)
-	assert.NoError(t, tx.Rollback())
+	require.NoError(t, err)
+	require.Equal(t, name, createdCategory.Name)
+	require.Equal(t, maxReservationTime, createdCategory.MaxReservationTime)
+	require.Equal(t, maxReservationUnits, createdCategory.MaxReservationUnits)
+	require.NoError(t, tx.Rollback())
 }
 
 func (s *categoryRepositorySuite) TestCategoryRepository_AllCategoriesTotal() {
 	t := s.T()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	total, err := s.repository.AllCategoriesTotal(ctx)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.categories), total)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.categories), total)
 }
 func (s *categoryRepositorySuite) TestCategoryRepository_AllCategory_EmptyOrderBy() {
 	t := s.T()
@@ -147,12 +147,12 @@ func (s *categoryRepositorySuite) TestCategoryRepository_AllCategory_EmptyOrderB
 
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	categories, err := s.repository.AllCategories(ctx, filter)
-	assert.Error(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Nil(t, categories)
+	require.Error(t, err)
+	require.NoError(t, tx.Commit())
+	require.Nil(t, categories)
 }
 
 func (s *categoryRepositorySuite) TestCategoryRepository_AllCategory_EmptyOrderColumn() {
@@ -165,12 +165,12 @@ func (s *categoryRepositorySuite) TestCategoryRepository_AllCategory_EmptyOrderC
 	}
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	categories, err := s.repository.AllCategories(ctx, filter)
-	assert.Error(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Nil(t, categories)
+	require.Error(t, err)
+	require.NoError(t, tx.Commit())
+	require.Nil(t, categories)
 }
 
 func (s *categoryRepositorySuite) TestCategoryRepository_AllCategory_WrongOrderColumn() {
@@ -186,12 +186,12 @@ func (s *categoryRepositorySuite) TestCategoryRepository_AllCategory_WrongOrderC
 
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	categories, err := s.repository.AllCategories(ctx, filter)
-	assert.Error(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Nil(t, categories)
+	require.Error(t, err)
+	require.NoError(t, tx.Commit())
+	require.Nil(t, categories)
 }
 
 func (s *categoryRepositorySuite) TestCategoryRepository_AllCategory_OrderByIDDesc() {
@@ -207,16 +207,16 @@ func (s *categoryRepositorySuite) TestCategoryRepository_AllCategory_OrderByIDDe
 
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	categories, err := s.repository.AllCategories(ctx, filter)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.categories), len(categories))
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.categories), len(categories))
 	prevCategoryID := math.MaxInt
 	for _, value := range categories {
-		assert.True(t, containsCategory(t, value, s.categories))
-		assert.LessOrEqual(t, value.ID, prevCategoryID)
+		require.True(t, containsCategory(t, value, s.categories))
+		require.LessOrEqual(t, value.ID, prevCategoryID)
 		prevCategoryID = value.ID
 	}
 }
@@ -233,16 +233,16 @@ func (s *categoryRepositorySuite) TestCategoryRepository_AllCategory_OrderByName
 
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	categories, err := s.repository.AllCategories(ctx, filter)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.categories), len(categories))
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.categories), len(categories))
 	prevCategoryName := "zzzzzzzzzzzzzzzzzzzzz"
 	for _, value := range categories {
-		assert.True(t, containsCategory(t, value, s.categories))
-		assert.LessOrEqual(t, value.Name, prevCategoryName)
+		require.True(t, containsCategory(t, value, s.categories))
+		require.LessOrEqual(t, value.Name, prevCategoryName)
 		prevCategoryName = value.Name
 	}
 }
@@ -260,16 +260,16 @@ func (s *categoryRepositorySuite) TestCategoryRepository_AllCategory_OrderByIDAs
 
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	categories, err := s.repository.AllCategories(ctx, filter)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.categories), len(categories))
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.categories), len(categories))
 	prevCategoryID := 0
 	for _, value := range categories {
-		assert.True(t, containsCategory(t, value, s.categories))
-		assert.GreaterOrEqual(t, value.ID, prevCategoryID)
+		require.True(t, containsCategory(t, value, s.categories))
+		require.GreaterOrEqual(t, value.ID, prevCategoryID)
 		prevCategoryID = value.ID
 	}
 }
@@ -287,16 +287,16 @@ func (s *categoryRepositorySuite) TestCategoryRepository_AllCategory_OrderByName
 
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	categories, err := s.repository.AllCategories(ctx, filter)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.categories), len(categories))
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.categories), len(categories))
 	prevCategoryName := ""
 	for _, value := range categories {
-		assert.True(t, containsCategory(t, value, s.categories))
-		assert.GreaterOrEqual(t, value.Name, prevCategoryName)
+		require.True(t, containsCategory(t, value, s.categories))
+		require.GreaterOrEqual(t, value.Name, prevCategoryName)
 		prevCategoryName = value.Name
 	}
 }
@@ -313,14 +313,14 @@ func (s *categoryRepositorySuite) TestCategoryRepository_AllCategory_Limit() {
 	}
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	categories, err := s.repository.AllCategories(ctx, filter)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, filter.Limit, len(categories))
+	require.NoError(t, tx.Commit())
+	require.Equal(t, filter.Limit, len(categories))
 }
 
 func (s *categoryRepositorySuite) TestCategoryRepository_AllCategory_Offset() {
@@ -336,14 +336,14 @@ func (s *categoryRepositorySuite) TestCategoryRepository_AllCategory_Offset() {
 
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	categories, err := s.repository.AllCategories(ctx, filter)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.categories)-filter.Offset, len(categories))
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.categories)-filter.Offset, len(categories))
 }
 
 func (s *categoryRepositorySuite) TestCategoryRepository_AllCategory_HasEquipment() {
@@ -359,28 +359,28 @@ func (s *categoryRepositorySuite) TestCategoryRepository_AllCategory_HasEquipmen
 
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	categories, err := s.repository.AllCategories(ctx, filter)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, 1, len(categories))
+	require.NoError(t, tx.Commit())
+	require.Equal(t, 1, len(categories))
 }
 
 func (s *categoryRepositorySuite) TestCategoryRepository_CategoryByID() {
 	t := s.T()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	category, err := s.repository.CategoryByID(ctx, s.categories[0].ID)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, s.categories[0].Name, category.Name)
-	assert.Equal(t, s.categories[0].MaxReservationTime, category.MaxReservationTime)
-	assert.Equal(t, s.categories[0].MaxReservationUnits, category.MaxReservationUnits)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, s.categories[0].Name, category.Name)
+	require.Equal(t, s.categories[0].MaxReservationTime, category.MaxReservationTime)
+	require.Equal(t, s.categories[0].MaxReservationUnits, category.MaxReservationUnits)
 }
 
 func (s *categoryRepositorySuite) TestCategoryRepository_DeleteCategoryByID() {
@@ -397,11 +397,11 @@ func (s *categoryRepositorySuite) TestCategoryRepository_DeleteCategoryByID() {
 	}
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	err = s.repository.DeleteCategoryByID(ctx, createdCategory.ID)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
 }
 
 func (s *categoryRepositorySuite) TestCategoryRepository_UpdateCategory() {
@@ -412,14 +412,14 @@ func (s *categoryRepositorySuite) TestCategoryRepository_UpdateCategory() {
 	}
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	category, err := s.repository.UpdateCategory(ctx, s.categories[0].ID, update)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, name, category.Name)
-	assert.Equal(t, s.categories[0].MaxReservationTime, category.MaxReservationTime)
-	assert.Equal(t, s.categories[0].MaxReservationUnits, category.MaxReservationUnits)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, name, category.Name)
+	require.Equal(t, s.categories[0].MaxReservationTime, category.MaxReservationTime)
+	require.Equal(t, s.categories[0].MaxReservationUnits, category.MaxReservationUnits)
 }
 
 func containsCategory(t *testing.T, eq *ent.Category, list []*ent.Category) bool {

--- a/internal/repositories/equipment_status_name_test.go
+++ b/internal/repositories/equipment_status_name_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/middlewares"
 )
@@ -20,18 +20,18 @@ func TestEquipmentStatusNameRepository_Create(t *testing.T) {
 
 	repo := NewEquipmentStatusNameRepository()
 	tx, err := client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	status, err := repo.Create(ctx, statusName)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
 
 	selectedStatus, err := client.EquipmentStatusName.Get(ctx, 1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, status.ID, selectedStatus.ID)
-	assert.Equal(t, status.Name, selectedStatus.Name)
+	require.Equal(t, status.ID, selectedStatus.ID)
+	require.Equal(t, status.Name, selectedStatus.Name)
 }
 
 func TestEquipmentStatusNameRepository_GetAll(t *testing.T) {
@@ -46,15 +46,15 @@ func TestEquipmentStatusNameRepository_GetAll(t *testing.T) {
 
 	repo := NewEquipmentStatusNameRepository()
 	tx, err := client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	statuses, err := repo.GetAll(ctx)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
 
-	assert.Equal(t, 1, statuses[0].ID)
-	assert.Equal(t, statusName, statuses[0].Name)
+	require.Equal(t, 1, statuses[0].ID)
+	require.Equal(t, statusName, statuses[0].Name)
 }
 
 func TestEquipmentStatusNameRepository_Get(t *testing.T) {
@@ -69,15 +69,15 @@ func TestEquipmentStatusNameRepository_Get(t *testing.T) {
 
 	repo := NewEquipmentStatusNameRepository()
 	tx, err := client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	status, err := repo.Get(ctx, 1)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
 
-	assert.Equal(t, 1, status.ID)
-	assert.Equal(t, statusName, status.Name)
+	require.Equal(t, 1, status.ID)
+	require.Equal(t, statusName, status.Name)
 }
 func TestEquipmentStatusNameRepository_GetByName(t *testing.T) {
 	ctx := context.Background()
@@ -91,15 +91,15 @@ func TestEquipmentStatusNameRepository_GetByName(t *testing.T) {
 
 	repo := NewEquipmentStatusNameRepository()
 	tx, err := client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	status, err := repo.GetByName(ctx, statusName)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
 
-	assert.Equal(t, 1, status.ID)
-	assert.Equal(t, statusName, status.Name)
+	require.Equal(t, 1, status.ID)
+	require.Equal(t, statusName, status.Name)
 }
 
 func TestEquipmentStatusNameRepository_Delete(t *testing.T) {
@@ -114,17 +114,17 @@ func TestEquipmentStatusNameRepository_Delete(t *testing.T) {
 
 	repo := NewEquipmentStatusNameRepository()
 	tx, err := client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	status, err := repo.Delete(ctx, 1)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
 
-	assert.Equal(t, 1, status.ID)
-	assert.Equal(t, statusName, status.Name)
+	require.Equal(t, 1, status.ID)
+	require.Equal(t, statusName, status.Name)
 
 	selectedStatus, err := client.EquipmentStatusName.Get(ctx, 1)
-	assert.ErrorContains(t, err, "ent: equipment_status_name not found")
-	assert.Nil(t, selectedStatus)
+	require.ErrorContains(t, err, "ent: equipment_status_name not found")
+	require.Nil(t, selectedStatus)
 }

--- a/internal/repositories/equipment_status_test.go
+++ b/internal/repositories/equipment_status_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/go-openapi/strfmt"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent"
@@ -134,12 +134,12 @@ func (s *equipmentStatusTestSuite) TestEquipmentStatusRepository_Create_OrderNot
 	}
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	eqStatus, err := s.repository.Create(ctx, data)
-	assert.Error(t, err)
-	assert.Nil(t, eqStatus)
-	assert.NoError(t, tx.Rollback())
+	require.Error(t, err)
+	require.Nil(t, eqStatus)
+	require.NoError(t, tx.Rollback())
 }
 
 func (s *equipmentStatusTestSuite) TestEquipmentStatusRepository_Create_StatusNameNotExists() {
@@ -160,12 +160,12 @@ func (s *equipmentStatusTestSuite) TestEquipmentStatusRepository_Create_StatusNa
 	}
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	eqStatus, err := s.repository.Create(ctx, data)
-	assert.Error(t, err)
-	assert.Nil(t, eqStatus)
-	assert.NoError(t, tx.Rollback())
+	require.Error(t, err)
+	require.Nil(t, eqStatus)
+	require.NoError(t, tx.Rollback())
 }
 
 func (s *equipmentStatusTestSuite) TestEquipmentStatusRepository_Create_EquipmentNotExists() {
@@ -186,12 +186,12 @@ func (s *equipmentStatusTestSuite) TestEquipmentStatusRepository_Create_Equipmen
 	}
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	eqStatus, err := s.repository.Create(ctx, data)
-	assert.Error(t, err)
-	assert.Nil(t, eqStatus)
-	assert.NoError(t, tx.Rollback())
+	require.Error(t, err)
+	require.Nil(t, eqStatus)
+	require.NoError(t, tx.Rollback())
 }
 
 func (s *equipmentStatusTestSuite) TestEquipmentStatusRepository_Create_LongerThanMaxReservationTime() {
@@ -212,12 +212,12 @@ func (s *equipmentStatusTestSuite) TestEquipmentStatusRepository_Create_LongerTh
 	}
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	eqStatus, err := s.repository.Create(ctx, data)
-	assert.Error(t, err)
-	assert.Nil(t, eqStatus)
-	assert.NoError(t, tx.Rollback())
+	require.Error(t, err)
+	require.Nil(t, eqStatus)
+	require.NoError(t, tx.Rollback())
 }
 
 func (s *equipmentStatusTestSuite) TestEquipmentStatusRepository_Create_OK() {
@@ -238,19 +238,19 @@ func (s *equipmentStatusTestSuite) TestEquipmentStatusRepository_Create_OK() {
 	}
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	eqStatus, err := s.repository.Create(ctx, data)
-	assert.NoError(t, err)
-	assert.NotNil(t, eqStatus)
-	assert.NoError(t, tx.Rollback())
+	require.NoError(t, err)
+	require.NotNil(t, eqStatus)
+	require.NoError(t, tx.Rollback())
 }
 
 func (s *equipmentStatusTestSuite) TestEquipmentStatusRepository_Update_StatusNameNotExists() {
 	t := s.T()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	eqStatusID := int64(s.eqStatus.ID)
 	statusName := "test status"
@@ -258,9 +258,9 @@ func (s *equipmentStatusTestSuite) TestEquipmentStatusRepository_Update_StatusNa
 		ID:         &eqStatusID,
 		StatusName: &statusName,
 	})
-	assert.Error(t, err)
-	assert.Nil(t, eqStatus)
-	assert.NoError(t, tx.Rollback())
+	require.Error(t, err)
+	require.Nil(t, eqStatus)
+	require.NoError(t, tx.Rollback())
 
 }
 
@@ -268,7 +268,7 @@ func (s *equipmentStatusTestSuite) TestEquipmentStatusRepository_Update_UpdStatu
 	t := s.T()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	eqStatusID := int64(s.eqStatus.ID)
 	statusName := s.statusNameMap[2]
@@ -276,9 +276,9 @@ func (s *equipmentStatusTestSuite) TestEquipmentStatusRepository_Update_UpdStatu
 		ID:         &eqStatusID,
 		StatusName: &statusName,
 	})
-	assert.NoError(t, err)
-	assert.NotNil(t, eqStatus)
-	assert.NoError(t, tx.Rollback())
+	require.NoError(t, err)
+	require.NotNil(t, eqStatus)
+	require.NoError(t, tx.Rollback())
 
 }
 
@@ -286,61 +286,61 @@ func (s *equipmentStatusTestSuite) TestEquipmentStatusRepository_IsAvailableByPe
 	t := s.T()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 
 	start := s.order.RentEnd.AddDate(0, 0, -2)
 	end := start.AddDate(0, 0, 10)
 
 	isAvailable, err := s.repository.HasStatusByPeriod(ctx, domain.EquipmentStatusAvailable, s.equipment.ID, start, end)
-	assert.NoError(t, err)
-	assert.False(t, isAvailable)
-	assert.NoError(t, tx.Rollback())
+	require.NoError(t, err)
+	require.False(t, isAvailable)
+	require.NoError(t, tx.Rollback())
 }
 
 func (s *equipmentStatusTestSuite) TestEquipmentStatusRepository_IsAvailableByPeriod_IntersectsWithAnotherStatusBeginning() {
 	t := s.T()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	start := time.Now()
 	end := s.order.RentStart.AddDate(0, 0, 2)
 
 	isAvailable, err := s.repository.HasStatusByPeriod(ctx, domain.EquipmentStatusAvailable, s.equipment.ID, start, end)
-	assert.NoError(t, err)
-	assert.False(t, isAvailable)
-	assert.NoError(t, tx.Rollback())
+	require.NoError(t, err)
+	require.False(t, isAvailable)
+	require.NoError(t, tx.Rollback())
 }
 
 func (s *equipmentStatusTestSuite) TestEquipmentStatusRepository_IsAvailableByPeriod_IntersectsExistingStatus() {
 	t := s.T()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	start := s.order.RentStart.AddDate(0, 0, -1)
 	end := s.order.RentEnd.AddDate(0, 0, 1)
 
 	isAvailable, err := s.repository.HasStatusByPeriod(ctx, domain.EquipmentStatusAvailable, s.equipment.ID, start, end)
-	assert.NoError(t, err)
-	assert.False(t, isAvailable)
-	assert.NoError(t, tx.Rollback())
+	require.NoError(t, err)
+	require.False(t, isAvailable)
+	require.NoError(t, tx.Rollback())
 }
 
 func (s *equipmentStatusTestSuite) TestEquipmentStatusRepository_IsAvailableByPeriod_OK() {
 	t := s.T()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	start := time.Now()
 	end := start.AddDate(0, 0, 5)
 
 	isAvailable, err := s.repository.HasStatusByPeriod(ctx, domain.EquipmentStatusAvailable, s.equipment.ID, start, end)
-	assert.NoError(t, err)
-	assert.True(t, isAvailable)
-	assert.NoError(t, tx.Rollback())
+	require.NoError(t, err)
+	require.True(t, isAvailable)
+	require.NoError(t, tx.Rollback())
 }
 
 func (s *equipmentStatusTestSuite) TestEquipmentStatusRepository_GetEquipmentsStatusesByOrder_OrderNotExists() {
@@ -348,12 +348,12 @@ func (s *equipmentStatusTestSuite) TestEquipmentStatusRepository_GetEquipmentsSt
 	orderID := s.order.ID + 10
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	eqStatus, err := s.repository.GetEquipmentsStatusesByOrder(ctx, orderID)
-	assert.NoError(t, err)
-	assert.Empty(t, eqStatus)
-	assert.NoError(t, tx.Rollback())
+	require.NoError(t, err)
+	require.Empty(t, eqStatus)
+	require.NoError(t, tx.Rollback())
 }
 
 func (s *equipmentStatusTestSuite) TestEquipmentStatusRepository_GetEquipmentsStatusesByOrder_OK() {
@@ -361,11 +361,11 @@ func (s *equipmentStatusTestSuite) TestEquipmentStatusRepository_GetEquipmentsSt
 	orderID := s.order.ID
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	eqStatus, err := s.repository.GetEquipmentsStatusesByOrder(ctx, orderID)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, eqStatus)
-	assert.Greater(t, len(eqStatus), 0)
-	assert.NoError(t, tx.Rollback())
+	require.NoError(t, err)
+	require.NotEmpty(t, eqStatus)
+	require.Greater(t, len(eqStatus), 0)
+	require.NoError(t, tx.Rollback())
 }

--- a/internal/repositories/equipment_test.go
+++ b/internal/repositories/equipment_test.go
@@ -5,7 +5,6 @@ import (
 	"math"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -157,12 +156,12 @@ func (s *EquipmentSuite) TestEquipmentRepository_AllEquipmentsEmptyOrderBy() {
 	orderColumn := equipment.FieldID
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	equipments, err := s.repository.AllEquipments(ctx, limit, offset, orderBy, orderColumn)
-	assert.Error(t, err)
-	assert.NoError(t, tx.Rollback())
-	assert.Nil(t, equipments)
+	require.Error(t, err)
+	require.NoError(t, tx.Rollback())
+	require.Nil(t, equipments)
 }
 
 func (s *EquipmentSuite) TestEquipmentRepository_AllEquipmentsWrongOrderColumn() {
@@ -173,13 +172,13 @@ func (s *EquipmentSuite) TestEquipmentRepository_AllEquipmentsWrongOrderColumn()
 	orderColumn := ""
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	equipments, err := s.repository.EquipmentsByFilter(ctx, models.EquipmentFilter{},
 		limit, offset, orderBy, orderColumn)
-	assert.Error(t, err)
-	assert.NoError(t, tx.Rollback())
-	assert.Nil(t, equipments)
+	require.Error(t, err)
+	require.NoError(t, tx.Rollback())
+	require.Nil(t, equipments)
 }
 
 func (s *EquipmentSuite) TestEquipmentRepository_AllEquipmentsOrderColumnNotExists() {
@@ -190,12 +189,12 @@ func (s *EquipmentSuite) TestEquipmentRepository_AllEquipmentsOrderColumnNotExis
 	orderColumn := "price"
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	equipments, err := s.repository.AllEquipments(ctx, limit, offset, orderBy, orderColumn)
-	assert.Error(t, err)
-	assert.NoError(t, tx.Rollback())
-	assert.Nil(t, equipments)
+	require.Error(t, err)
+	require.NoError(t, tx.Rollback())
+	require.Nil(t, equipments)
 }
 
 func (s *EquipmentSuite) TestEquipmentRepository_AllEquipmentsOrderByIDDesc() {
@@ -206,18 +205,18 @@ func (s *EquipmentSuite) TestEquipmentRepository_AllEquipmentsOrderByIDDesc() {
 	orderColumn := equipment.FieldID
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	equipments, err := s.repository.AllEquipments(ctx, limit, offset, orderBy, orderColumn)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.equipments), len(equipments))
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.equipments), len(equipments))
 	prevEquipmentID := math.MaxInt
 	for _, value := range equipments {
-		assert.True(t, mapContainsEquipment(value, s.equipments))
-		assert.Less(t, value.ID, prevEquipmentID)
+		require.True(t, mapContainsEquipment(value, s.equipments))
+		require.Less(t, value.ID, prevEquipmentID)
 		prevEquipmentID = value.ID
 	}
 }
@@ -230,18 +229,18 @@ func (s *EquipmentSuite) TestEquipmentRepository_AllEquipmentsOrderByNameDesc() 
 	orderColumn := equipment.FieldName
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	equipments, err := s.repository.AllEquipments(ctx, limit, offset, orderBy, orderColumn)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.equipments), len(equipments))
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.equipments), len(equipments))
 	prevEquipmentName := "zzzzzzzzzzzzzzzzzzzzzzzzzzz"
 	for _, value := range equipments {
-		assert.True(t, mapContainsEquipment(value, s.equipments))
-		assert.Less(t, value.Name, prevEquipmentName)
+		require.True(t, mapContainsEquipment(value, s.equipments))
+		require.Less(t, value.Name, prevEquipmentName)
 		prevEquipmentName = value.Name
 	}
 }
@@ -254,18 +253,18 @@ func (s *EquipmentSuite) TestEquipmentRepository_AllEquipmentsOrderByTitleDesc()
 	orderColumn := equipment.FieldTitle
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	equipments, err := s.repository.AllEquipments(ctx, limit, offset, orderBy, orderColumn)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.equipments), len(equipments))
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.equipments), len(equipments))
 	prevEquipmentTitle := "zzzzzzzzzzzzzzzzzzzzzzzzzzz"
 	for _, value := range equipments {
-		assert.True(t, mapContainsEquipment(value, s.equipments))
-		assert.Less(t, value.Title, prevEquipmentTitle)
+		require.True(t, mapContainsEquipment(value, s.equipments))
+		require.Less(t, value.Title, prevEquipmentTitle)
 		prevEquipmentTitle = value.Title
 	}
 }
@@ -278,18 +277,18 @@ func (s *EquipmentSuite) TestEquipmentRepository_AllEquipmentsOrderByIDAsc() {
 	orderColumn := equipment.FieldID
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	equipments, err := s.repository.AllEquipments(ctx, limit, offset, orderBy, orderColumn)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.equipments), len(equipments))
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.equipments), len(equipments))
 	prevEquipmentID := 0
 	for _, value := range equipments {
-		assert.True(t, mapContainsEquipment(value, s.equipments))
-		assert.Greater(t, value.ID, prevEquipmentID)
+		require.True(t, mapContainsEquipment(value, s.equipments))
+		require.Greater(t, value.ID, prevEquipmentID)
 		prevEquipmentID = value.ID
 	}
 }
@@ -302,18 +301,18 @@ func (s *EquipmentSuite) TestEquipmentRepository_AllEquipmentsOrderByNameAsc() {
 	orderColumn := equipment.FieldName
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	equipments, err := s.repository.AllEquipments(ctx, limit, offset, orderBy, orderColumn)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.equipments), len(equipments))
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.equipments), len(equipments))
 	prevEquipmentName := ""
 	for _, value := range equipments {
-		assert.True(t, mapContainsEquipment(value, s.equipments))
-		assert.Greater(t, value.Name, prevEquipmentName)
+		require.True(t, mapContainsEquipment(value, s.equipments))
+		require.Greater(t, value.Name, prevEquipmentName)
 		prevEquipmentName = value.Name
 	}
 }
@@ -326,18 +325,18 @@ func (s *EquipmentSuite) TestEquipmentRepository_AllEquipmentsOrderByTitleAsc() 
 	orderColumn := equipment.FieldTitle
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	equipments, err := s.repository.AllEquipments(ctx, limit, offset, orderBy, orderColumn)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.equipments), len(equipments))
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.equipments), len(equipments))
 	prevEquipmentTitle := ""
 	for _, value := range equipments {
-		assert.True(t, mapContainsEquipment(value, s.equipments))
-		assert.Greater(t, value.Title, prevEquipmentTitle)
+		require.True(t, mapContainsEquipment(value, s.equipments))
+		require.Greater(t, value.Title, prevEquipmentTitle)
 		prevEquipmentTitle = value.Title
 	}
 }
@@ -350,17 +349,17 @@ func (s *EquipmentSuite) TestEquipmentRepository_AllEquipmentsLimit() {
 	orderColumn := equipment.FieldTitle
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	equipments, err := s.repository.AllEquipments(ctx, limit, offset, orderBy, orderColumn)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, 3, len(equipments))
+	require.NoError(t, tx.Commit())
+	require.Equal(t, 3, len(equipments))
 	for i, value := range equipments {
-		assert.True(t, mapContainsEquipment(value, s.equipments))
-		assert.Equal(t, s.equipments[i+1].Name, value.Name)
+		require.True(t, mapContainsEquipment(value, s.equipments))
+		require.Equal(t, s.equipments[i+1].Name, value.Name)
 	}
 }
 
@@ -372,17 +371,17 @@ func (s *EquipmentSuite) TestEquipmentRepository_AllEquipmentsOffset() {
 	orderColumn := equipment.FieldTitle
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	equipments, err := s.repository.AllEquipments(ctx, limit, offset, orderBy, orderColumn)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, 2, len(equipments))
+	require.NoError(t, tx.Commit())
+	require.Equal(t, 2, len(equipments))
 	for i, value := range equipments {
-		assert.True(t, mapContainsEquipment(value, s.equipments))
-		assert.Equal(t, s.equipments[i+1+offset].Name, value.Name)
+		require.True(t, mapContainsEquipment(value, s.equipments))
+		require.Equal(t, s.equipments[i+1+offset].Name, value.Name)
 	}
 }
 
@@ -390,14 +389,14 @@ func (s *EquipmentSuite) TestEquipmentRepository_AllEquipmentsTotal() {
 	t := s.T()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	totalEquipment, err := s.repository.AllEquipmentsTotal(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.equipments), totalEquipment)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.equipments), totalEquipment)
 }
 
 func (s *EquipmentSuite) TestEquipmentRepository_FindEquipmentsOrderByTitleDesc() {
@@ -409,19 +408,19 @@ func (s *EquipmentSuite) TestEquipmentRepository_FindEquipmentsOrderByTitleDesc(
 	filter := models.EquipmentFilter{NameSubstring: "test"}
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	equipments, err := s.repository.EquipmentsByFilter(ctx, filter, limit, offset, orderBy, orderColumn)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, 3, len(equipments))
+	require.NoError(t, tx.Commit())
+	require.Equal(t, 3, len(equipments))
 	prevEquipmentTitle := "zzzzzzzzzzzzzzzzzzzzzz"
 	for _, value := range equipments {
-		assert.True(t, mapContainsEquipment(value, s.equipments))
-		assert.Contains(t, value.Name, filter.NameSubstring)
-		assert.Less(t, value.Title, prevEquipmentTitle)
+		require.True(t, mapContainsEquipment(value, s.equipments))
+		require.Contains(t, value.Name, filter.NameSubstring)
+		require.Less(t, value.Title, prevEquipmentTitle)
 		prevEquipmentTitle = value.Title
 	}
 }
@@ -450,17 +449,17 @@ func (s *EquipmentSuite) TestEquipmentRepository_FindEquipmentsOrderByTitleDesc(
 //	equipments, err := s.repository.EquipmentsByFilter(ctx, filter, limit, offset, orderBy, orderColumn)
 //	require.NoError(t, err)
 //	require.NoError(t, tx.Commit())
-//	assert.Equal(t, 1, len(equipments))
+//	require.Equal(t, 1, len(equipments))
 //
 //	for _, value := range equipments {
-//		assert.True(t, strings.EqualFold(value.Name, filter.Name))
-//		assert.True(t, strings.EqualFold(value.Title, filter.Title))
-//		assert.True(t, strings.EqualFold(value.Description, filter.Description))
-//		assert.True(t, strings.EqualFold(value.TermsOfUse, filter.TermsOfUse))
-//		assert.True(t, strings.EqualFold(value.TechIssue, filter.TechnicalIssues))
-//		assert.True(t, strings.EqualFold(value.Supplier, filter.Supplier))
-//		assert.True(t, strings.EqualFold(value.ReceiptDate, filter.ReceiptDate))
-//		assert.True(t, strings.EqualFold(value.Condition, filter.Condition))
+//		require.True(t, strings.EqualFold(value.Name, filter.Name))
+//		require.True(t, strings.EqualFold(value.Title, filter.Title))
+//		require.True(t, strings.EqualFold(value.Description, filter.Description))
+//		require.True(t, strings.EqualFold(value.TermsOfUse, filter.TermsOfUse))
+//		require.True(t, strings.EqualFold(value.TechIssue, filter.TechnicalIssues))
+//		require.True(t, strings.EqualFold(value.Supplier, filter.Supplier))
+//		require.True(t, strings.EqualFold(value.ReceiptDate, filter.ReceiptDate))
+//		require.True(t, strings.EqualFold(value.Condition, filter.Condition))
 //	}
 //}
 
@@ -473,19 +472,19 @@ func (s *EquipmentSuite) TestEquipmentRepository_FindEquipmentsLimit() {
 	filter := models.EquipmentFilter{NameSubstring: "test"}
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	equipments, err := s.repository.EquipmentsByFilter(ctx, filter, limit, offset, orderBy, orderColumn)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, 2, len(equipments))
+	require.NoError(t, tx.Commit())
+	require.Equal(t, 2, len(equipments))
 	prevEquipmentTitle := ""
 	for _, value := range equipments {
-		assert.True(t, mapContainsEquipment(value, s.equipments))
-		assert.Contains(t, value.Name, filter.NameSubstring)
-		assert.Greater(t, value.Title, prevEquipmentTitle)
+		require.True(t, mapContainsEquipment(value, s.equipments))
+		require.Contains(t, value.Name, filter.NameSubstring)
+		require.Greater(t, value.Title, prevEquipmentTitle)
 		prevEquipmentTitle = value.Title
 	}
 }
@@ -500,17 +499,17 @@ func (s *EquipmentSuite) TestEquipmentRepository_FindEquipmentsOffset() {
 	filter := models.EquipmentFilter{NameSubstring: "tEsT"}
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	equipments, err := s.repository.EquipmentsByFilter(ctx, filter, limit, offset, orderBy, orderColumn)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, 1, len(equipments))
+	require.NoError(t, tx.Commit())
+	require.Equal(t, 1, len(equipments))
 	for _, value := range equipments {
-		assert.True(t, mapContainsEquipment(value, s.equipments))
-		assert.Contains(t, value.Name, name)
+		require.True(t, mapContainsEquipment(value, s.equipments))
+		require.Contains(t, value.Name, name)
 	}
 }
 
@@ -519,14 +518,14 @@ func (s *EquipmentSuite) TestEquipmentRepository_FindEquipmentsTotal() {
 	filter := models.EquipmentFilter{NameSubstring: "test"}
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	totalEquipment, err := s.repository.EquipmentsByFilterTotal(ctx, filter)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, 3, totalEquipment)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, 3, totalEquipment)
 }
 
 func mapContainsEquipment(eq *ent.Equipment, m map[int]*ent.Equipment) bool {

--- a/internal/repositories/order_filter_test.go
+++ b/internal/repositories/order_filter_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent"
@@ -140,21 +140,21 @@ func (s *orderFilterTestSuite) TestOrderRepositoryWithFilter_OrdersByStatusTotal
 	status := s.statusesNames[0].Status
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	totalOrders, err := s.repository.OrdersByStatusTotal(ctx, status)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, 2, totalOrders)
+	require.Equal(t, 2, totalOrders)
 
 	status = s.statusesNames[1].Status
 	totalOrders, err = s.repository.OrdersByStatusTotal(ctx, status)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, 3, totalOrders)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, 3, totalOrders)
 }
 
 func (s *orderFilterTestSuite) TestOrderRepositoryWithFilter_OrdersByStatus_EmptyOrderBy() {
@@ -167,12 +167,12 @@ func (s *orderFilterTestSuite) TestOrderRepositoryWithFilter_OrdersByStatus_Empt
 	status := s.statusesNames[0].Status
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	orders, err := s.repository.OrdersByStatus(ctx, status, limit, offset, orderBy, orderColumn)
-	assert.Error(t, err)
-	assert.NoError(t, tx.Rollback())
-	assert.Nil(t, orders)
+	require.Error(t, err)
+	require.NoError(t, tx.Rollback())
+	require.Nil(t, orders)
 }
 
 func (s *orderFilterTestSuite) TestOrderRepositoryWithFilter_OrdersByStatus_WrongOrderColumn() {
@@ -185,12 +185,12 @@ func (s *orderFilterTestSuite) TestOrderRepositoryWithFilter_OrdersByStatus_Wron
 	status := s.statusesNames[0].Status
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	orders, err := s.repository.OrdersByStatus(ctx, status, limit, offset, orderBy, orderColumn)
-	assert.Error(t, err)
-	assert.NoError(t, tx.Rollback())
-	assert.Nil(t, orders)
+	require.Error(t, err)
+	require.NoError(t, tx.Rollback())
+	require.Nil(t, orders)
 }
 
 func (s *orderFilterTestSuite) TestOrderRepositoryWithFilter_OrdersByStatus_OrderByIDDesc() {
@@ -203,16 +203,16 @@ func (s *orderFilterTestSuite) TestOrderRepositoryWithFilter_OrdersByStatus_Orde
 	status := s.statusesNames[1].Status
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	orders, err := s.repository.OrdersByStatus(ctx, status, limit, offset, orderBy, orderColumn)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, 3, len(orders))
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, 3, len(orders))
 	prevOrderID := math.MaxInt
 	for _, o := range orders {
-		assert.True(t, containsOrder(t, o, s.orders))
-		assert.GreaterOrEqual(t, prevOrderID, o.ID)
+		require.True(t, containsOrder(t, o, s.orders))
+		require.GreaterOrEqual(t, prevOrderID, o.ID)
 		prevOrderID = o.ID
 	}
 }
@@ -227,16 +227,16 @@ func (s *orderFilterTestSuite) TestOrderRepositoryWithFilter_OrdersByStatus_Orde
 	status := s.statusesNames[1].Status
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	orders, err := s.repository.OrdersByStatus(ctx, status, limit, offset, orderBy, orderColumn)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, 3, len(orders))
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, 3, len(orders))
 	prevOrderCreatedAt := time.Unix(1<<63-62135596801, 999999999)
 	for _, o := range orders {
-		assert.True(t, containsOrder(t, o, s.orders))
-		assert.True(t, prevOrderCreatedAt.After(o.CreatedAt) || prevOrderCreatedAt.Equal(o.CreatedAt))
+		require.True(t, containsOrder(t, o, s.orders))
+		require.True(t, prevOrderCreatedAt.After(o.CreatedAt) || prevOrderCreatedAt.Equal(o.CreatedAt))
 		prevOrderCreatedAt = o.CreatedAt
 	}
 }
@@ -251,16 +251,16 @@ func (s *orderFilterTestSuite) TestOrderRepositoryWithFilter_OrdersByStatus_Orde
 	status := s.statusesNames[1].Status
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	orders, err := s.repository.OrdersByStatus(ctx, status, limit, offset, orderBy, orderColumn)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, 3, len(orders))
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, 3, len(orders))
 	prevOrderID := 0
 	for _, o := range orders {
-		assert.True(t, containsOrder(t, o, s.orders))
-		assert.LessOrEqual(t, prevOrderID, o.ID)
+		require.True(t, containsOrder(t, o, s.orders))
+		require.LessOrEqual(t, prevOrderID, o.ID)
 		prevOrderID = o.ID
 	}
 }
@@ -275,16 +275,16 @@ func (s *orderFilterTestSuite) TestOrderRepositoryWithFilter_OrdersByStatus_Orde
 	status := s.statusesNames[1].Status
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	orders, err := s.repository.OrdersByStatus(ctx, status, limit, offset, orderBy, orderColumn)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, 3, len(orders))
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, 3, len(orders))
 	prevOrderCreatedAt := time.Unix(0, 0)
 	for _, o := range orders {
-		assert.True(t, containsOrder(t, o, s.orders))
-		assert.True(t, prevOrderCreatedAt.Before(o.CreatedAt) || prevOrderCreatedAt.Equal(o.CreatedAt))
+		require.True(t, containsOrder(t, o, s.orders))
+		require.True(t, prevOrderCreatedAt.Before(o.CreatedAt) || prevOrderCreatedAt.Equal(o.CreatedAt))
 		prevOrderCreatedAt = o.CreatedAt
 	}
 }
@@ -299,13 +299,13 @@ func (s *orderFilterTestSuite) TestOrderRepositoryWithFilter_OrdersByStatus_Limi
 	status := s.statusesNames[1].Status
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	orders, err := s.repository.OrdersByStatus(ctx, status, limit, offset, orderBy, orderColumn)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.GreaterOrEqual(t, limit, len(orders))
-	assert.Greater(t, len(s.orders), len(orders))
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.GreaterOrEqual(t, limit, len(orders))
+	require.Greater(t, len(s.orders), len(orders))
 }
 
 func (s *orderFilterTestSuite) TestOrderRepositoryWithFilter_OrdersByStatus_Offset() {
@@ -318,13 +318,13 @@ func (s *orderFilterTestSuite) TestOrderRepositoryWithFilter_OrdersByStatus_Offs
 	status := s.statusesNames[1].Status
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	orders, err := s.repository.OrdersByStatus(ctx, status, limit, offset, orderBy, orderColumn)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.GreaterOrEqual(t, len(s.orders)-offset, len(orders))
-	assert.Greater(t, len(s.orders), len(orders))
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.GreaterOrEqual(t, len(s.orders)-offset, len(orders))
+	require.Greater(t, len(s.orders), len(orders))
 }
 
 func (s *orderFilterTestSuite) TestOrderRepositoryWithFilter_OrdersByPeriodAndStatusTotal() {
@@ -335,13 +335,13 @@ func (s *orderFilterTestSuite) TestOrderRepositoryWithFilter_OrdersByPeriodAndSt
 	to := time.Now().Add(3 * time.Hour)
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	totalOrders, err := s.repository.OrdersByPeriodAndStatusTotal(ctx, from, to, status)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, 1, totalOrders)
+	require.Equal(t, 1, totalOrders)
 
 	status = s.statusesNames[1].Status
 	from = time.Now().Add(-6 * time.Hour)
@@ -350,8 +350,8 @@ func (s *orderFilterTestSuite) TestOrderRepositoryWithFilter_OrdersByPeriodAndSt
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, 3, totalOrders)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, 3, totalOrders)
 }
 
 func (s *orderFilterTestSuite) TestOrderRepositoryWithFilter_OrdersByPeriodAndStatus_EmptyOrderBy() {
@@ -366,12 +366,12 @@ func (s *orderFilterTestSuite) TestOrderRepositoryWithFilter_OrdersByPeriodAndSt
 	to := time.Now().Add(3 * time.Hour)
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	orders, err := s.repository.OrdersByPeriodAndStatus(ctx, from, to, status, limit, offset, orderBy, orderColumn)
-	assert.Error(t, err)
-	assert.NoError(t, tx.Rollback())
-	assert.Nil(t, orders)
+	require.Error(t, err)
+	require.NoError(t, tx.Rollback())
+	require.Nil(t, orders)
 }
 
 func (s *orderFilterTestSuite) TestOrderRepositoryWithFilter_OrdersByPeriodAndStatus_WrongOrderColumn() {
@@ -386,12 +386,12 @@ func (s *orderFilterTestSuite) TestOrderRepositoryWithFilter_OrdersByPeriodAndSt
 	to := time.Now().Add(3 * time.Hour)
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	orders, err := s.repository.OrdersByPeriodAndStatus(ctx, from, to, status, limit, offset, orderBy, orderColumn)
-	assert.Error(t, err)
-	assert.NoError(t, tx.Rollback())
-	assert.Nil(t, orders)
+	require.Error(t, err)
+	require.NoError(t, tx.Rollback())
+	require.Nil(t, orders)
 }
 
 func (s *orderFilterTestSuite) TestOrderRepositoryWithFilter_OrdersByPeriodAndStatus_OrderByIDDesc() {
@@ -406,16 +406,16 @@ func (s *orderFilterTestSuite) TestOrderRepositoryWithFilter_OrdersByPeriodAndSt
 	to := time.Now().Add(3 * time.Hour)
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	orders, err := s.repository.OrdersByPeriodAndStatus(ctx, from, to, status, limit, offset, orderBy, orderColumn)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, 2, len(orders))
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, 2, len(orders))
 	prevOrderID := math.MaxInt
 	for _, o := range orders {
-		assert.True(t, containsOrder(t, o, s.orders))
-		assert.GreaterOrEqual(t, prevOrderID, o.ID)
+		require.True(t, containsOrder(t, o, s.orders))
+		require.GreaterOrEqual(t, prevOrderID, o.ID)
 		prevOrderID = o.ID
 	}
 }
@@ -432,16 +432,16 @@ func (s *orderFilterTestSuite) TestOrderRepositoryWithFilter_OrdersByPeriodAndSt
 	to := time.Now().Add(3 * time.Hour)
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	orders, err := s.repository.OrdersByPeriodAndStatus(ctx, from, to, status, limit, offset, orderBy, orderColumn)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, 2, len(orders))
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, 2, len(orders))
 	prevOrderCreatedAt := time.Unix(1<<63-62135596801, 999999999)
 	for _, o := range orders {
-		assert.True(t, containsOrder(t, o, s.orders))
-		assert.True(t, prevOrderCreatedAt.After(o.CreatedAt) || prevOrderCreatedAt.Equal(o.CreatedAt))
+		require.True(t, containsOrder(t, o, s.orders))
+		require.True(t, prevOrderCreatedAt.After(o.CreatedAt) || prevOrderCreatedAt.Equal(o.CreatedAt))
 		prevOrderCreatedAt = o.CreatedAt
 	}
 }
@@ -458,16 +458,16 @@ func (s *orderFilterTestSuite) TestOrderRepositoryWithFilter_OrdersByPeriodAndSt
 	to := time.Now().Add(3 * time.Hour)
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	orders, err := s.repository.OrdersByPeriodAndStatus(ctx, from, to, status, limit, offset, orderBy, orderColumn)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, 2, len(orders))
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, 2, len(orders))
 	prevOrderID := 0
 	for _, o := range orders {
-		assert.True(t, containsOrder(t, o, s.orders))
-		assert.LessOrEqual(t, prevOrderID, o.ID)
+		require.True(t, containsOrder(t, o, s.orders))
+		require.LessOrEqual(t, prevOrderID, o.ID)
 		prevOrderID = o.ID
 	}
 }
@@ -484,16 +484,16 @@ func (s *orderFilterTestSuite) TestOrderRepositoryWithFilter_OrdersByPeriodAndSt
 	to := time.Now().Add(3 * time.Hour)
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	orders, err := s.repository.OrdersByPeriodAndStatus(ctx, from, to, status, limit, offset, orderBy, orderColumn)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, 2, len(orders))
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, 2, len(orders))
 	prevOrderCreatedAt := time.Unix(0, 0)
 	for _, o := range orders {
-		assert.True(t, containsOrder(t, o, s.orders))
-		assert.True(t, prevOrderCreatedAt.Before(o.CreatedAt) || prevOrderCreatedAt.Equal(o.CreatedAt))
+		require.True(t, containsOrder(t, o, s.orders))
+		require.True(t, prevOrderCreatedAt.Before(o.CreatedAt) || prevOrderCreatedAt.Equal(o.CreatedAt))
 		prevOrderCreatedAt = o.CreatedAt
 	}
 }
@@ -510,13 +510,13 @@ func (s *orderFilterTestSuite) TestOrderRepositoryWithFilter_OrdersByPeriodAndSt
 	to := time.Now().Add(3 * time.Hour)
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	orders, err := s.repository.OrdersByPeriodAndStatus(ctx, from, to, status, limit, offset, orderBy, orderColumn)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, limit, len(orders))
-	assert.Greater(t, len(s.orders), len(orders))
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, limit, len(orders))
+	require.Greater(t, len(s.orders), len(orders))
 }
 
 func (s *orderFilterTestSuite) TestOrderRepositoryWithFilter_OrdersByPeriodAndStatus_Offset() {
@@ -531,11 +531,11 @@ func (s *orderFilterTestSuite) TestOrderRepositoryWithFilter_OrdersByPeriodAndSt
 	to := time.Now().Add(3 * time.Hour)
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	orders, err := s.repository.OrdersByPeriodAndStatus(ctx, from, to, status, limit, offset, orderBy, orderColumn)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.GreaterOrEqual(t, len(s.orders)-offset, len(orders))
-	assert.Greater(t, len(s.orders), len(orders))
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.GreaterOrEqual(t, len(s.orders)-offset, len(orders))
+	require.Greater(t, len(s.orders), len(orders))
 }

--- a/internal/repositories/order_status_name_test.go
+++ b/internal/repositories/order_status_name_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent/enttest"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/middlewares"
@@ -23,13 +23,13 @@ func TestOrderStatusNameRepository_ListOfStatuses(t *testing.T) {
 
 	repo := NewOrderStatusNameRepository()
 	tx, err := client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	statuses, err := repo.ListOfOrderStatusNames(ctx)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, 1, statuses[0].ID)
-	assert.Equal(t, statusName, statuses[0].Status)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, 1, statuses[0].ID)
+	require.Equal(t, statusName, statuses[0].Status)
 	_, err = client.OrderStatusName.Delete().Exec(ctx)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/repositories/order_status_test.go
+++ b/internal/repositories/order_status_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/go-openapi/strfmt"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent"
@@ -106,11 +106,11 @@ func (s *orderStatusTestSuite) TestOrderStatusRepository_UpdateStatus_OrderNotEx
 	}
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	err = s.repository.UpdateStatus(ctx, userID, data)
-	assert.Error(t, err)
-	assert.NoError(t, tx.Rollback())
+	require.Error(t, err)
+	require.NoError(t, tx.Rollback())
 }
 
 func (s *orderStatusTestSuite) TestOrderStatusRepository_UpdateStatus_StatusNameNotExists() {
@@ -128,11 +128,11 @@ func (s *orderStatusTestSuite) TestOrderStatusRepository_UpdateStatus_StatusName
 	}
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	err = s.repository.UpdateStatus(ctx, userID, data)
-	assert.Error(t, err)
-	assert.NoError(t, tx.Rollback())
+	require.Error(t, err)
+	require.NoError(t, tx.Rollback())
 }
 
 func (s *orderStatusTestSuite) TestOrderStatusRepository_UpdateStatus_UserNotExists() {
@@ -153,11 +153,11 @@ func (s *orderStatusTestSuite) TestOrderStatusRepository_UpdateStatus_UserNotExi
 	}
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	err = s.repository.UpdateStatus(ctx, userID, data)
-	assert.Error(t, err)
-	assert.NoError(t, tx.Rollback())
+	require.Error(t, err)
+	require.NoError(t, tx.Rollback())
 }
 
 func (s *orderStatusTestSuite) TestOrderStatusRepository_UpdateStatus_OK() {
@@ -178,11 +178,11 @@ func (s *orderStatusTestSuite) TestOrderStatusRepository_UpdateStatus_OK() {
 	}
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	err = s.repository.UpdateStatus(ctx, userID, data)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
 	_, err = s.client.OrderStatus.Delete().Exec(s.ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -194,12 +194,12 @@ func (s *orderStatusTestSuite) TestOrderStatusRepository_StatusHistory_Empty() {
 	orderID := s.order.ID
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	statuses, err := s.repository.StatusHistory(ctx, orderID)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Empty(t, statuses)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Empty(t, statuses)
 }
 
 func (s *orderStatusTestSuite) TestOrderStatusRepository_StatusHistory() {
@@ -215,15 +215,15 @@ func (s *orderStatusTestSuite) TestOrderStatusRepository_StatusHistory() {
 
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	statuses, err := s.repository.StatusHistory(ctx, orderID)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, 1, len(statuses))
-	assert.Equal(t, orderStatus.ID, statuses[0].ID)
-	assert.Equal(t, orderStatus.Comment, statuses[0].Comment)
-	assert.Equal(t, orderStatus.CurrentDate, statuses[0].CurrentDate)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, 1, len(statuses))
+	require.Equal(t, orderStatus.ID, statuses[0].ID)
+	require.Equal(t, orderStatus.Comment, statuses[0].Comment)
+	require.Equal(t, orderStatus.CurrentDate, statuses[0].CurrentDate)
 	_, err = s.client.OrderStatus.Delete().Exec(s.ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -242,14 +242,14 @@ func (s *orderStatusTestSuite) TestOrderStatusRepository_GetOrderCurrentStatus()
 
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	status, err := s.repository.GetOrderCurrentStatus(ctx, orderID)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, orderStatus.ID, status.ID)
-	assert.Equal(t, orderStatus.Comment, status.Comment)
-	assert.Equal(t, orderStatus.CurrentDate, status.CurrentDate)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, orderStatus.ID, status.ID)
+	require.Equal(t, orderStatus.Comment, status.Comment)
+	require.Equal(t, orderStatus.CurrentDate, status.CurrentDate)
 	_, err = s.client.OrderStatus.Delete().Exec(s.ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -268,15 +268,15 @@ func (s *orderStatusTestSuite) TestOrderStatusRepository_GetUserStatusHistory() 
 
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	statuses, err := s.repository.GetUserStatusHistory(ctx, userID)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, 1, len(statuses))
-	assert.Equal(t, orderStatus.ID, statuses[0].ID)
-	assert.Equal(t, orderStatus.Comment, statuses[0].Comment)
-	assert.Equal(t, orderStatus.CurrentDate, statuses[0].CurrentDate)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, 1, len(statuses))
+	require.Equal(t, orderStatus.ID, statuses[0].ID)
+	require.Equal(t, orderStatus.Comment, statuses[0].Comment)
+	require.Equal(t, orderStatus.CurrentDate, statuses[0].CurrentDate)
 	_, err = s.client.OrderStatus.Delete().Exec(s.ctx)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/repositories/order_test.go
+++ b/internal/repositories/order_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/go-openapi/strfmt"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent"
@@ -175,7 +175,7 @@ func (s *OrderSuite) TestOrderRepository_Create_EmptyEquipments() {
 	t := s.T()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 
 	description := "test"
@@ -187,15 +187,15 @@ func (s *OrderSuite) TestOrderRepository_Create_EmptyEquipments() {
 		RentStart:   &startDate,
 	}
 	createdOrder, err := s.orderRepository.Create(ctx, data, s.user.ID, []int{})
-	assert.Error(t, err)
-	assert.Nil(t, createdOrder)
+	require.Error(t, err)
+	require.Nil(t, createdOrder)
 }
 
 func (s *OrderSuite) TestOrderRepository_Create_OK() {
 	t := s.T()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 
 	description := "test"
@@ -210,17 +210,17 @@ func (s *OrderSuite) TestOrderRepository_Create_OK() {
 		RentStart:   &startDate,
 	}
 	createdOrder, err := s.orderRepository.Create(ctx, data, s.user.ID, []int{s.equipments[0].ID})
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.NotEmpty(t, createdOrder)
-	assert.Equal(t, description, createdOrder.Description)
-	assert.NotEmpty(t, createdOrder.Edges.Equipments)
-	assert.Equal(t, int(equipmentID), createdOrder.Edges.Equipments[0].ID)
-	assert.NotEmpty(t, createdOrder.Edges.Users)
-	assert.Equal(t, s.user.ID, createdOrder.Edges.Users.ID)
-	assert.NotEmpty(t, createdOrder.Edges.OrderStatus)
-	assert.Equal(t, domain.OrderStatusInReview, createdOrder.Edges.OrderStatus[0].Edges.OrderStatusName.Status)
-	assert.Equal(t, true, createdOrder.IsFirst)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.NotEmpty(t, createdOrder)
+	require.Equal(t, description, createdOrder.Description)
+	require.NotEmpty(t, createdOrder.Edges.Equipments)
+	require.Equal(t, int(equipmentID), createdOrder.Edges.Equipments[0].ID)
+	require.NotEmpty(t, createdOrder.Edges.Users)
+	require.Equal(t, s.user.ID, createdOrder.Edges.Users.ID)
+	require.NotEmpty(t, createdOrder.Edges.OrderStatus)
+	require.Equal(t, domain.OrderStatusInReview, createdOrder.Edges.OrderStatus[0].Edges.OrderStatusName.Status)
+	require.Equal(t, true, createdOrder.IsFirst)
 }
 
 // isFirst field should be false, if one of orders has approved status
@@ -228,7 +228,7 @@ func (s *OrderSuite) TestOrderRepository_Create_isFirstCreatedOrderIsFalseIfOneO
 	t := s.T()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 
 	description := "test"
@@ -245,7 +245,7 @@ func (s *OrderSuite) TestOrderRepository_Create_isFirstCreatedOrderIsFalseIfOneO
 	err = s.client.OrderStatusName.Create().
 		SetStatus(domain.OrderStatusApproved).
 		Exec(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	orderId := int64(s.orders[0].ID)
 	testComment := "testComment"
 	model := models.NewOrderStatus{
@@ -255,22 +255,22 @@ func (s *OrderSuite) TestOrderRepository_Create_isFirstCreatedOrderIsFalseIfOneO
 		Comment:   &testComment,
 	}
 	err = s.orderStatusRepository.UpdateStatus(ctx, s.user.ID, model)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	createdOrder, err := s.orderRepository.Create(ctx, data, s.user.ID, []int{s.equipments[0].ID})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.NotEmpty(t, createdOrder)
-	assert.Equal(t, description, createdOrder.Description)
-	assert.NotEmpty(t, createdOrder.Edges.Equipments)
-	assert.Equal(t, int(equipmentID), createdOrder.Edges.Equipments[0].ID)
-	assert.NotEmpty(t, createdOrder.Edges.Users)
-	assert.Equal(t, s.user.ID, createdOrder.Edges.Users.ID)
-	assert.NotEmpty(t, createdOrder.Edges.OrderStatus)
-	assert.Equal(t, domain.OrderStatusInReview, createdOrder.Edges.OrderStatus[0].Edges.OrderStatusName.Status)
-	assert.Equal(t, false, createdOrder.IsFirst)
+	require.NotEmpty(t, createdOrder)
+	require.Equal(t, description, createdOrder.Description)
+	require.NotEmpty(t, createdOrder.Edges.Equipments)
+	require.Equal(t, int(equipmentID), createdOrder.Edges.Equipments[0].ID)
+	require.NotEmpty(t, createdOrder.Edges.Users)
+	require.Equal(t, s.user.ID, createdOrder.Edges.Users.ID)
+	require.NotEmpty(t, createdOrder.Edges.OrderStatus)
+	require.Equal(t, domain.OrderStatusInReview, createdOrder.Edges.OrderStatus[0].Edges.OrderStatusName.Status)
+	require.Equal(t, false, createdOrder.IsFirst)
 
-	assert.NoError(t, tx.Commit())
+	require.NoError(t, tx.Commit())
 }
 
 // isFirst field should be true, if one of orders has rejected status
@@ -278,7 +278,7 @@ func (s *OrderSuite) TestOrderRepository_Create_isFirstCreatedOrderIsTrueIfOneOf
 	t := s.T()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 
 	description := "test"
@@ -295,7 +295,7 @@ func (s *OrderSuite) TestOrderRepository_Create_isFirstCreatedOrderIsTrueIfOneOf
 	err = s.client.OrderStatusName.Create().
 		SetStatus(domain.OrderStatusRejected).
 		Exec(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	orderId := int64(s.orders[0].ID)
 	testComment := "testComment"
 	model := models.NewOrderStatus{
@@ -305,22 +305,22 @@ func (s *OrderSuite) TestOrderRepository_Create_isFirstCreatedOrderIsTrueIfOneOf
 		Comment:   &testComment,
 	}
 	err = s.orderStatusRepository.UpdateStatus(ctx, s.user.ID, model)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	createdOrder, err := s.orderRepository.Create(ctx, data, s.user.ID, []int{s.equipments[0].ID})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.NotEmpty(t, createdOrder)
-	assert.Equal(t, description, createdOrder.Description)
-	assert.NotEmpty(t, createdOrder.Edges.Equipments)
-	assert.Equal(t, int(equipmentID), createdOrder.Edges.Equipments[0].ID)
-	assert.NotEmpty(t, createdOrder.Edges.Users)
-	assert.Equal(t, s.user.ID, createdOrder.Edges.Users.ID)
-	assert.NotEmpty(t, createdOrder.Edges.OrderStatus)
-	assert.Equal(t, domain.OrderStatusInReview, createdOrder.Edges.OrderStatus[0].Edges.OrderStatusName.Status)
-	assert.Equal(t, true, createdOrder.IsFirst)
+	require.NotEmpty(t, createdOrder)
+	require.Equal(t, description, createdOrder.Description)
+	require.NotEmpty(t, createdOrder.Edges.Equipments)
+	require.Equal(t, int(equipmentID), createdOrder.Edges.Equipments[0].ID)
+	require.NotEmpty(t, createdOrder.Edges.Users)
+	require.Equal(t, s.user.ID, createdOrder.Edges.Users.ID)
+	require.NotEmpty(t, createdOrder.Edges.OrderStatus)
+	require.Equal(t, domain.OrderStatusInReview, createdOrder.Edges.OrderStatus[0].Edges.OrderStatusName.Status)
+	require.Equal(t, true, createdOrder.IsFirst)
 
-	assert.NoError(t, tx.Commit())
+	require.NoError(t, tx.Commit())
 }
 
 // isFirst field should be true for all new created orders
@@ -328,7 +328,7 @@ func (s *OrderSuite) TestOrderRepository_Create_isFirstFieldIsTrueForSeveralNewC
 	t := s.T()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 
 	description := "test"
@@ -343,32 +343,32 @@ func (s *OrderSuite) TestOrderRepository_Create_isFirstFieldIsTrueForSeveralNewC
 	}
 
 	createdFirstOrder, err := s.orderRepository.Create(ctx, data, s.user.ID, []int{s.equipments[0].ID})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.NotEmpty(t, createdFirstOrder)
-	assert.Equal(t, description, createdFirstOrder.Description)
-	assert.NotEmpty(t, createdFirstOrder.Edges.Equipments)
-	assert.Equal(t, int(equipmentID), createdFirstOrder.Edges.Equipments[0].ID)
-	assert.NotEmpty(t, createdFirstOrder.Edges.Users)
-	assert.Equal(t, s.user.ID, createdFirstOrder.Edges.Users.ID)
-	assert.NotEmpty(t, createdFirstOrder.Edges.OrderStatus)
-	assert.Equal(t, domain.OrderStatusInReview, createdFirstOrder.Edges.OrderStatus[0].Edges.OrderStatusName.Status)
-	assert.Equal(t, true, createdFirstOrder.IsFirst)
+	require.NotEmpty(t, createdFirstOrder)
+	require.Equal(t, description, createdFirstOrder.Description)
+	require.NotEmpty(t, createdFirstOrder.Edges.Equipments)
+	require.Equal(t, int(equipmentID), createdFirstOrder.Edges.Equipments[0].ID)
+	require.NotEmpty(t, createdFirstOrder.Edges.Users)
+	require.Equal(t, s.user.ID, createdFirstOrder.Edges.Users.ID)
+	require.NotEmpty(t, createdFirstOrder.Edges.OrderStatus)
+	require.Equal(t, domain.OrderStatusInReview, createdFirstOrder.Edges.OrderStatus[0].Edges.OrderStatusName.Status)
+	require.Equal(t, true, createdFirstOrder.IsFirst)
 
 	createdSecondOrder, err := s.orderRepository.Create(ctx, data, s.user.ID, []int{s.equipments[0].ID})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.NotEmpty(t, createdSecondOrder)
-	assert.Equal(t, description, createdSecondOrder.Description)
-	assert.NotEmpty(t, createdSecondOrder.Edges.Equipments)
-	assert.Equal(t, int(equipmentID), createdSecondOrder.Edges.Equipments[0].ID)
-	assert.NotEmpty(t, createdSecondOrder.Edges.Users)
-	assert.Equal(t, s.user.ID, createdSecondOrder.Edges.Users.ID)
-	assert.NotEmpty(t, createdSecondOrder.Edges.OrderStatus)
-	assert.Equal(t, domain.OrderStatusInReview, createdSecondOrder.Edges.OrderStatus[0].Edges.OrderStatusName.Status)
-	assert.Equal(t, true, createdSecondOrder.IsFirst)
+	require.NotEmpty(t, createdSecondOrder)
+	require.Equal(t, description, createdSecondOrder.Description)
+	require.NotEmpty(t, createdSecondOrder.Edges.Equipments)
+	require.Equal(t, int(equipmentID), createdSecondOrder.Edges.Equipments[0].ID)
+	require.NotEmpty(t, createdSecondOrder.Edges.Users)
+	require.Equal(t, s.user.ID, createdSecondOrder.Edges.Users.ID)
+	require.NotEmpty(t, createdSecondOrder.Edges.OrderStatus)
+	require.Equal(t, domain.OrderStatusInReview, createdSecondOrder.Edges.OrderStatus[0].Edges.OrderStatusName.Status)
+	require.Equal(t, true, createdSecondOrder.IsFirst)
 
-	assert.NoError(t, tx.Commit())
+	require.NoError(t, tx.Commit())
 }
 
 // isFirst field should be false for all previous created orders if one of them was approved
@@ -376,7 +376,7 @@ func (s *OrderSuite) TestOrderRepository_Create_isFirstFieldForPreviousCreatedOr
 	t := s.T()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 
 	description := "test"
@@ -402,45 +402,45 @@ func (s *OrderSuite) TestOrderRepository_Create_isFirstFieldForPreviousCreatedOr
 	err = s.client.OrderStatusName.Create().
 		SetStatus(domain.OrderStatusApproved).
 		Exec(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	createdFirstOrder, err := s.orderRepository.Create(ctx, data, s.user.ID, []int{s.equipments[0].ID})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.NotEmpty(t, createdFirstOrder)
-	assert.Equal(t, description, createdFirstOrder.Description)
-	assert.NotEmpty(t, createdFirstOrder.Edges.Equipments)
-	assert.Equal(t, int(equipmentID), createdFirstOrder.Edges.Equipments[0].ID)
-	assert.NotEmpty(t, createdFirstOrder.Edges.Users)
-	assert.Equal(t, s.user.ID, createdFirstOrder.Edges.Users.ID)
-	assert.NotEmpty(t, createdFirstOrder.Edges.OrderStatus)
-	assert.Equal(t, domain.OrderStatusInReview, createdFirstOrder.Edges.OrderStatus[0].Edges.OrderStatusName.Status)
-	assert.Equal(t, true, createdFirstOrder.IsFirst)
+	require.NotEmpty(t, createdFirstOrder)
+	require.Equal(t, description, createdFirstOrder.Description)
+	require.NotEmpty(t, createdFirstOrder.Edges.Equipments)
+	require.Equal(t, int(equipmentID), createdFirstOrder.Edges.Equipments[0].ID)
+	require.NotEmpty(t, createdFirstOrder.Edges.Users)
+	require.Equal(t, s.user.ID, createdFirstOrder.Edges.Users.ID)
+	require.NotEmpty(t, createdFirstOrder.Edges.OrderStatus)
+	require.Equal(t, domain.OrderStatusInReview, createdFirstOrder.Edges.OrderStatus[0].Edges.OrderStatusName.Status)
+	require.Equal(t, true, createdFirstOrder.IsFirst)
 
 	createdSecondOrder, err := s.orderRepository.Create(ctx, data, s.user.ID, []int{s.equipments[0].ID})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.NotEmpty(t, createdSecondOrder)
-	assert.Equal(t, description, createdSecondOrder.Description)
-	assert.NotEmpty(t, createdSecondOrder.Edges.Equipments)
-	assert.Equal(t, int(equipmentID), createdSecondOrder.Edges.Equipments[0].ID)
-	assert.NotEmpty(t, createdSecondOrder.Edges.Users)
-	assert.Equal(t, s.user.ID, createdSecondOrder.Edges.Users.ID)
-	assert.NotEmpty(t, createdSecondOrder.Edges.OrderStatus)
-	assert.Equal(t, domain.OrderStatusInReview, createdSecondOrder.Edges.OrderStatus[0].Edges.OrderStatusName.Status)
-	assert.Equal(t, true, createdSecondOrder.IsFirst)
+	require.NotEmpty(t, createdSecondOrder)
+	require.Equal(t, description, createdSecondOrder.Description)
+	require.NotEmpty(t, createdSecondOrder.Edges.Equipments)
+	require.Equal(t, int(equipmentID), createdSecondOrder.Edges.Equipments[0].ID)
+	require.NotEmpty(t, createdSecondOrder.Edges.Users)
+	require.Equal(t, s.user.ID, createdSecondOrder.Edges.Users.ID)
+	require.NotEmpty(t, createdSecondOrder.Edges.OrderStatus)
+	require.Equal(t, domain.OrderStatusInReview, createdSecondOrder.Edges.OrderStatus[0].Edges.OrderStatusName.Status)
+	require.Equal(t, true, createdSecondOrder.IsFirst)
 
 	err = s.orderStatusRepository.UpdateStatus(ctx, s.user.ID, model)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	orderList, err := s.orderRepository.List(ctx, s.user.ID, math.MaxInt, 0, utils.AscOrder, order.FieldID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	for _, order := range orderList {
-		assert.Equal(t, false, order.IsFirst)
+		require.Equal(t, false, order.IsFirst)
 	}
 
-	assert.NoError(t, tx.Commit())
+	require.NoError(t, tx.Commit())
 
 }
 
@@ -448,14 +448,14 @@ func (s *OrderSuite) TestOrderRepository_OrdersTotal() {
 	t := s.T()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	totalOrders, err := s.orderRepository.OrdersTotal(ctx, s.user.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.orders), totalOrders)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.orders), totalOrders)
 }
 
 func (s *OrderSuite) TestOrderRepository_List_EmptyOrderBy() {
@@ -466,12 +466,12 @@ func (s *OrderSuite) TestOrderRepository_List_EmptyOrderBy() {
 	orderColumn := order.FieldID
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	orders, err := s.orderRepository.List(ctx, s.user.ID, limit, offset, orderBy, orderColumn)
-	assert.Error(t, err)
-	assert.NoError(t, tx.Rollback())
-	assert.Nil(t, orders)
+	require.Error(t, err)
+	require.NoError(t, tx.Rollback())
+	require.Nil(t, orders)
 }
 
 func (s *OrderSuite) TestOrderRepository_List_WrongOrderColumn() {
@@ -482,12 +482,12 @@ func (s *OrderSuite) TestOrderRepository_List_WrongOrderColumn() {
 	orderColumn := order.FieldDescription
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	orders, err := s.orderRepository.List(ctx, s.user.ID, limit, offset, orderBy, orderColumn)
-	assert.Error(t, err)
-	assert.NoError(t, tx.Rollback())
-	assert.Nil(t, orders)
+	require.Error(t, err)
+	require.NoError(t, tx.Rollback())
+	require.Nil(t, orders)
 }
 
 func (s *OrderSuite) TestOrderRepository_List_OrderByIDDesc() {
@@ -498,18 +498,18 @@ func (s *OrderSuite) TestOrderRepository_List_OrderByIDDesc() {
 	orderColumn := order.FieldID
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	orders, err := s.orderRepository.List(ctx, s.user.ID, limit, offset, orderBy, orderColumn)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.orders), len(orders))
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.orders), len(orders))
 	prevOrderID := math.MaxInt
 	for _, value := range orders {
-		assert.True(t, containsOrder(t, value, s.orders))
-		assert.Less(t, value.ID, prevOrderID)
+		require.True(t, containsOrder(t, value, s.orders))
+		require.Less(t, value.ID, prevOrderID)
 		prevOrderID = value.ID
 	}
 }
@@ -522,18 +522,18 @@ func (s *OrderSuite) TestOrderRepository_List_OrderByRentStartDesc() {
 	orderColumn := order.FieldRentStart
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	orders, err := s.orderRepository.List(ctx, s.user.ID, limit, offset, orderBy, orderColumn)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.orders), len(orders))
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.orders), len(orders))
 	prevOrderRentStart := time.Unix(1<<63-62135596801, 999999999)
 	for _, value := range orders {
-		assert.True(t, containsOrder(t, value, s.orders))
-		assert.True(t, value.RentStart.Before(prevOrderRentStart) || value.RentStart.Equal(prevOrderRentStart))
+		require.True(t, containsOrder(t, value, s.orders))
+		require.True(t, value.RentStart.Before(prevOrderRentStart) || value.RentStart.Equal(prevOrderRentStart))
 		prevOrderRentStart = value.RentStart
 	}
 }
@@ -546,18 +546,18 @@ func (s *OrderSuite) TestOrderRepository_List_OrderByIDAsc() {
 	orderColumn := order.FieldID
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	orders, err := s.orderRepository.List(ctx, s.user.ID, limit, offset, orderBy, orderColumn)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.orders), len(orders))
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.orders), len(orders))
 	prevOrderID := 0
 	for _, value := range orders {
-		assert.True(t, containsOrder(t, value, s.orders))
-		assert.Greater(t, value.ID, prevOrderID)
+		require.True(t, containsOrder(t, value, s.orders))
+		require.Greater(t, value.ID, prevOrderID)
 		prevOrderID = value.ID
 	}
 }
@@ -570,18 +570,18 @@ func (s *OrderSuite) TestOrderRepository_List_OrderByRentStartAsc() {
 	orderColumn := order.FieldRentStart
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	orders, err := s.orderRepository.List(ctx, s.user.ID, limit, offset, orderBy, orderColumn)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.orders), len(orders))
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.orders), len(orders))
 	prevOrderRentStart := time.Unix(0, 0)
 	for _, value := range orders {
-		assert.True(t, containsOrder(t, value, s.orders))
-		assert.True(t, value.RentStart.After(prevOrderRentStart) || value.RentStart.Equal(prevOrderRentStart))
+		require.True(t, containsOrder(t, value, s.orders))
+		require.True(t, value.RentStart.After(prevOrderRentStart) || value.RentStart.Equal(prevOrderRentStart))
 		prevOrderRentStart = value.RentStart
 	}
 }
@@ -594,15 +594,15 @@ func (s *OrderSuite) TestOrderRepository_List_Limit() {
 	orderColumn := order.FieldID
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	orders, err := s.orderRepository.List(ctx, s.user.ID, limit, offset, orderBy, orderColumn)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, limit, len(orders))
-	assert.Greater(t, len(s.orders), len(orders))
+	require.NoError(t, tx.Commit())
+	require.Equal(t, limit, len(orders))
+	require.Greater(t, len(s.orders), len(orders))
 }
 
 func (s *OrderSuite) TestOrderRepository_List_Offset() {
@@ -613,15 +613,15 @@ func (s *OrderSuite) TestOrderRepository_List_Offset() {
 	orderColumn := order.FieldID
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	orders, err := s.orderRepository.List(ctx, s.user.ID, limit, offset, orderBy, orderColumn)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.orders)-offset, len(orders))
-	assert.Greater(t, len(s.orders), len(orders))
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.orders)-offset, len(orders))
+	require.Greater(t, len(s.orders), len(orders))
 }
 
 func containsOrder(t *testing.T, order *ent.Order, orders []*ent.Order) bool {

--- a/internal/repositories/pet_kind_test.go
+++ b/internal/repositories/pet_kind_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent/enttest"
@@ -27,18 +27,18 @@ func TestPetKindRepository_Create(t *testing.T) {
 
 	repo := NewPetKindRepository()
 	tx, err := client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	petKind, err := repo.Create(ctx, models.PetKind{Name: &name})
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
 
 	selectedPetKind, err := client.PetKind.Get(ctx, 1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, petKind.ID, selectedPetKind.ID)
-	assert.Equal(t, petKind.Name, selectedPetKind.Name)
+	require.Equal(t, petKind.ID, selectedPetKind.ID)
+	require.Equal(t, petKind.Name, selectedPetKind.Name)
 }
 
 func TestPetKindRepository_GetAll(t *testing.T) {
@@ -53,15 +53,15 @@ func TestPetKindRepository_GetAll(t *testing.T) {
 
 	repo := NewPetKindRepository()
 	tx, err := client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	rows, err := repo.GetAll(ctx)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
 
-	assert.Equal(t, 1, rows[0].ID)
-	assert.Equal(t, name, rows[0].Name)
+	require.Equal(t, 1, rows[0].ID)
+	require.Equal(t, name, rows[0].Name)
 }
 
 func TestPetKindRepository_Get(t *testing.T) {
@@ -76,15 +76,15 @@ func TestPetKindRepository_Get(t *testing.T) {
 
 	repo := NewPetKindRepository()
 	tx, err := client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	row, err := repo.GetByID(ctx, 1)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
 
-	assert.Equal(t, 1, row.ID)
-	assert.Equal(t, name, row.Name)
+	require.Equal(t, 1, row.ID)
+	require.Equal(t, name, row.Name)
 }
 
 func TestPetKindRepository_Delete(t *testing.T) {
@@ -99,16 +99,16 @@ func TestPetKindRepository_Delete(t *testing.T) {
 
 	repo := NewPetKindRepository()
 	tx, err := client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	err = repo.Delete(ctx, 1)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
 
 	selected, err := client.PetKind.Get(ctx, 1)
-	assert.ErrorContains(t, err, "ent: pet_kind not found")
-	assert.Nil(t, selected)
+	require.ErrorContains(t, err, "ent: pet_kind not found")
+	require.Nil(t, selected)
 }
 
 func TestPetKindRepository_Update(t *testing.T) {
@@ -124,16 +124,16 @@ func TestPetKindRepository_Update(t *testing.T) {
 
 	repo := NewPetKindRepository()
 	tx, err := client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	_, err = repo.Update(ctx, 1, &models.PetKind{Name: &name2})
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
 
 	selected, err := client.PetKind.Get(ctx, 1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, 1, selected.ID)
-	assert.Equal(t, name2, selected.Name)
+	require.Equal(t, 1, selected.ID)
+	require.Equal(t, name2, selected.Name)
 }

--- a/internal/repositories/pet_size_test.go
+++ b/internal/repositories/pet_size_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/models"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/middlewares"
@@ -21,18 +21,18 @@ func TestPetSizeRepository_Create(t *testing.T) {
 
 	repo := NewPetSizeRepository()
 	tx, err := client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	petSize, err := repo.Create(ctx, models.PetSize{Name: &name, Size: &size})
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
 
 	selectedPetSize, err := client.PetSize.Get(ctx, 1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, petSize.ID, selectedPetSize.ID)
-	assert.Equal(t, petSize.Name, selectedPetSize.Name)
+	require.Equal(t, petSize.ID, selectedPetSize.ID)
+	require.Equal(t, petSize.Name, selectedPetSize.Name)
 }
 
 func TestPetSizeRepository_GetAll(t *testing.T) {
@@ -47,15 +47,15 @@ func TestPetSizeRepository_GetAll(t *testing.T) {
 
 	repo := NewPetSizeRepository()
 	tx, err := client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	rows, err := repo.GetAll(ctx)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
 
-	assert.Equal(t, 1, rows[0].ID)
-	assert.Equal(t, name, rows[0].Name)
+	require.Equal(t, 1, rows[0].ID)
+	require.Equal(t, name, rows[0].Name)
 }
 
 func TestPetSizeRepository_Get(t *testing.T) {
@@ -70,15 +70,15 @@ func TestPetSizeRepository_Get(t *testing.T) {
 
 	repo := NewPetSizeRepository()
 	tx, err := client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	row, err := repo.GetByID(ctx, 1)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
 
-	assert.Equal(t, 1, row.ID)
-	assert.Equal(t, name, row.Name)
+	require.Equal(t, 1, row.ID)
+	require.Equal(t, name, row.Name)
 }
 
 func TestPetSizeRepository_Delete(t *testing.T) {
@@ -93,16 +93,16 @@ func TestPetSizeRepository_Delete(t *testing.T) {
 
 	repo := NewPetSizeRepository()
 	tx, err := client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	err = repo.Delete(ctx, 1)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
 
 	selected, err := client.PetSize.Get(ctx, 1)
-	assert.ErrorContains(t, err, "ent: pet_size not found")
-	assert.Nil(t, selected)
+	require.ErrorContains(t, err, "ent: pet_size not found")
+	require.Nil(t, selected)
 }
 
 func TestPetSizeRepository_Update(t *testing.T) {
@@ -120,17 +120,17 @@ func TestPetSizeRepository_Update(t *testing.T) {
 
 	repo := NewPetSizeRepository()
 	tx, err := client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	_, err = repo.Update(ctx, 1, &models.PetSize{Name: &name2, Size: &size2})
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
 
 	selected, err := client.PetSize.Get(ctx, 1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, 1, selected.ID)
-	assert.Equal(t, name2, selected.Name)
-	assert.Equal(t, size2, selected.Size)
+	require.Equal(t, 1, selected.ID)
+	require.Equal(t, name2, selected.Name)
+	require.Equal(t, size2, selected.Size)
 }

--- a/internal/repositories/photo_test.go
+++ b/internal/repositories/photo_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent"
@@ -42,13 +42,13 @@ func (s *photoRepositorySuite) TestPhotoRepository_CreatePhoto_EmptyID() {
 
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	createdPhoto, err := s.repository.CreatePhoto(ctx, newPhoto)
-	assert.Error(t, err)
-	assert.NoError(t, tx.Rollback())
-	assert.Errorf(t, err, "id must not be empty")
-	assert.Nil(t, createdPhoto)
+	require.Error(t, err)
+	require.NoError(t, tx.Rollback())
+	require.Errorf(t, err, "id must not be empty")
+	require.Nil(t, createdPhoto)
 
 	_, err = s.client.Photo.Delete().Exec(s.ctx)
 	if err != nil {
@@ -66,13 +66,13 @@ func (s *photoRepositorySuite) TestPhotoRepository_CreatePhoto_EmptyFileName() {
 
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	createdPhoto, err := s.repository.CreatePhoto(ctx, newPhoto)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, id, createdPhoto.ID)
-	assert.Equal(t, fileName, createdPhoto.FileName)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, id, createdPhoto.ID)
+	require.Equal(t, fileName, createdPhoto.FileName)
 
 	_, err = s.client.Photo.Delete().Exec(s.ctx)
 	if err != nil {
@@ -91,13 +91,13 @@ func (s *photoRepositorySuite) TestPhotoRepository_CreatePhoto_OK() {
 
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	createdPhoto, err := s.repository.CreatePhoto(ctx, newPhoto)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, id, createdPhoto.ID)
-	assert.Equal(t, fileName, createdPhoto.FileName)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, id, createdPhoto.ID)
+	require.Equal(t, fileName, createdPhoto.FileName)
 
 	_, err = s.client.Photo.Delete().Exec(s.ctx)
 	if err != nil {
@@ -111,13 +111,13 @@ func (s *photoRepositorySuite) TestPhotoRepository_PhotoByID_NotFound() {
 
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	photo, err := s.repository.PhotoByID(ctx, id)
-	assert.Error(t, err)
-	assert.NoError(t, tx.Rollback())
-	assert.Errorf(t, err, "not found")
-	assert.Nil(t, photo)
+	require.Error(t, err)
+	require.NoError(t, tx.Rollback())
+	require.Errorf(t, err, "not found")
+	require.Nil(t, photo)
 
 	_, err = s.client.Photo.Delete().Exec(s.ctx)
 	if err != nil {
@@ -138,13 +138,13 @@ func (s *photoRepositorySuite) TestPhotoRepository_PhotoByID_OK() {
 
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	photo, err := s.repository.PhotoByID(ctx, createdPhoto.ID)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, id, photo.ID)
-	assert.Equal(t, fileName, photo.FileName)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, id, photo.ID)
+	require.Equal(t, fileName, photo.FileName)
 
 	_, err = s.client.Photo.Delete().Exec(s.ctx)
 	if err != nil {
@@ -158,11 +158,11 @@ func (s *photoRepositorySuite) TestPhotoRepository_DeletePhotoByID_NotExistsOK()
 
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	err = s.repository.DeletePhotoByID(ctx, id)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
 
 	_, err = s.client.Photo.Delete().Exec(s.ctx)
 	if err != nil {
@@ -183,11 +183,11 @@ func (s *photoRepositorySuite) TestPhotoRepository_DeletePhotoByID_OK() {
 
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	err = s.repository.DeletePhotoByID(ctx, createdPhoto.ID)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
 
 	_, err = s.client.Photo.Delete().Exec(s.ctx)
 	if err != nil {

--- a/internal/repositories/role_test.go
+++ b/internal/repositories/role_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent"
@@ -57,13 +57,13 @@ func (s *roleRepositoryTestSuite) TestRoleRepository_GetRoles() {
 	t := s.T()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	roles, err := s.repository.GetRoles(ctx)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.roles), len(roles))
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.roles), len(roles))
 	for _, role := range roles {
-		assert.Contains(t, s.roles, role.Name)
+		require.Contains(t, s.roles, role.Name)
 	}
 }

--- a/internal/repositories/subcategory_test.go
+++ b/internal/repositories/subcategory_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent"
@@ -103,12 +103,12 @@ func (s *subcategoryRepositorySuite) TestSubcategoryRepository_CreateSubcategory
 	}
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	createdSubcategory, err := s.repository.CreateSubcategory(ctx, int(categoryID), newSubcategory)
-	assert.Error(t, err)
-	assert.Nil(t, createdSubcategory)
-	assert.NoError(t, tx.Rollback())
+	require.Error(t, err)
+	require.Nil(t, createdSubcategory)
+	require.NoError(t, tx.Rollback())
 }
 
 func (s *subcategoryRepositorySuite) TestSubcategoryRepository_CreateSubcategory_OK() {
@@ -125,40 +125,40 @@ func (s *subcategoryRepositorySuite) TestSubcategoryRepository_CreateSubcategory
 	}
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	createdSubcategory, err := s.repository.CreateSubcategory(ctx, int(categoryID), newSubcategory)
-	assert.NoError(t, err)
-	assert.Equal(t, name, createdSubcategory.Name)
-	assert.Equal(t, maxReservationTime, createdSubcategory.MaxReservationTime)
-	assert.Equal(t, maxReservationUnits, createdSubcategory.MaxReservationUnits)
-	assert.NoError(t, tx.Rollback())
+	require.NoError(t, err)
+	require.Equal(t, name, createdSubcategory.Name)
+	require.Equal(t, maxReservationTime, createdSubcategory.MaxReservationTime)
+	require.Equal(t, maxReservationUnits, createdSubcategory.MaxReservationUnits)
+	require.NoError(t, tx.Rollback())
 }
 
 func (s *subcategoryRepositorySuite) TestSubcategoryRepository_ListSubcategories_CategoryNotExists() {
 	t := s.T()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	categories, err := s.repository.ListSubcategories(ctx, s.category.ID+10)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, 0, len(categories))
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, 0, len(categories))
 }
 
 func (s *subcategoryRepositorySuite) TestSubcategoryRepository_ListSubcategories_OK() {
 	t := s.T()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	categories, err := s.repository.ListSubcategories(ctx, s.category.ID)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.subcategories), len(categories))
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.subcategories), len(categories))
 	for _, value := range categories {
-		assert.True(t, containsSubcategory(t, value, s.subcategories))
+		require.True(t, containsSubcategory(t, value, s.subcategories))
 	}
 }
 
@@ -166,26 +166,26 @@ func (s *subcategoryRepositorySuite) TestSubcategoryRepository_SubcategoryByID()
 	t := s.T()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	subcat, err := s.repository.SubcategoryByID(ctx, s.subcategories[0].ID)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, s.subcategories[0].Name, subcat.Name)
-	assert.Equal(t, s.subcategories[0].MaxReservationTime, subcat.MaxReservationTime)
-	assert.Equal(t, s.subcategories[0].MaxReservationUnits, subcat.MaxReservationUnits)
-	assert.Equal(t, s.subcategories[0].Edges.Category.ID, subcat.Edges.Category.ID)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, s.subcategories[0].Name, subcat.Name)
+	require.Equal(t, s.subcategories[0].MaxReservationTime, subcat.MaxReservationTime)
+	require.Equal(t, s.subcategories[0].MaxReservationUnits, subcat.MaxReservationUnits)
+	require.Equal(t, s.subcategories[0].Edges.Category.ID, subcat.Edges.Category.ID)
 }
 
 func (s *subcategoryRepositorySuite) TestSubcategoryRepository_DeleteSubcategoryByID() {
 	t := s.T()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	err = s.repository.DeleteSubcategoryByID(ctx, s.subcategories[0].ID)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Rollback())
+	require.NoError(t, err)
+	require.NoError(t, tx.Rollback())
 }
 
 func (s *subcategoryRepositorySuite) TestSubcategoryRepository_UpdateSubcategory() {
@@ -196,14 +196,14 @@ func (s *subcategoryRepositorySuite) TestSubcategoryRepository_UpdateSubcategory
 	}
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	subcat, err := s.repository.UpdateSubcategory(ctx, s.subcategories[0].ID, update)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Rollback())
-	assert.Equal(t, name, subcat.Name)
-	assert.Equal(t, s.subcategories[0].MaxReservationTime, subcat.MaxReservationTime)
-	assert.Equal(t, s.subcategories[0].MaxReservationUnits, subcat.MaxReservationUnits)
+	require.NoError(t, err)
+	require.NoError(t, tx.Rollback())
+	require.Equal(t, name, subcat.Name)
+	require.Equal(t, s.subcategories[0].MaxReservationTime, subcat.MaxReservationTime)
+	require.Equal(t, s.subcategories[0].MaxReservationUnits, subcat.MaxReservationUnits)
 }
 
 func containsSubcategory(t *testing.T, eq *ent.Subcategory, list []*ent.Subcategory) bool {

--- a/internal/repositories/user_test.go
+++ b/internal/repositories/user_test.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent"
@@ -95,14 +95,14 @@ func (s *UserSuite) TestUserRepository_UsersListTotal() {
 	repository := NewUserRepository()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	totalUsers, err := repository.UsersListTotal(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.users), totalUsers)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.users), totalUsers)
 }
 
 func (s *UserSuite) TestUserRepository_UserList_EmptyOrderBy() {
@@ -114,12 +114,12 @@ func (s *UserSuite) TestUserRepository_UserList_EmptyOrderBy() {
 	repository := NewUserRepository()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	users, err := repository.UserList(ctx, limit, offset, orderBy, orderColumn)
-	assert.Error(t, err)
-	assert.NoError(t, tx.Rollback())
-	assert.Nil(t, users)
+	require.Error(t, err)
+	require.NoError(t, tx.Rollback())
+	require.Nil(t, users)
 }
 
 func (s *UserSuite) TestUserRepository_UserList_EmptyOrderColumn() {
@@ -131,12 +131,12 @@ func (s *UserSuite) TestUserRepository_UserList_EmptyOrderColumn() {
 	repository := NewUserRepository()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	users, err := repository.UserList(ctx, limit, offset, orderBy, orderColumn)
-	assert.Error(t, err)
-	assert.NoError(t, tx.Rollback())
-	assert.Nil(t, users)
+	require.Error(t, err)
+	require.NoError(t, tx.Rollback())
+	require.Nil(t, users)
 }
 
 func (s *UserSuite) TestUserRepository_UserList_WrongOrderColumn() {
@@ -148,12 +148,12 @@ func (s *UserSuite) TestUserRepository_UserList_WrongOrderColumn() {
 	repository := NewUserRepository()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	users, err := repository.UserList(ctx, limit, offset, orderBy, orderColumn)
-	assert.Error(t, err)
-	assert.NoError(t, tx.Rollback())
-	assert.Nil(t, users)
+	require.Error(t, err)
+	require.NoError(t, tx.Rollback())
+	require.Nil(t, users)
 }
 
 func (s *UserSuite) TestUserRepository_UserList_OrderByIDDesc() {
@@ -165,16 +165,16 @@ func (s *UserSuite) TestUserRepository_UserList_OrderByIDDesc() {
 	repository := NewUserRepository()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	users, err := repository.UserList(ctx, limit, offset, orderBy, orderColumn)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.users), len(users))
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.users), len(users))
 	prevUserID := math.MaxInt
 	for _, value := range users {
-		assert.True(t, mapContainsUser(t, value, s.users))
-		assert.LessOrEqual(t, value.ID, prevUserID)
+		require.True(t, mapContainsUser(t, value, s.users))
+		require.LessOrEqual(t, value.ID, prevUserID)
 		prevUserID = value.ID
 	}
 }
@@ -188,16 +188,16 @@ func (s *UserSuite) TestUserRepository_UserList_OrderByNameDesc() {
 	repository := NewUserRepository()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	users, err := repository.UserList(ctx, limit, offset, orderBy, orderColumn)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.users), len(users))
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.users), len(users))
 	prevUserName := "zzzzzzzzzzzzzzzzzzzzz"
 	for _, value := range users {
-		assert.True(t, mapContainsUser(t, value, s.users))
-		assert.LessOrEqual(t, value.Name, prevUserName)
+		require.True(t, mapContainsUser(t, value, s.users))
+		require.LessOrEqual(t, value.Name, prevUserName)
 		prevUserName = value.Name
 	}
 }
@@ -211,16 +211,16 @@ func (s *UserSuite) TestUserRepository_UserList_OrderByIDAsc() {
 	repository := NewUserRepository()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	users, err := repository.UserList(ctx, limit, offset, orderBy, orderColumn)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.users), len(users))
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.users), len(users))
 	prevUserID := 0
 	for _, value := range users {
-		assert.True(t, mapContainsUser(t, value, s.users))
-		assert.GreaterOrEqual(t, value.ID, prevUserID)
+		require.True(t, mapContainsUser(t, value, s.users))
+		require.GreaterOrEqual(t, value.ID, prevUserID)
 		prevUserID = value.ID
 	}
 }
@@ -234,16 +234,16 @@ func (s *UserSuite) TestUserRepository_UserList_OrderByNameAsc() {
 	repository := NewUserRepository()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	users, err := repository.UserList(ctx, limit, offset, orderBy, orderColumn)
-	assert.NoError(t, err)
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.users), len(users))
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.users), len(users))
 	prevUserName := ""
 	for _, value := range users {
-		assert.True(t, mapContainsUser(t, value, s.users))
-		assert.GreaterOrEqual(t, value.Name, prevUserName)
+		require.True(t, mapContainsUser(t, value, s.users))
+		require.GreaterOrEqual(t, value.Name, prevUserName)
 		prevUserName = value.Name
 	}
 }
@@ -257,14 +257,14 @@ func (s *UserSuite) TestUserRepository_UserList_Limit() {
 	repository := NewUserRepository()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	users, err := repository.UserList(ctx, limit, offset, orderBy, orderColumn)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, limit, len(users))
+	require.NoError(t, tx.Commit())
+	require.Equal(t, limit, len(users))
 }
 
 func (s *UserSuite) TestUserRepository_UserList_Offset() {
@@ -276,14 +276,14 @@ func (s *UserSuite) TestUserRepository_UserList_Offset() {
 	repository := NewUserRepository()
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	users, err := repository.UserList(ctx, limit, offset, orderBy, orderColumn)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, tx.Commit())
-	assert.Equal(t, len(s.users)-offset, len(users))
+	require.NoError(t, tx.Commit())
+	require.Equal(t, len(s.users)-offset, len(users))
 }
 
 func mapContainsUser(t *testing.T, eq *ent.User, m map[int]*ent.User) bool {

--- a/internal/services/password_service_test.go
+++ b/internal/services/password_service_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
@@ -49,8 +49,8 @@ func (s *PasswordResetTestSuite) TestPasswordReset_SendResetPasswordLink_UserByL
 	err := errors.New("error")
 	s.userRepository.On("UserByLogin", ctx, login).Return(nil, err)
 	errReturn := s.passwordService.SendResetPasswordLink(ctx, login)
-	assert.Error(t, errReturn)
-	assert.Equal(t, err, errReturn)
+	require.Error(t, errReturn)
+	require.Equal(t, err, errReturn)
 	s.userRepository.AssertExpectations(t)
 }
 
@@ -64,8 +64,8 @@ func (s *PasswordResetTestSuite) TestPasswordReset_SendResetPasswordLink_CreateT
 	s.passwordRepo.On("CreateToken", ctx, mock.AnythingOfType("string"),
 		mock.AnythingOfType("time.Time"), user.ID).Return(err)
 	errReturn := s.passwordService.SendResetPasswordLink(ctx, login)
-	assert.Error(t, errReturn)
-	assert.Equal(t, err, errReturn)
+	require.Error(t, errReturn)
+	require.Equal(t, err, errReturn)
 	s.userRepository.AssertExpectations(t)
 	s.passwordRepo.AssertExpectations(t)
 }
@@ -85,8 +85,8 @@ func (s *PasswordResetTestSuite) TestPasswordReset_SendResetPasswordLink_SendLin
 		mock.AnythingOfType("string")).Return(err)
 
 	errReturn := s.passwordService.SendResetPasswordLink(ctx, login)
-	assert.Error(t, errReturn)
-	assert.Equal(t, err, errReturn)
+	require.Error(t, errReturn)
+	require.Equal(t, err, errReturn)
 	s.userRepository.AssertExpectations(t)
 	s.passwordRepo.AssertExpectations(t)
 	s.emailClient.AssertExpectations(t)
@@ -108,7 +108,7 @@ func (s *PasswordResetTestSuite) TestPasswordReset_SendResetPasswordLink_OK() {
 	s.emailClient.On("IsSendRequired").Return(false)
 
 	errReturn := s.passwordService.SendResetPasswordLink(ctx, login)
-	assert.NoError(t, errReturn)
+	require.NoError(t, errReturn)
 	s.userRepository.AssertExpectations(t)
 	s.passwordRepo.AssertExpectations(t)
 	s.emailClient.AssertExpectations(t)
@@ -121,8 +121,8 @@ func (s *PasswordResetTestSuite) TestPasswordReset_VerifyTokenAndSendPassword_Ge
 	err := errors.New("error")
 	s.passwordRepo.On("GetToken", ctx, token).Return(nil, err)
 	errReturn := s.passwordService.VerifyTokenAndSendPassword(ctx, token)
-	assert.Error(t, errReturn)
-	assert.Equal(t, err, errReturn)
+	require.Error(t, errReturn)
+	require.Equal(t, err, errReturn)
 	s.passwordRepo.AssertExpectations(t)
 }
 
@@ -140,7 +140,7 @@ func (s *PasswordResetTestSuite) TestPasswordReset_VerifyTokenAndSendPassword_To
 	s.passwordRepo.On("GetToken", ctx, token).Return(returnToken, nil)
 	s.passwordRepo.On("DeleteToken", ctx, token).Return(nil)
 	errReturn := s.passwordService.VerifyTokenAndSendPassword(ctx, token)
-	assert.Error(t, errReturn)
+	require.Error(t, errReturn)
 	s.passwordRepo.AssertExpectations(t)
 }
 
@@ -159,7 +159,7 @@ func (s *PasswordResetTestSuite) TestPasswordReset_VerifyTokenAndSendPassword_De
 	s.passwordRepo.On("GetToken", ctx, token).Return(returnToken, nil)
 	s.passwordRepo.On("DeleteToken", ctx, token).Return(err)
 	errReturn := s.passwordService.VerifyTokenAndSendPassword(ctx, token)
-	assert.Error(t, errReturn)
+	require.Error(t, errReturn)
 	s.passwordRepo.AssertExpectations(t)
 }
 
@@ -180,8 +180,8 @@ func (s *PasswordResetTestSuite) TestPasswordReset_VerifyTokenAndSendPassword_Pa
 	s.passwordGenerator.On("NewPassword").Return(newPassword, err)
 
 	errReturn := s.passwordService.VerifyTokenAndSendPassword(ctx, token)
-	assert.Error(t, errReturn)
-	assert.Equal(t, err, errReturn)
+	require.Error(t, errReturn)
+	require.Equal(t, err, errReturn)
 	s.passwordRepo.AssertExpectations(t)
 	s.userRepository.AssertExpectations(t)
 	s.emailClient.AssertExpectations(t)
@@ -207,8 +207,8 @@ func (s *PasswordResetTestSuite) TestPasswordReset_VerifyTokenAndSendPassword_Ch
 	s.passwordGenerator.On("NewPassword").Return(newPassword, nil)
 
 	errReturn := s.passwordService.VerifyTokenAndSendPassword(ctx, token)
-	assert.Error(t, errReturn)
-	assert.Equal(t, err, errReturn)
+	require.Error(t, errReturn)
+	require.Equal(t, err, errReturn)
 	s.passwordRepo.AssertExpectations(t)
 	s.userRepository.AssertExpectations(t)
 	s.emailClient.AssertExpectations(t)
@@ -235,8 +235,8 @@ func (s *PasswordResetTestSuite) TestPasswordReset_VerifyTokenAndSendPassword_Se
 	s.emailClient.On("SendNewPassword", returnToken.Edges.Users.Email,
 		returnToken.Edges.Users.Login, newPassword).Return(err)
 	errReturn := s.passwordService.VerifyTokenAndSendPassword(ctx, token)
-	assert.Error(t, errReturn)
-	assert.Equal(t, err, errReturn)
+	require.Error(t, errReturn)
+	require.Equal(t, err, errReturn)
 	s.passwordRepo.AssertExpectations(t)
 	s.userRepository.AssertExpectations(t)
 	s.emailClient.AssertExpectations(t)
@@ -264,7 +264,7 @@ func (s *PasswordResetTestSuite) TestPasswordReset_VerifyTokenAndSendPassword_De
 	s.passwordRepo.On("DeleteToken", ctx, token).Return(errors.New("error"))
 	s.emailClient.On("IsSendRequired").Return(false)
 	errReturn := s.passwordService.VerifyTokenAndSendPassword(ctx, token)
-	assert.NoError(t, errReturn)
+	require.NoError(t, errReturn)
 	s.passwordRepo.AssertExpectations(t)
 	s.userRepository.AssertExpectations(t)
 	s.emailClient.AssertExpectations(t)
@@ -292,7 +292,7 @@ func (s *PasswordResetTestSuite) TestPasswordReset_VerifyTokenAndSendPassword_OK
 	s.passwordRepo.On("DeleteToken", ctx, token).Return(nil)
 	s.emailClient.On("IsSendRequired").Return(false)
 	errReturn := s.passwordService.VerifyTokenAndSendPassword(ctx, token)
-	assert.NoError(t, errReturn)
+	require.NoError(t, errReturn)
 	s.passwordRepo.AssertExpectations(t)
 	s.userRepository.AssertExpectations(t)
 	s.emailClient.AssertExpectations(t)

--- a/internal/services/registration_confirm_test.go
+++ b/internal/services/registration_confirm_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
@@ -47,8 +47,8 @@ func (s *RegistrationConfirmTestSuite) TestPasswordReset_SendConfirmationLink_Us
 	err := errors.New("error while getting user by login")
 	s.userRepository.On("UserByLogin", ctx, login).Return(nil, err)
 	errReturn := s.regConfirmService.SendConfirmationLink(ctx, login)
-	assert.Error(t, errReturn)
-	assert.Equal(t, err, errReturn)
+	require.Error(t, errReturn)
+	require.Equal(t, err, errReturn)
 	s.userRepository.AssertExpectations(t)
 }
 
@@ -62,8 +62,8 @@ func (s *RegistrationConfirmTestSuite) TestPasswordReset_SendConfirmationLink_Cr
 	s.regConfirmRepo.On("CreateToken", ctx, mock.AnythingOfType("string"),
 		mock.AnythingOfType("time.Time"), user.ID).Return(err)
 	errReturn := s.regConfirmService.SendConfirmationLink(ctx, login)
-	assert.Error(t, errReturn)
-	assert.Equal(t, err, errReturn)
+	require.Error(t, errReturn)
+	require.Equal(t, err, errReturn)
 	s.userRepository.AssertExpectations(t)
 	s.regConfirmRepo.AssertExpectations(t)
 }
@@ -80,8 +80,8 @@ func (s *RegistrationConfirmTestSuite) TestPasswordReset_SendConfirmationLink_Se
 	s.emailClient.On("SendRegistrationConfirmLink", user.Email, user.Login,
 		mock.AnythingOfType("string")).Return(err)
 	errReturn := s.regConfirmService.SendConfirmationLink(ctx, login)
-	assert.Error(t, errReturn)
-	assert.Equal(t, err, errReturn)
+	require.Error(t, errReturn)
+	require.Equal(t, err, errReturn)
 	s.userRepository.AssertExpectations(t)
 	s.regConfirmRepo.AssertExpectations(t)
 	s.emailClient.AssertExpectations(t)
@@ -99,7 +99,7 @@ func (s *RegistrationConfirmTestSuite) TestPasswordReset_SendConfirmationLink_OK
 		mock.AnythingOfType("string")).Return(nil)
 	s.emailClient.On("IsSendRequired").Return(false)
 	errReturn := s.regConfirmService.SendConfirmationLink(ctx, login)
-	assert.NoError(t, errReturn)
+	require.NoError(t, errReturn)
 	s.userRepository.AssertExpectations(t)
 	s.regConfirmRepo.AssertExpectations(t)
 	s.emailClient.AssertExpectations(t)
@@ -112,8 +112,8 @@ func (s *RegistrationConfirmTestSuite) TestPasswordReset_VerifyConfirmationToken
 	err := errors.New("error")
 	s.regConfirmRepo.On("GetToken", ctx, token).Return(nil, err)
 	errReturn := s.regConfirmService.VerifyConfirmationToken(ctx, token)
-	assert.Error(t, errReturn)
-	assert.Equal(t, err, errReturn)
+	require.Error(t, errReturn)
+	require.Equal(t, err, errReturn)
 	s.regConfirmRepo.AssertExpectations(t)
 }
 
@@ -131,7 +131,7 @@ func (s *RegistrationConfirmTestSuite) TestPasswordReset_VerifyConfirmationToken
 	s.regConfirmRepo.On("GetToken", ctx, token).Return(returnToken, nil)
 	s.regConfirmRepo.On("DeleteToken", ctx, token).Return(nil)
 	errReturn := s.regConfirmService.VerifyConfirmationToken(ctx, token)
-	assert.Error(t, errReturn)
+	require.Error(t, errReturn)
 	s.regConfirmRepo.AssertExpectations(t)
 }
 
@@ -150,7 +150,7 @@ func (s *RegistrationConfirmTestSuite) TestPasswordReset_VerifyConfirmationToken
 	s.regConfirmRepo.On("GetToken", ctx, token).Return(returnToken, nil)
 	s.regConfirmRepo.On("DeleteToken", ctx, token).Return(err)
 	errReturn := s.regConfirmService.VerifyConfirmationToken(ctx, token)
-	assert.Error(t, errReturn)
+	require.Error(t, errReturn)
 	s.regConfirmRepo.AssertExpectations(t)
 }
 
@@ -169,8 +169,8 @@ func (s *RegistrationConfirmTestSuite) TestPasswordReset_VerifyConfirmationToken
 	s.regConfirmRepo.On("GetToken", ctx, token).Return(returnToken, nil)
 	s.userRepository.On("ConfirmRegistration", ctx, returnToken.Edges.Users.Login).Return(err)
 	errReturn := s.regConfirmService.VerifyConfirmationToken(ctx, token)
-	assert.Error(t, errReturn)
-	assert.Equal(t, err, errReturn)
+	require.Error(t, errReturn)
+	require.Equal(t, err, errReturn)
 	s.regConfirmRepo.AssertExpectations(t)
 	s.userRepository.AssertExpectations(t)
 	s.emailClient.AssertExpectations(t)
@@ -191,7 +191,7 @@ func (s *RegistrationConfirmTestSuite) TestPasswordReset_VerifyConfirmationToken
 	s.userRepository.On("ConfirmRegistration", ctx, returnToken.Edges.Users.Login).Return(nil)
 	s.regConfirmRepo.On("DeleteToken", ctx, token).Return(errors.New("error"))
 	errReturn := s.regConfirmService.VerifyConfirmationToken(ctx, token)
-	assert.NoError(t, errReturn)
+	require.NoError(t, errReturn)
 	s.regConfirmRepo.AssertExpectations(t)
 	s.userRepository.AssertExpectations(t)
 	s.emailClient.AssertExpectations(t)
@@ -212,7 +212,7 @@ func (s *RegistrationConfirmTestSuite) TestPasswordReset_VerifyConfirmationToken
 	s.userRepository.On("ConfirmRegistration", ctx, returnToken.Edges.Users.Login).Return(nil)
 	s.regConfirmRepo.On("DeleteToken", ctx, token).Return(nil)
 	errReturn := s.regConfirmService.VerifyConfirmationToken(ctx, token)
-	assert.NoError(t, errReturn)
+	require.NoError(t, errReturn)
 	s.regConfirmRepo.AssertExpectations(t)
 	s.userRepository.AssertExpectations(t)
 	s.emailClient.AssertExpectations(t)

--- a/internal/services/user_test.go
+++ b/internal/services/user_test.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/bcrypt"
@@ -47,11 +47,11 @@ func (s *UserServiceTestSuite) TestUserService_GenerateAccessToken_UserNotFound(
 
 	s.userRepository.On("GetUserByLogin", ctx, login).Return(nil, err)
 	accessToken, refreshToken, isInternalErr, errGen := s.userService.GenerateTokens(ctx, login, password)
-	assert.Error(t, errGen)
-	assert.True(t, ent.IsNotFound(errGen))
-	assert.Empty(t, accessToken)
-	assert.Empty(t, refreshToken)
-	assert.False(t, isInternalErr)
+	require.Error(t, errGen)
+	require.True(t, ent.IsNotFound(errGen))
+	require.Empty(t, accessToken)
+	require.Empty(t, refreshToken)
+	require.False(t, isInternalErr)
 	s.userRepository.AssertExpectations(t)
 }
 
@@ -65,11 +65,11 @@ func (s *UserServiceTestSuite) TestUserService_GenerateAccessToken_RepoErr() {
 
 	s.userRepository.On("GetUserByLogin", ctx, login).Return(nil, err)
 	accessToken, refreshToken, isInternalErr, errGen := s.userService.GenerateTokens(ctx, login, password)
-	assert.Error(t, errGen)
-	assert.False(t, ent.IsNotFound(errGen))
-	assert.Empty(t, accessToken)
-	assert.Empty(t, refreshToken)
-	assert.True(t, isInternalErr)
+	require.Error(t, errGen)
+	require.False(t, ent.IsNotFound(errGen))
+	require.Empty(t, accessToken)
+	require.Empty(t, refreshToken)
+	require.True(t, isInternalErr)
 	s.userRepository.AssertExpectations(t)
 }
 
@@ -86,11 +86,11 @@ func (s *UserServiceTestSuite) TestUserService_GenerateAccessToken_HashCompareEr
 
 	s.userRepository.On("GetUserByLogin", ctx, login).Return(user, nil)
 	accessToken, refreshToken, isInternalErr, errGen := s.userService.GenerateTokens(ctx, login, password)
-	assert.Error(t, errGen)
-	assert.False(t, ent.IsNotFound(errGen))
-	assert.Empty(t, accessToken)
-	assert.Empty(t, refreshToken)
-	assert.False(t, isInternalErr)
+	require.Error(t, errGen)
+	require.False(t, ent.IsNotFound(errGen))
+	require.Empty(t, accessToken)
+	require.Empty(t, refreshToken)
+	require.False(t, isInternalErr)
 	s.userRepository.AssertExpectations(t)
 }
 
@@ -125,11 +125,11 @@ func (s *UserServiceTestSuite) TestUserService_GenerateAccessToken_TokenRepoErr(
 	s.tokenRepository.On("CreateTokens", ctx, user.ID, mock.AnythingOfType("string"),
 		mock.AnythingOfType("string")).Return(err)
 	accessToken, refreshToken, isInternalErr, errGen := s.userService.GenerateTokens(ctx, login, password)
-	assert.Error(t, errGen)
-	assert.False(t, ent.IsNotFound(errGen))
-	assert.Empty(t, accessToken)
-	assert.Empty(t, refreshToken)
-	assert.True(t, isInternalErr)
+	require.Error(t, errGen)
+	require.False(t, ent.IsNotFound(errGen))
+	require.Empty(t, accessToken)
+	require.Empty(t, refreshToken)
+	require.True(t, isInternalErr)
 	s.userRepository.AssertExpectations(t)
 	s.tokenRepository.AssertExpectations(t)
 }
@@ -164,10 +164,10 @@ func (s *UserServiceTestSuite) TestUserService_GenerateAccessToken_OK() {
 	s.tokenRepository.On("CreateTokens", ctx, user.ID, mock.AnythingOfType("string"),
 		mock.AnythingOfType("string")).Return(nil)
 	accessToken, refreshToken, isInternalErr, errGen := s.userService.GenerateTokens(ctx, login, password)
-	assert.NoError(t, errGen)
-	assert.NotEmpty(t, accessToken)
-	assert.NotEmpty(t, refreshToken)
-	assert.False(t, isInternalErr)
+	require.NoError(t, errGen)
+	require.NotEmpty(t, accessToken)
+	require.NotEmpty(t, refreshToken)
+	require.False(t, isInternalErr)
 	s.userRepository.AssertExpectations(t)
 	s.tokenRepository.AssertExpectations(t)
 }

--- a/internal/utils/filename_test.go
+++ b/internal/utils/filename_test.go
@@ -4,12 +4,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateFileName(t *testing.T) {
 	f, err := GenerateFileName()
-	assert.NoError(t, err)
-	assert.Len(t, f, 32)
-	assert.Equal(t, -1, strings.LastIndex(f, "-"))
+	require.NoError(t, err)
+	require.Len(t, f, 32)
+	require.Equal(t, -1, strings.LastIndex(f, "-"))
 }

--- a/internal/utils/ordering_test.go
+++ b/internal/utils/ordering_test.go
@@ -3,24 +3,24 @@ package utils
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetOrderFunc(t *testing.T) {
 	f, err := GetOrderFunc("desc", "1")
-	assert.NoError(t, err)
-	assert.NotNil(t, f)
+	require.NoError(t, err)
+	require.NotNil(t, f)
 
 	f, err = GetOrderFunc("asc", "2")
-	assert.NoError(t, err)
-	assert.NotNil(t, f)
+	require.NoError(t, err)
+	require.NotNil(t, f)
 
 	f, err = GetOrderFunc("something", "2")
-	assert.Nil(t, f)
-	assert.ErrorContains(t, err, "wrong value for orderBy: something")
+	require.Nil(t, f)
+	require.ErrorContains(t, err, "wrong value for orderBy: something")
 }
 
 func TestIsInOrderFields(t *testing.T) {
-	assert.True(t, IsValueInList("1", []string{"1", "2", "3"}))
-	assert.False(t, IsValueInList("4", []string{"1", "2", "3"}))
+	require.True(t, IsValueInList("1", []string{"1", "2", "3"}))
+	require.False(t, IsValueInList("4", []string{"1", "2", "3"}))
 }

--- a/internal/utils/password_generator_test.go
+++ b/internal/utils/password_generator_test.go
@@ -3,32 +3,32 @@ package utils
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewPasswordGenerator_PasswordLengthTooLow(t *testing.T) {
 	generator, err := NewPasswordGenerator(1)
-	assert.Error(t, err)
-	assert.Nil(t, generator)
+	require.Error(t, err)
+	require.Nil(t, generator)
 }
 
 func TestNewPasswordGenerator_PasswordLengthTooBig(t *testing.T) {
 	generator, err := NewPasswordGenerator(33)
-	assert.Error(t, err)
-	assert.Nil(t, generator)
+	require.Error(t, err)
+	require.Nil(t, generator)
 }
 
 func TestNewPasswordGenerator_OK(t *testing.T) {
 	generator, err := NewPasswordGenerator(10)
-	assert.NoError(t, err)
-	assert.NotNil(t, generator)
+	require.NoError(t, err)
+	require.NotNil(t, generator)
 }
 
 func TestPasswordGenerator_Generate(t *testing.T) {
 	length := 10
 	generator, err := NewPasswordGenerator(length)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	password, err := generator.NewPassword()
-	assert.NoError(t, err)
-	assert.Len(t, password, length)
+	require.NoError(t, err)
+	require.Len(t, password, length)
 }

--- a/internal/utils/request_params_test.go
+++ b/internal/utils/request_params_test.go
@@ -3,12 +3,12 @@ package utils
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetParamInt(t *testing.T) {
 	a := 5
-	assert.Equal(t, 5, GetValueByPointerOrDefaultValue(&a, 6))
+	require.Equal(t, 5, GetValueByPointerOrDefaultValue(&a, 6))
 
-	assert.Equal(t, 6, GetValueByPointerOrDefaultValue(nil, 6))
+	require.Equal(t, 6, GetValueByPointerOrDefaultValue(nil, 6))
 }


### PR DESCRIPTION
All `assert` replaced with `require` in unit tests. Reason - `assert` doesn't stop test, so even after failed assertion test continues, consumes more time. 

https://jira.epam.com/jira/browse/EPMUII-6554