### PR TITLE
Remove unnecessary fields from some models.

### DIFF
--- a/internal/handlers/equipment.go
+++ b/internal/handlers/equipment.go
@@ -235,8 +235,7 @@ func mapEquipmentResponse(eq *ent.Equipment) (*models.EquipmentResponse, error) 
 
 	petKinds := make([]*models.PetKind, len(eq.Edges.PetKinds))
 	for i, petKindEdge := range eq.Edges.PetKinds {
-		petKindID := int64(petKindEdge.ID)
-		petKind := models.PetKind{ID: petKindID, Name: &petKindEdge.Name}
+		petKind := models.PetKind{Name: &petKindEdge.Name}
 		petKinds[i] = &petKind
 	}
 

--- a/internal/handlers/equipment_status_name_test.go
+++ b/internal/handlers/equipment_status_name_test.go
@@ -75,7 +75,7 @@ func (s *EquipmentStatusNameTestSuite) TestStatus_PostStatus_RepoErr() {
 	statusName := "statusName"
 	data := eqStatusName.PostEquipmentStatusNameParams{
 		HTTPRequest: &request,
-		Name: &models.EquipmentStatusName{
+		Name: &models.NewEquipmentStatusName{
 			Name: &statusName,
 		},
 	}
@@ -101,7 +101,7 @@ func (s *EquipmentStatusNameTestSuite) TestStatus_PostStatus_OK() {
 	statusName := "statusName"
 	data := eqStatusName.PostEquipmentStatusNameParams{
 		HTTPRequest: &request,
-		Name: &models.EquipmentStatusName{
+		Name: &models.NewEquipmentStatusName{
 			Name: &statusName,
 		},
 	}

--- a/internal/handlers/order.go
+++ b/internal/handlers/order.go
@@ -87,7 +87,6 @@ func mapOrder(o *ent.Order, log *zap.Logger) (*models.Order, error) {
 		if eq.Edges.PetKinds != nil {
 			for _, petKind := range eq.Edges.PetKinds {
 				j := &models.PetKind{
-					ID:   int64(petKind.ID),
 					Name: &petKind.Name,
 				}
 				petKinds = append(petKinds, j)

--- a/internal/handlers/pet_kind_test.go
+++ b/internal/handlers/pet_kind_test.go
@@ -376,6 +376,7 @@ func (s *PetKindTestSuite) TestPetKind_EditPetKindFunc_OK() {
 	ctx := request.Context()
 	name := "test pet kind name"
 	handlerFunc := s.petKind.UpdatePetKindByID(s.petKindRepo)
+	id := 0
 	petKindToUpdate := &models.PetKind{
 		Name: &name,
 	}
@@ -386,7 +387,7 @@ func (s *PetKindTestSuite) TestPetKind_EditPetKindFunc_OK() {
 
 	petKindToReturn := ValidPetKind(t)
 
-	s.petKindRepo.On("Update", ctx, int(petKindToUpdate.ID), petKindToUpdate).Return(petKindToReturn, nil)
+	s.petKindRepo.On("Update", ctx, id, petKindToUpdate).Return(petKindToReturn, nil)
 
 	access := "dummy access"
 	resp := handlerFunc(data, access)
@@ -411,6 +412,7 @@ func (s *PetKindTestSuite) TestPetKind_EditPetKindFunc_ErrRespNil() {
 	request := http.Request{}
 	ctx := request.Context()
 	name := "test pet kind name"
+	id := 0
 	handlerFunc := s.petKind.UpdatePetKindByID(s.petKindRepo)
 	petKindToUpdate := &models.PetKind{
 		Name: &name,
@@ -419,7 +421,7 @@ func (s *PetKindTestSuite) TestPetKind_EditPetKindFunc_ErrRespNil() {
 		HTTPRequest: &request,
 		EditPetKind: petKindToUpdate,
 	}
-	s.petKindRepo.On("Update", ctx, int(petKindToUpdate.ID), petKindToUpdate).Return(nil, nil)
+	s.petKindRepo.On("Update", ctx, id, petKindToUpdate).Return(nil, nil)
 
 	access := "dummy access"
 	resp := handlerFunc(data, access)
@@ -435,6 +437,7 @@ func (s *PetKindTestSuite) TestPetKind_EditPetKindFunc_ErrFromRepo() {
 	request := http.Request{}
 	ctx := request.Context()
 	name := "test pet kind name"
+	id := 0
 	handlerFunc := s.petKind.UpdatePetKindByID(s.petKindRepo)
 	petKindToUpdate := &models.PetKind{
 		Name: &name,
@@ -444,7 +447,7 @@ func (s *PetKindTestSuite) TestPetKind_EditPetKindFunc_ErrFromRepo() {
 		EditPetKind: petKindToUpdate,
 	}
 	err := errors.New("test")
-	s.petKindRepo.On("Update", ctx, int(petKindToUpdate.ID), petKindToUpdate).Return(nil, err)
+	s.petKindRepo.On("Update", ctx, id, petKindToUpdate).Return(nil, err)
 
 	access := "dummy access"
 	resp := handlerFunc(data, access)

--- a/internal/handlers/pet_size.go
+++ b/internal/handlers/pet_size.go
@@ -111,8 +111,9 @@ func (ps PetSize) GetAllPetSizeFunc(repository domain.PetSizeRepository) pet_siz
 		}
 		listOfPetSize := models.ListOfPetSizes{}
 		for _, v := range petSizes {
-			listOfPetSize = append(listOfPetSize, &models.PetSize{
-				ID:          int64(v.ID),
+			id := int64(v.ID)
+			listOfPetSize = append(listOfPetSize, &models.PetSizeResponse{
+				ID:          &id,
 				Name:        &v.Name,
 				Size:        &v.Size,
 				IsUniversal: v.IsUniversal,

--- a/internal/handlers/pet_size_test.go
+++ b/internal/handlers/pet_size_test.go
@@ -437,6 +437,7 @@ func (s *PetSizeTestSuite) TestPetSize_EditPetSizeFunc_OK() {
 	ctx := request.Context()
 	name := "test pet name"
 	size := "test size"
+	id := 0
 	handlerFunc := s.petSize.UpdatePetSizeByID(s.petSizeRepo)
 	petSizeToUpdate := &models.PetSize{
 		Name: &name,
@@ -449,7 +450,7 @@ func (s *PetSizeTestSuite) TestPetSize_EditPetSizeFunc_OK() {
 
 	petSizeToReturn := ValidPetSize(t)
 
-	s.petSizeRepo.On("Update", ctx, int(petSizeToUpdate.ID), petSizeToUpdate).Return(petSizeToReturn, nil)
+	s.petSizeRepo.On("Update", ctx, id, petSizeToUpdate).Return(petSizeToReturn, nil)
 
 	access := "dummy access"
 	resp := handlerFunc(data, access)
@@ -475,6 +476,7 @@ func (s *PetSizeTestSuite) TestPetSize_EditPetSizeFunc_ErrRespNil() {
 	ctx := request.Context()
 	name := "test pet name"
 	size := "test size"
+	id := 0
 	handlerFunc := s.petSize.UpdatePetSizeByID(s.petSizeRepo)
 	petSizeToUpdate := &models.PetSize{
 		Name: &name,
@@ -484,7 +486,7 @@ func (s *PetSizeTestSuite) TestPetSize_EditPetSizeFunc_ErrRespNil() {
 		HTTPRequest: &request,
 		EditPetSize: petSizeToUpdate,
 	}
-	s.petSizeRepo.On("Update", ctx, int(petSizeToUpdate.ID), petSizeToUpdate).Return(nil, nil)
+	s.petSizeRepo.On("Update", ctx, id, petSizeToUpdate).Return(nil, nil)
 
 	access := "dummy access"
 	resp := handlerFunc(data, access)
@@ -502,6 +504,7 @@ func (s *PetSizeTestSuite) TestPetSize_EditPetSizeFunc_ErrFromRepo() {
 	name := "test pet name"
 	size := "test size"
 	handlerFunc := s.petSize.UpdatePetSizeByID(s.petSizeRepo)
+	id := 0
 	petSizeToUpdate := &models.PetSize{
 		Name: &name,
 		Size: &size,
@@ -511,7 +514,7 @@ func (s *PetSizeTestSuite) TestPetSize_EditPetSizeFunc_ErrFromRepo() {
 		EditPetSize: petSizeToUpdate,
 	}
 	err := errors.New("test")
-	s.petSizeRepo.On("Update", ctx, int(petSizeToUpdate.ID), petSizeToUpdate).Return(nil, err)
+	s.petSizeRepo.On("Update", ctx, id, petSizeToUpdate).Return(nil, err)
 
 	access := "dummy access"
 	resp := handlerFunc(data, access)

--- a/internal/integration-tests/equipment/integration_test.go
+++ b/internal/integration-tests/equipment/integration_test.go
@@ -63,7 +63,6 @@ func TestIntegration_CreateEquipment(t *testing.T) {
 		//assert.Equal(t, location, *res.Payload.Location)
 		assert.Equal(t, model.MaximumDays, res.Payload.MaximumDays)
 		assert.Equal(t, model.Name, res.Payload.Name)
-		assert.Equal(t, model.PetKinds[0], res.Payload.PetKinds[0].ID)
 		assert.Equal(t, model.PetSize, res.Payload.PetSize)
 		assert.Contains(t, *res.Payload.PhotoID, *model.PhotoID)
 		assert.Equal(t, model.ReceiptDate, res.Payload.ReceiptDate)
@@ -240,7 +239,6 @@ func TestIntegration_GetEquipment(t *testing.T) {
 		assert.Equal(t, model.MaximumDays, res.Payload.MaximumDays)
 		assert.Equal(t, model.Name, res.Payload.Name)
 		//assert.Equal(t, model.Location, res.Payload.Location)
-		assert.Equal(t, model.PetKinds[0], res.Payload.PetKinds[0].ID)
 		assert.Equal(t, model.PetSize, res.Payload.PetSize)
 		assert.Contains(t, *res.Payload.PhotoID, *model.PhotoID)
 		assert.Equal(t, model.ReceiptDate, res.Payload.ReceiptDate)
@@ -557,7 +555,7 @@ func setParameters(ctx context.Context, client *client.Be, auth runtime.ClientAu
 		Name:             &catName,
 		NameSubstring:    "box",
 		PetKinds:         []int64{*cats.Payload.ID},
-		PetSize:          &petSize.Payload[0].ID,
+		PetSize:          petSize.Payload[0].ID,
 		PhotoID:          photo.Payload.Data.ID,
 		ReceiptDate:      &rDate,
 		Status:           &status.Payload.Data.ID,

--- a/internal/integration-tests/equipmentstatusname/equipment_status_name_test.go
+++ b/internal/integration-tests/equipmentstatusname/equipment_status_name_test.go
@@ -131,7 +131,7 @@ func TestIntegration_PostStatus(t *testing.T) {
 	t.Run("Post Status successfully", func(t *testing.T) {
 		want := "test status"
 		params := eqStatusName.NewPostEquipmentStatusNameParamsWithContext(ctx)
-		params.Name = &models.EquipmentStatusName{
+		params.Name = &models.NewEquipmentStatusName{
 			Name: &want,
 		}
 		res, err := client.EquipmentStatusName.PostEquipmentStatusName(params, utils.AuthInfoFunc(token))
@@ -144,7 +144,7 @@ func TestIntegration_PostStatus(t *testing.T) {
 	t.Run("Post Status failed: post same status again", func(t *testing.T) {
 		wantSameStatus := "test status"
 		params := eqStatusName.NewPostEquipmentStatusNameParamsWithContext(ctx)
-		params.Name = &models.EquipmentStatusName{
+		params.Name = &models.NewEquipmentStatusName{
 			Name: &wantSameStatus,
 		}
 		_, gotErr := client.EquipmentStatusName.PostEquipmentStatusName(params, utils.AuthInfoFunc(token))
@@ -158,7 +158,7 @@ func TestIntegration_PostStatus(t *testing.T) {
 	t.Run("Post Status failed: invalid auth", func(t *testing.T) {
 		want := "new status"
 		params := eqStatusName.NewPostEquipmentStatusNameParamsWithContext(ctx)
-		params.Name = &models.EquipmentStatusName{
+		params.Name = &models.NewEquipmentStatusName{
 			Name: &want,
 		}
 		dummyToken := utils.TokenNotExist

--- a/internal/integration-tests/orders/order_test.go
+++ b/internal/integration-tests/orders/order_test.go
@@ -471,7 +471,7 @@ func setParameters(ctx context.Context, client *client.Be, auth runtime.ClientAu
 		Name:             &catName,
 		NameSubstring:    "box",
 		PetKinds:         []int64{*cats.Payload.ID},
-		PetSize:          &petSize.Payload[0].ID,
+		PetSize:          petSize.Payload[0].ID,
 		PhotoID:          photo.Payload.Data.ID,
 		ReceiptDate:      &rDate,
 		Status:           &status.Payload.Data.ID,

--- a/internal/integration-tests/petsize/get_integration_test.go
+++ b/internal/integration-tests/petsize/get_integration_test.go
@@ -118,7 +118,7 @@ func getSizeIDByName(ctx context.Context, client *client.Be, token *string, petS
 
 	for _, petSize := range allPetSize.GetPayload() {
 		if *petSize.Name == petSizeName {
-			petSizeID = &petSize.ID
+			petSizeID = petSize.ID
 		}
 	}
 	return petSizeID, nil

--- a/internal/repositories/subcategory_test.go
+++ b/internal/repositories/subcategory_test.go
@@ -96,7 +96,6 @@ func (s *subcategoryRepositorySuite) TestSubcategoryRepository_CreateSubcategory
 	maxReservationUnits := int64(1)
 	categoryID := int64(s.category.ID + 10)
 	newSubcategory := models.NewSubcategory{
-		Category:            &categoryID,
 		MaxReservationTime:  &maxReservationTime,
 		MaxReservationUnits: &maxReservationUnits,
 		Name:                &name,
@@ -118,7 +117,6 @@ func (s *subcategoryRepositorySuite) TestSubcategoryRepository_CreateSubcategory
 	maxReservationUnits := int64(1)
 	categoryID := int64(s.category.ID)
 	newSubcategory := models.NewSubcategory{
-		Category:            &categoryID,
 		MaxReservationTime:  &maxReservationTime,
 		MaxReservationUnits: &maxReservationUnits,
 		Name:                &name,

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -497,7 +497,7 @@ paths:
           description: Status Name for equipment
           required: true
           schema:
-            $ref: "#/definitions/EquipmentStatusName"
+            $ref: "#/definitions/NewEquipmentStatusName"
       responses:
         201:
           description: Status name for equipment has been created
@@ -666,10 +666,6 @@ paths:
           schema:
             type: string
           description: Not Found
-        default:
-          description: Unexpected error.
-          schema:
-            $ref: "#/definitions/Error"
   /equipment/categories/{categoryId}:
     parameters:
       - name: categoryId
@@ -1815,8 +1811,6 @@ definitions:
     required:
       - name
     properties:
-      id:
-        type: integer
       name:
         type: string
   Error:
@@ -1864,7 +1858,7 @@ definitions:
             description: Surname of user.
           patronymic:
             type: string
-            description: Patronymyc data.
+            description: Patronymic data.
           passport_series:
             type: string
           passport_number:
@@ -1990,7 +1984,7 @@ definitions:
         description: Surname of user.
       patronymic:
         type: string
-        description: Patronymyc data.
+        description: Patronymic data.
       passport_series:
         type: string
       passport_number:
@@ -2193,6 +2187,13 @@ definitions:
     properties:
       id:
         type: integer
+      name:
+        type: string
+  NewEquipmentStatusName:
+    type: object
+    required:
+      - name
+    properties:
       name:
         type: string
   ListEquipmentStatusNames:
@@ -2512,14 +2513,11 @@ definitions:
     type: object
     required:
       - name
-      - category
       - max_reservation_time
       - max_reservation_units
     properties:
       name:
         type: string
-      category:
-        type: integer
       max_reservation_time:
         type: integer
       max_reservation_units:
@@ -2531,8 +2529,6 @@ definitions:
       - name
       - size
     properties:
-      id:
-        type: integer
       name:
         type: string
         example: "big"
@@ -2545,7 +2541,7 @@ definitions:
   ListOfPetSizes:
     type: array
     items:
-      $ref: "#/definitions/PetSize"
+      $ref: "#/definitions/PetSizeResponse"
   PetSizeResponse:
     type: object
     required:


### PR DESCRIPTION
Remove duplication of the "id" from the equipment subcategory.
Remove unnecessary "id" fields from the pet kind, pet size, and equipment status POST and PUT requests.