### PR TITLE
Fix issue with returning an array of unavailable dates

### DIFF
--- a/internal/handlers/equipment_periods_test.go
+++ b/internal/handlers/equipment_periods_test.go
@@ -68,15 +68,18 @@ func (s *EquipmentPeriodsTestSuite) Test_Get_EquipmentUnavailableDatesFunc_OK() 
 
 	startDate := time.Date(2023, time.February, 14, 12, 34, 56, 0, time.UTC)
 	endDate := startDate.AddDate(0, 0, 10)
-	eqStatusResponse := ent.EquipmentStatus{
+	eqStatus := ent.EquipmentStatus{
 		StartDate: startDate,
 		EndDate:   endDate,
 	}
 
+	var eqStatusResponse []*ent.EquipmentStatus
+	eqStatusResponse = append(eqStatusResponse, &eqStatus)
+
 	s.equipmentStatusRepository.On(
 		"GetUnavailableEquipmentStatusByEquipmentID",
 		ctx, int(data.EquipmentID),
-	).Return(&eqStatusResponse, nil)
+	).Return(eqStatusResponse, nil)
 
 	handlerFunc := s.handler.GetEquipmentUnavailableDatesFunc(
 		s.equipmentStatusRepository,
@@ -99,11 +102,11 @@ func (s *EquipmentPeriodsTestSuite) Test_Get_EquipmentUnavailableDatesFunc_OK() 
 
 	require.Equal(
 		t, (*strfmt.DateTime)(&startDate),
-		actualResponse.Data.StartDate,
+		actualResponse.Items[0].StartDate,
 	)
 
 	require.Equal(
 		t, (*strfmt.DateTime)(&endDate),
-		actualResponse.Data.EndDate,
+		actualResponse.Items[0].EndDate,
 	)
 }

--- a/internal/repositories/equipment_status.go
+++ b/internal/repositories/equipment_status.go
@@ -117,7 +117,7 @@ func (r *equipmentStatusRepository) GetOrderAndUserByEquipmentStatusID(
 }
 
 func (r *equipmentStatusRepository) GetUnavailableEquipmentStatusByEquipmentID(
-	ctx context.Context, equipmentID int) (*ent.EquipmentStatus, error) {
+	ctx context.Context, equipmentID int) ([]*ent.EquipmentStatus, error) {
 	tx, err := middlewares.TxFromContext(ctx)
 	if err != nil {
 		return nil, err
@@ -126,7 +126,8 @@ func (r *equipmentStatusRepository) GetUnavailableEquipmentStatusByEquipmentID(
 	return tx.EquipmentStatus.Query().
 		Where(equipmentstatus.HasEquipmentsWith(equipment.IDEQ(equipmentID))).
 		Where(equipmentstatus.HasEquipmentStatusNameWith(equipmentstatusname.IDEQ(4))).
-		Only(ctx)
+		Where(equipmentstatus.EndDateGTE(time.Now())).
+		All(ctx)
 }
 
 func (r *equipmentStatusRepository) HasStatusByPeriod(ctx context.Context, status string, eqID int,

--- a/pkg/domain/repositories.go
+++ b/pkg/domain/repositories.go
@@ -56,7 +56,7 @@ type EquipmentStatusRepository interface {
 	Update(ctx context.Context, data *models.EquipmentStatus) (*ent.EquipmentStatus, error)
 	GetOrderAndUserByEquipmentStatusID(ctx context.Context, id int) (*ent.Order, *ent.User, error)
 	GetEquipmentStatusByID(ctx context.Context, equipmentStatusID int) (*ent.EquipmentStatus, error)
-	GetUnavailableEquipmentStatusByEquipmentID(ctx context.Context, equipmentID int) (*ent.EquipmentStatus, error)
+	GetUnavailableEquipmentStatusByEquipmentID(ctx context.Context, equipmentID int) ([]*ent.EquipmentStatus, error)
 }
 
 type EquipmentStatusNameRepository interface {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2268,10 +2268,12 @@ definitions:
   EquipmentUnavailabilityPeriodsResponse:
     type: object
     required:
-      - data
+      - items
     properties:
-      data:
-        $ref: "#/definitions/EquipmentUnavailabilityPeriods"
+      items:
+        type: array
+        items:
+          $ref: "#/definitions/EquipmentUnavailabilityPeriods"
   #EquipmentStatusRepairConfirmation
   EquipmentStatusRepairConfirmation:
     type: object


### PR DESCRIPTION
Issue: Endpoint returns one unavailable period for equipment: 
https://stage.csr.golangforall.com/api/docs#/Equipment/GetUnavailabilityPeriodsByEquipmentID

Expected: Endpoint should return all unavailable periods for equipment from current date.

Actual changes in this PR: 
1) Endpoint returns all unavailable periods for equipment from current date. 
2) If periods not found equipment returns empty array.
3) If error, returns 404 status code.
