### PR TITLE
Limits for 'name' and 'description' fields of equipment

### DIFF
--- a/internal/integration-tests/common/utils.go
+++ b/internal/integration-tests/common/utils.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math/rand"
 	"net/http"
+	"strings"
 	"time"
 
 	httptransport "github.com/go-openapi/runtime/client"
@@ -141,4 +143,18 @@ func NewAPIClient(host string, schemes []string) (*client.Be, error) {
 	// https://github.com/go-swagger/go-swagger/issues/1244
 	be.Consumers["image/jpg"] = runtime.ByteStreamConsumer()
 	return client.New(be, nil), nil
+}
+
+func GenerateRandomString(length int) (string, error) {
+	rand.Seed(time.Now().UnixNano())
+	charset := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	var builder strings.Builder
+	for i := 0; i < length; i++ {
+		err := builder.WriteByte(charset[rand.Intn(len(charset))])
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return builder.String(), nil
 }

--- a/internal/integration-tests/equipment/integration_test.go
+++ b/internal/integration-tests/equipment/integration_test.go
@@ -73,6 +73,51 @@ func TestIntegration_CreateEquipment(t *testing.T) {
 		assert.Equal(t, model.Title, res.Payload.Title)
 	})
 
+	t.Run("Create Equipment failed: 422 status code error, description and name fields have a number of characters greater than the limit ",
+		func(t *testing.T) {
+			params := equipment.NewCreateNewEquipmentParamsWithContext(ctx)
+			model, err := setParameters(ctx, client, auth)
+			require.NoError(t, err)
+
+			// name field tests:
+			// max length of name field: 100 characters
+			name, err := utils.GenerateRandomString(101)
+			require.NoError(t, err)
+			model.Name = &name
+			params.NewEquipment = model
+
+			_, err = client.Equipment.CreateNewEquipment(params, auth)
+			require.Error(t, err)
+
+			name, err = utils.GenerateRandomString(99)
+			require.NoError(t, err)
+			model.Name = &name
+			params.NewEquipment = model
+
+			_, err = client.Equipment.CreateNewEquipment(params, auth)
+			require.NoError(t, err)
+
+			// description field tests:
+			// max length of description field: 255 characters
+			model, err = setParameters(ctx, client, auth)
+			require.NoError(t, err)
+			description, err := utils.GenerateRandomString(256)
+			require.NoError(t, err)
+			model.Description = &description
+
+			params.NewEquipment = model
+			_, err = client.Equipment.CreateNewEquipment(params, auth)
+			require.Error(t, err)
+
+			description, err = utils.GenerateRandomString(254)
+			require.NoError(t, err)
+			model.Description = &description
+			params.NewEquipment = model
+
+			_, err = client.Equipment.CreateNewEquipment(params, auth)
+			require.NoError(t, err)
+		})
+
 	t.Run("Create Equipment failed: foreign key constraint error", func(t *testing.T) {
 		params := equipment.NewCreateNewEquipmentParamsWithContext(ctx)
 		model, err := setParameters(ctx, client, auth)

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2611,10 +2611,12 @@ definitions:
       name:
         type: string
         example: "Dog harness 3000"
+        maxLength: 100
       nameSubstring:
         type: string
         example: "box"
         description: "Substring of name for case in-sensitive search"
+        maxLength: 255
       title:
         type: string
         example: "клетка midwest icrate 1"


### PR DESCRIPTION
Added max length for "name" field: 100 symbols.
Added max lentght for "description" field: 255 symbols.
Integration tests for boundary values.

This task require 500 symbols for "description" field, but field in database can receive only 255 symbols. So max symbols for "description" field will be 255.

[Feature-7602](https://jira.epam.com/jira/browse/EPMUII-7602)