### PR TITLE
Add unauthorized error docs to all secured endpoints

### DIFF
--- a/cmd/swagger/setup.go
+++ b/cmd/swagger/setup.go
@@ -6,6 +6,7 @@ import (
 	"go.uber.org/zap"
 
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/config"
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/docs"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/email"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi"
@@ -25,7 +26,7 @@ func SetupAPI(entClient *ent.Client, lg *zap.Logger, conf *config.AppConfig) (*r
 		return nil, nil, err
 	}
 
-	swaggerSpec, err := loads.Analyzed(restapi.SwaggerJSON, "")
+	swaggerSpec, err := loadSwaggerSpec()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -87,4 +88,24 @@ func SetupAPI(entClient *ent.Client, lg *zap.Logger, conf *config.AppConfig) (*r
 	return server,
 		overdue.NewOverdueCheckup(orderStatusRepo, orderFilterRepo, equipmentStatusRepo, lg),
 		nil
+}
+
+func loadSwaggerSpec() (*loads.Document, error) {
+	swaggerSpec, err := loads.Analyzed(restapi.SwaggerJSON, "")
+	if err != nil {
+		return nil, err
+	}
+	// adding unauthorized error to all endpoints
+	code, unauthorizedErr := docs.UnauthorizedError()
+	docs.AddErrorToSecuredEndpoints(code, unauthorizedErr, swaggerSpec)
+	raw, err := swaggerSpec.Spec().MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	swaggerSpec, err = loads.Analyzed(raw, "")
+	if err != nil {
+		return nil, err
+	}
+	return swaggerSpec, nil
 }

--- a/internal/docs/middleware.go
+++ b/internal/docs/middleware.go
@@ -1,0 +1,67 @@
+package docs
+
+import (
+	"net/http"
+
+	"github.com/go-openapi/loads"
+	"github.com/go-openapi/spec"
+)
+
+const SwaggerErrRef = "#/definitions/SwaggerError"
+
+// AddErrorCodeToAllEndpoints adds the error code documentation to all swagger endpoints.
+func AddErrorToSecuredEndpoints(code int, response spec.Response, spec *loads.Document) {
+	for path, pathItem := range spec.Spec().Paths.Paths {
+		operations := GetSecuredOperation(&pathItem.PathItemProps)
+		for _, operation := range operations {
+			operation.Responses.StatusCodeResponses[code] = response
+		}
+		spec.Spec().Paths.Paths[path] = pathItem
+	}
+}
+
+func GetSecuredOperation(pathItemProps *spec.PathItemProps) []*spec.Operation {
+	var operations []*spec.Operation
+	if pathItemProps.Get != nil && pathItemProps.Get.Security != nil {
+		operations = append(operations, pathItemProps.Get)
+	}
+	if pathItemProps.Put != nil && pathItemProps.Put.Security != nil {
+		operations = append(operations, pathItemProps.Put)
+	}
+	if pathItemProps.Post != nil && pathItemProps.Post.Security != nil {
+		operations = append(operations, pathItemProps.Post)
+	}
+	if pathItemProps.Delete != nil && pathItemProps.Delete.Security != nil {
+		operations = append(operations, pathItemProps.Delete)
+	}
+	if pathItemProps.Options != nil && pathItemProps.Options.Security != nil {
+		operations = append(operations, pathItemProps.Options)
+	}
+	if pathItemProps.Head != nil && pathItemProps.Head.Security != nil {
+		operations = append(operations, pathItemProps.Head)
+	}
+	if pathItemProps.Patch != nil && pathItemProps.Patch.Security != nil {
+		operations = append(operations, pathItemProps.Patch)
+	}
+	return operations
+}
+
+// UnauthorizedError returns the error code and response for unauthorized error.
+func UnauthorizedError() (int, spec.Response) {
+	return http.StatusUnauthorized, spec.Response{
+		// Keep in mind that this response will be used by frontend team.
+		// So, if you change it, you should notify them.
+		ResponseProps: spec.ResponseProps{
+			Description: "Unauthorized",
+			Schema:      SwaggerErrorReference(),
+		},
+	}
+}
+
+func SwaggerErrorReference() *spec.Schema {
+	return &spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			Ref: spec.MustCreateRef(SwaggerErrRef),
+		},
+	}
+}

--- a/internal/integration-tests/activeareas/integration_test.go
+++ b/internal/integration-tests/activeareas/integration_test.go
@@ -59,7 +59,7 @@ func TestIntegration_GetActiveAreas(t *testing.T) {
 		_, err = client.ActiveAreas.GetAllActiveAreas(params, utils.AuthInfoFunc(&dummyToken))
 		require.Error(t, err)
 
-		errExp := active_areas.NewGetAllActiveAreasDefault(http.StatusInternalServerError)
+		errExp := active_areas.NewGetAllActiveAreasDefault(http.StatusUnauthorized)
 		errExp.Payload = &models.Error{
 			Data: nil,
 		}

--- a/internal/integration-tests/category/category_test.go
+++ b/internal/integration-tests/category/category_test.go
@@ -106,7 +106,7 @@ func TestIntegration_CreateCategory(t *testing.T) {
 		_, gotErr := client.Categories.CreateNewCategory(categories.NewCreateNewCategoryParamsWithContext(ctx).WithNewCategory(modelCategory), utils.AuthInfoFunc(&token))
 		require.Error(t, gotErr)
 
-		wantErr := categories.NewCreateNewCategoryDefault(http.StatusInternalServerError)
+		wantErr := categories.NewCreateNewCategoryDefault(http.StatusUnauthorized)
 		wantErr.Payload = &models.Error{Data: nil}
 		assert.Equal(t, wantErr, gotErr)
 	})
@@ -193,7 +193,7 @@ func TestIntegration_GetCategoryByID(t *testing.T) {
 		_, gotErr := client.Categories.GetCategoryByID(categories.NewGetCategoryByIDParamsWithContext(ctx).WithCategoryID(1), utils.AuthInfoFunc(&token))
 		require.Error(t, gotErr)
 
-		wantErr := categories.NewGetCategoryByIDDefault(http.StatusInternalServerError)
+		wantErr := categories.NewGetCategoryByIDDefault(http.StatusUnauthorized)
 		wantErr.Payload = &models.Error{Data: nil}
 		assert.Equal(t, wantErr, gotErr)
 	})
@@ -297,7 +297,7 @@ func TestIntegration_EditCategory(t *testing.T) {
 			WithCategoryID(*newCategory.Payload.Data.ID).WithUpdateCategory(updateCategory), utils.AuthInfoFunc(&token))
 		require.Error(t, gotErr)
 
-		wantErr := categories.NewUpdateCategoryDefault(http.StatusInternalServerError)
+		wantErr := categories.NewUpdateCategoryDefault(http.StatusUnauthorized)
 		wantErr.Payload = &models.Error{Data: nil}
 		assert.Equal(t, wantErr, gotErr)
 	})
@@ -340,7 +340,7 @@ func TestIntegration_DeleteCategory(t *testing.T) {
 		_, gotErr := client.Categories.DeleteCategory(categories.NewDeleteCategoryParamsWithContext(ctx).WithCategoryID(1), utils.AuthInfoFunc(&token))
 		require.Error(t, gotErr)
 
-		wantErr := categories.NewDeleteCategoryDefault(http.StatusInternalServerError)
+		wantErr := categories.NewDeleteCategoryDefault(http.StatusUnauthorized)
 		wantErr.Payload = &models.Error{Data: nil}
 		assert.Equal(t, wantErr, gotErr)
 	})

--- a/internal/integration-tests/equipment/integration_test.go
+++ b/internal/integration-tests/equipment/integration_test.go
@@ -2,6 +2,7 @@ package equipment
 
 import (
 	"context"
+	"net/http"
 	"os"
 	"testing"
 
@@ -147,7 +148,7 @@ func TestIntegration_CreateEquipment(t *testing.T) {
 		_, gotErr := client.Equipment.CreateNewEquipment(params, utils.AuthInfoFunc(&token))
 		require.Error(t, gotErr)
 
-		wantErr := equipment.NewCreateNewEquipmentDefault(500)
+		wantErr := equipment.NewCreateNewEquipmentDefault(http.StatusUnauthorized)
 		wantErr.Payload = &models.Error{Data: nil}
 		assert.Equal(t, wantErr, gotErr)
 	})
@@ -188,7 +189,7 @@ func TestIntegration_GetAllEquipment(t *testing.T) {
 		_, gotErr := client.Equipment.GetAllEquipment(params, utils.AuthInfoFunc(&token))
 		require.Error(t, gotErr)
 
-		wantErr := equipment.NewGetAllEquipmentDefault(500)
+		wantErr := equipment.NewGetAllEquipmentDefault(http.StatusUnauthorized)
 		wantErr.Payload = &models.Error{Data: nil}
 		assert.Equal(t, wantErr, gotErr)
 	})
@@ -270,7 +271,7 @@ func TestIntegration_GetEquipment(t *testing.T) {
 		_, gotErr := client.Equipment.GetEquipment(params, utils.AuthInfoFunc(&token))
 		require.Error(t, gotErr)
 
-		wantErr := equipment.NewGetEquipmentDefault(500)
+		wantErr := equipment.NewGetEquipmentDefault(http.StatusUnauthorized)
 		wantErr.Payload = &models.Error{Data: nil}
 		assert.Equal(t, wantErr, gotErr)
 	})
@@ -338,7 +339,7 @@ func TestIntegration_FindEquipment(t *testing.T) {
 		_, gotErr := client.Equipment.FindEquipment(params, utils.AuthInfoFunc(&token))
 		require.Error(t, gotErr)
 
-		wantErr := equipment.NewFindEquipmentDefault(500)
+		wantErr := equipment.NewFindEquipmentDefault(http.StatusUnauthorized)
 		wantErr.Payload = &models.Error{Data: nil}
 		assert.Equal(t, wantErr, gotErr)
 	})
@@ -415,7 +416,7 @@ func TestIntegration_EditEquipment(t *testing.T) {
 		_, gotErr := client.Equipment.EditEquipment(params, utils.AuthInfoFunc(&token))
 		require.Error(t, gotErr)
 
-		wantErr := equipment.NewEditEquipmentDefault(500)
+		wantErr := equipment.NewEditEquipmentDefault(http.StatusUnauthorized)
 		wantErr.Payload = &models.Error{Data: nil}
 		assert.Equal(t, wantErr, gotErr)
 	})
@@ -478,7 +479,7 @@ func TestIntegration_DeleteEquipment(t *testing.T) {
 		_, gotErr := client.Equipment.DeleteEquipment(params, utils.AuthInfoFunc(&token))
 		require.Error(t, gotErr)
 
-		wantErr := equipment.NewDeleteEquipmentDefault(500)
+		wantErr := equipment.NewDeleteEquipmentDefault(http.StatusUnauthorized)
 		wantErr.Payload = &models.Error{Data: nil}
 		assert.Equal(t, wantErr, gotErr)
 	})

--- a/internal/integration-tests/equipmentstatusname/equipment_status_name_test.go
+++ b/internal/integration-tests/equipmentstatusname/equipment_status_name_test.go
@@ -2,6 +2,7 @@ package equipmentstatusname
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,7 +47,7 @@ func TestIntegration_GetStatuses(t *testing.T) {
 		_, gotErr := client.EquipmentStatusName.ListEquipmentStatusNames(params, utils.AuthInfoFunc(&dummyToken))
 		require.Error(t, gotErr)
 
-		wantErr := eqStatusName.NewListEquipmentStatusNamesDefault(500)
+		wantErr := eqStatusName.NewListEquipmentStatusNamesDefault(http.StatusUnauthorized)
 		wantErr.Payload = &models.Error{Data: nil}
 		assert.Equal(t, wantErr, gotErr)
 	})
@@ -103,7 +104,7 @@ func TestIntegration_GetStatus(t *testing.T) {
 		_, gotErr := client.EquipmentStatusName.GetEquipmentStatusName(params, utils.AuthInfoFunc(&dummyToken))
 		require.Error(t, gotErr)
 
-		wantErr := eqStatusName.NewGetEquipmentStatusNameDefault(500)
+		wantErr := eqStatusName.NewGetEquipmentStatusNameDefault(http.StatusUnauthorized)
 		wantErr.Payload = &models.Error{Data: nil}
 		assert.Equal(t, wantErr, gotErr)
 	})
@@ -165,7 +166,7 @@ func TestIntegration_PostStatus(t *testing.T) {
 		_, gotErr := client.EquipmentStatusName.PostEquipmentStatusName(params, utils.AuthInfoFunc(&dummyToken))
 		require.Error(t, gotErr)
 
-		wantErr := eqStatusName.NewPostEquipmentStatusNameDefault(500)
+		wantErr := eqStatusName.NewPostEquipmentStatusNameDefault(http.StatusUnauthorized)
 		wantErr.Payload = &models.Error{Data: nil}
 		assert.Equal(t, wantErr, gotErr)
 	})
@@ -232,7 +233,7 @@ func TestIntegration_DeleteStatus(t *testing.T) {
 		_, gotErr := client.EquipmentStatusName.DeleteEquipmentStatusName(params, utils.AuthInfoFunc(&dummyToken))
 		require.Error(t, gotErr)
 
-		wantErr := eqStatusName.NewDeleteEquipmentStatusNameDefault(500)
+		wantErr := eqStatusName.NewDeleteEquipmentStatusNameDefault(http.StatusUnauthorized)
 		wantErr.Payload = &models.Error{Data: nil}
 		assert.Equal(t, wantErr, gotErr)
 	})

--- a/internal/integration-tests/orders/order_test.go
+++ b/internal/integration-tests/orders/order_test.go
@@ -80,7 +80,7 @@ func TestIntegration_CreateOrder(t *testing.T) {
 		_, gotErr := client.Orders.CreateOrder(params, common.AuthInfoFunc(&incorrectToken))
 		require.Error(t, gotErr)
 
-		wantErr := orders.NewCreateOrderDefault(http.StatusInternalServerError)
+		wantErr := orders.NewCreateOrderDefault(http.StatusUnauthorized)
 		wantErr.Payload = &models.Error{Data: nil}
 		assert.Equal(t, wantErr, gotErr)
 	})
@@ -295,7 +295,7 @@ func TestIntegration_GetAllOrders(t *testing.T) {
 		_, gotErr := client.Orders.GetAllOrders(params, common.AuthInfoFunc(&token))
 		require.Error(t, gotErr)
 
-		wantErr := orders.NewGetAllOrdersDefault(http.StatusInternalServerError)
+		wantErr := orders.NewGetAllOrdersDefault(http.StatusUnauthorized)
 		wantErr.Payload = &models.Error{Data: nil}
 		assert.Equal(t, wantErr, gotErr)
 	})

--- a/internal/integration-tests/petkind/create_integration_test.go
+++ b/internal/integration-tests/petkind/create_integration_test.go
@@ -88,7 +88,7 @@ func TestIntegration_PetKind(t *testing.T) {
 		_, err = client.PetKind.CreateNewPetKind(params, utils.AuthInfoFunc(&dummyToken))
 		require.Error(t, err)
 
-		errExp := pet_kind.NewCreateNewPetKindDefault(http.StatusInternalServerError)
+		errExp := pet_kind.NewCreateNewPetKindDefault(http.StatusUnauthorized)
 		errExp.Payload = &models.Error{
 			Data: nil,
 		}

--- a/internal/integration-tests/petsize/create_integration_test.go
+++ b/internal/integration-tests/petsize/create_integration_test.go
@@ -94,7 +94,7 @@ func TestIntegration_PetSize(t *testing.T) {
 		_, err = client.PetSize.CreateNewPetSize(params, utils.AuthInfoFunc(&dummyToken))
 		require.Error(t, err)
 
-		errExp := pet_size.NewCreateNewPetSizeDefault(http.StatusInternalServerError)
+		errExp := pet_size.NewCreateNewPetSizeDefault(http.StatusUnauthorized)
 		errExp.Payload = &models.Error{
 			Data: nil,
 		}

--- a/internal/integration-tests/photos/integration_test.go
+++ b/internal/integration-tests/photos/integration_test.go
@@ -140,7 +140,7 @@ func TestIntegration_PhotosUpload(t *testing.T) {
 			common.AuthInfoFunc(&token))
 		require.Error(t, gotErr)
 
-		wantErr := photos.NewCreateNewPhotoDefault(http.StatusInternalServerError)
+		wantErr := photos.NewCreateNewPhotoDefault(http.StatusUnauthorized)
 		wantErr.Payload = &models.Error{Data: nil}
 		assert.Equal(t, wantErr, gotErr)
 		f.Close()
@@ -170,7 +170,7 @@ func TestIntegration_DeletePhoto(t *testing.T) {
 
 		require.Error(t, gotErr)
 
-		wantErr := photos.NewDeletePhotoDefault(http.StatusInternalServerError)
+		wantErr := photos.NewDeletePhotoDefault(http.StatusUnauthorized)
 		wantErr.Payload = &models.Error{Data: nil}
 		assert.Equal(t, wantErr, gotErr)
 	})
@@ -267,7 +267,7 @@ func TestIntegration_PhotosDownload(t *testing.T) {
 			common.AuthInfoFunc(&token), io.Discard)
 		require.Error(t, gotErr)
 
-		wantErr := photos.NewDownloadPhotoDefault(http.StatusInternalServerError)
+		wantErr := photos.NewDownloadPhotoDefault(http.StatusUnauthorized)
 		wantErr.Payload = &models.Error{Data: nil}
 		assert.Equal(t, wantErr, gotErr)
 		f.Close()
@@ -343,7 +343,7 @@ func TestIntegration_PhotoGet(t *testing.T) {
 		_, gotErr := beClient.Photos.GetPhoto(photos.NewGetPhotoParamsWithContext(ctx).WithPhotoID(*res.Payload.Data.ID), common.AuthInfoFunc(&token), io.Discard)
 		require.Error(t, gotErr)
 
-		wantErr := photos.NewGetPhotoDefault(http.StatusInternalServerError)
+		wantErr := photos.NewGetPhotoDefault(http.StatusUnauthorized)
 		wantErr.Payload = &models.Error{Data: nil}
 		assert.Equal(t, wantErr, gotErr)
 		f.Close()

--- a/internal/integration-tests/roles/integration_test.go
+++ b/internal/integration-tests/roles/integration_test.go
@@ -59,7 +59,7 @@ func TestIntegration_GetRoles(t *testing.T) {
 		_, err = client.Roles.GetRoles(params, utils.AuthInfoFunc(&dummyToken))
 		require.Error(t, err)
 
-		errExp := roles.NewGetRolesDefault(http.StatusInternalServerError)
+		errExp := roles.NewGetRolesDefault(http.StatusUnauthorized)
 		errExp.Payload = &models.Error{
 			Data: nil,
 		}

--- a/internal/integration-tests/user/get_data_integration_test.go
+++ b/internal/integration-tests/user/get_data_integration_test.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"context"
+	"net/http"
 	"testing"
 	"time"
 
@@ -58,7 +59,7 @@ func TestIntegration_GetCurrentUser(t *testing.T) {
 
 		_, err = client.Users.GetCurrentUser(params, authInfo)
 
-		errExp := users.NewGetCurrentUserDefault(500)
+		errExp := users.NewGetCurrentUserDefault(http.StatusUnauthorized)
 		errExp.Payload = &models.Error{
 			Data: nil,
 		}
@@ -122,7 +123,7 @@ func TestIntegration_GetAllUsers(t *testing.T) {
 
 		_, err = client.Users.GetAllUsers(params, authInfo)
 
-		errExp := users.NewGetAllUsersDefault(500)
+		errExp := users.NewGetAllUsersDefault(http.StatusUnauthorized)
 		errExp.Payload = &models.Error{
 			Data: nil,
 		}

--- a/internal/integration-tests/user/patch_user_integration_test.go
+++ b/internal/integration-tests/user/patch_user_integration_test.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"context"
+	"net/http"
 	"testing"
 	"time"
 
@@ -100,7 +101,7 @@ func TestIntegration_PatchUpdate(t *testing.T) {
 		_, err = client.Users.PatchUser(params, utils.AuthInfoFunc(&dummyToken))
 		assert.Error(t, err)
 
-		errExp := users.NewPatchUserDefault(500)
+		errExp := users.NewPatchUserDefault(http.StatusUnauthorized)
 		errExp.Payload = &models.Error{
 			Data: nil,
 		}
@@ -113,7 +114,7 @@ func TestIntegration_PatchUpdate(t *testing.T) {
 		_, err = client.Users.PatchUser(params, utils.AuthInfoFunc(token))
 		assert.Error(t, err)
 
-		errExp := users.NewPatchUserDefault(422)
+		errExp := users.NewPatchUserDefault(http.StatusUnprocessableEntity)
 		errExp.Payload = &models.Error{
 			Data: nil,
 		}

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1806,6 +1806,24 @@ paths:
             $ref: "#/definitions/Error"
 
 definitions:
+  SwaggerError: # Do not delete it. It is used for generating error responses.
+    type: object
+    required:
+      - code
+      - message
+    properties:
+        code:
+            type: integer
+            enum:
+              - 401
+              - 403
+            format: int32
+        message:
+            type: string
+            enum:
+              - Token is invalid
+              - User is not authorized
+              - User has no confirmed email
   PetKind:
     type: object
     required:


### PR DESCRIPTION
Introduce a generator for swagger docs that add auth middleware error responses.