### PR TITLE
Fix email confirmation issue on token refresh

### DIFF
--- a/config.json
+++ b/config.json
@@ -27,7 +27,7 @@
     {
       "role": {
         "slug": "user",
-        "isEmailConfirmed": false,
+        "isRegistrationConfirmed": false,
         "isPersonalDataConfirmed": false
       },
       "allowedEndpoints": {
@@ -39,7 +39,7 @@
     {
       "role": {
         "slug": "user",
-        "isEmailConfirmed": true,
+        "isRegistrationConfirmed": true,
         "isPersonalDataConfirmed": false,
         "isReadonly": false
       },
@@ -71,7 +71,7 @@
     {
       "role": {
         "slug": "user",
-        "isEmailConfirmed": true,
+        "isRegistrationConfirmed": true,
         "isPersonalDataConfirmed": true,
         "isReadonly": false
       },
@@ -111,7 +111,7 @@
     {
       "role": {
         "slug": "user",
-        "isEmailConfirmed": true,
+        "isRegistrationConfirmed": true,
         "isPersonalDataConfirmed": false,
         "isReadonly": true
       },
@@ -139,7 +139,7 @@
     {
       "role": {
         "slug": "user",
-        "isEmailConfirmed": true,
+        "isRegistrationConfirmed": true,
         "isPersonalDataConfirmed": true,
         "isReadonly": true
       },

--- a/er.html
+++ b/er.html
@@ -81,6 +81,8 @@ erDiagram
         timeDOTTime passport_issue_date
         string phone
         bool is_readonly
+        bool is_registration_confirmed
+        bool is_deleted
         userDOTType type
         string org_name
         string website

--- a/int-test-infra/config.json
+++ b/int-test-infra/config.json
@@ -29,7 +29,7 @@
     {
       "role": {
         "slug": "user",
-        "isEmailConfirmed": false,
+        "isRegistrationConfirmed": false,
         "isPersonalDataConfirmed": false
       },
       "allowedEndpoints": {
@@ -44,7 +44,7 @@
     {
       "role": {
         "slug": "user",
-        "isEmailConfirmed": true,
+        "isRegistrationConfirmed": true,
         "isPersonalDataConfirmed": false
       },
       "allowedEndpoints": {
@@ -78,7 +78,7 @@
     {
       "role": {
         "slug": "user",
-        "isEmailConfirmed": true,
+        "isRegistrationConfirmed": true,
         "isPersonalDataConfirmed": true
       },
       "allowedEndpoints": {

--- a/int-test-infra/config.json
+++ b/int-test-infra/config.json
@@ -38,6 +38,9 @@
         ],
         "POST": [
           "/v1/management/users/{userId}/role"
+        ],
+        "PATCH": [
+          "/v1/users/me/password"
         ]
       }
     },

--- a/internal/authentication/auth.go
+++ b/internal/authentication/auth.go
@@ -18,7 +18,7 @@ const UserSlug = "user"
 type Auth struct {
 	Id                      int
 	Login                   string
-	IsEmailConfirmed        bool
+	IsRegistrationConfirmed bool
 	IsPersonalDataConfirmed bool
 	IsReadonly              bool
 	Role                    *Role

--- a/internal/db/migrations/000007_rename_isConfirmed_to_isRegistrationConfirmed_in_users.sql
+++ b/internal/db/migrations/000007_rename_isConfirmed_to_isRegistrationConfirmed_in_users.sql
@@ -1,0 +1,5 @@
+-- +migrate Up
+ALTER TABLE users RENAME is_confirmed to is_registration_confirmed;
+
+-- +migrate Down
+ALTER TABLE users RENAME is_registration_confirmed to is_confirmed;

--- a/internal/ent/schema/user.go
+++ b/internal/ent/schema/user.go
@@ -35,7 +35,7 @@ func (User) Fields() []ent.Field {
 		field.String("org_name").Optional().Nillable(),
 		field.String("website").Optional().Nillable(),
 		field.String("vk").Optional().Nillable(),
-		field.Bool("is_confirmed").Default(false),
+		field.Bool("is_registration_confirmed").Default(false),
 		field.Bool("is_deleted").Default(false),
 	}
 }

--- a/internal/handlers/user.go
+++ b/internal/handlers/user.go
@@ -422,21 +422,22 @@ func mapUserInfo(user *ent.User) (*models.UserInfo, error) {
 	}
 	typeString := user.Type.String()
 	result := &models.UserInfo{
-		Email:             &user.Email,
-		ID:                &userID,
-		IsReadonly:        &user.IsReadonly,
-		Login:             &user.Login,
-		Name:              &user.Name,
-		OrgName:           user.OrgName,
-		PassportAuthority: user.PassportAuthority,
-		PassportIssueDate: &passportDate,
-		PassportNumber:    user.PassportNumber,
-		PassportSeries:    user.PassportSeries,
-		Patronymic:        user.Patronymic,
-		PhoneNumber:       user.Phone,
-		Role:              &userRoleInfo,
-		Surname:           user.Surname,
-		Type:              &typeString,
+		Email:                   &user.Email,
+		ID:                      &userID,
+		IsReadonly:              &user.IsReadonly,
+		Login:                   &user.Login,
+		Name:                    &user.Name,
+		OrgName:                 user.OrgName,
+		PassportAuthority:       user.PassportAuthority,
+		PassportIssueDate:       &passportDate,
+		PassportNumber:          user.PassportNumber,
+		PassportSeries:          user.PassportSeries,
+		Patronymic:              user.Patronymic,
+		PhoneNumber:             user.Phone,
+		Role:                    &userRoleInfo,
+		Surname:                 user.Surname,
+		Type:                    &typeString,
+		IsRegistrationConfirmed: &user.IsRegistrationConfirmed,
 	}
 	return result, nil
 }

--- a/internal/middlewares/access_manager.go
+++ b/internal/middlewares/access_manager.go
@@ -16,7 +16,6 @@ const apiPrefix = "/api"
 
 // do not change this values, it is used in swagger spec
 const forbiddenMessage = "User is not authorized"
-const unconfirmedEmailMessage = "User has no confirmed email"
 
 const numRoleVariations = 8
 
@@ -55,7 +54,7 @@ func (e ExistingEndpoints) Validate() error {
 
 type Role struct {
 	Slug                    string
-	IsEmailConfirmed        bool
+	IsRegistrationConfirmed bool
 	IsPersonalDataConfirmed bool
 	IsReadonly              bool
 }
@@ -83,12 +82,12 @@ func allRoleVariation(roles []Role) []Role {
 	variations := []bool{false, true}
 
 	for _, role := range roles {
-		for _, isEmailConfirmed := range variations {
+		for _, isRegistrationConfirmed := range variations {
 			for _, isPersonalDataConfirmed := range variations {
 				for _, isReadonly := range variations {
 					res = append(res, Role{
 						Slug:                    role.Slug,
-						IsEmailConfirmed:        isEmailConfirmed,
+						IsRegistrationConfirmed: isRegistrationConfirmed,
 						IsPersonalDataConfirmed: isPersonalDataConfirmed,
 						IsReadonly:              isReadonly,
 					})
@@ -219,13 +218,9 @@ func (a *blackListAccessManager) Authorize(r *http.Request, auth interface{}) er
 		return openApiErrors.New(http.StatusForbidden, forbiddenMessage)
 	}
 
-	if !userInfo.IsEmailConfirmed {
-		return openApiErrors.New(http.StatusForbidden, unconfirmedEmailMessage)
-	}
-
 	role := Role{
 		Slug:                    userInfo.Role.Slug,
-		IsEmailConfirmed:        userInfo.IsEmailConfirmed,
+		IsRegistrationConfirmed: userInfo.IsRegistrationConfirmed,
 		IsPersonalDataConfirmed: userInfo.IsPersonalDataConfirmed,
 		IsReadonly:              userInfo.IsReadonly,
 	}

--- a/internal/middlewares/access_manager_test.go
+++ b/internal/middlewares/access_manager_test.go
@@ -59,31 +59,31 @@ func Test_blackListAccessManager(t *testing.T) {
 		}
 		newAccessRules := []accessRule{
 			{
-				role:   Role{Slug: userRole, IsEmailConfirmed: true},
+				role:   Role{Slug: userRole, IsRegistrationConfirmed: true},
 				method: http.MethodGet,
 				path:   simpleValidPath,
 				isOk:   true,
 			},
 			{
-				role:   Role{Slug: userRole, IsEmailConfirmed: true},
+				role:   Role{Slug: userRole, IsRegistrationConfirmed: true},
 				method: http.MethodGet,
 				path:   simpleValidPath + "/",
 				isErr:  true,
 			},
 			{
-				role:   Role{Slug: userRole, IsEmailConfirmed: true},
+				role:   Role{Slug: userRole, IsRegistrationConfirmed: true},
 				method: http.MethodGet,
 				path:   simpleInvalidPath,
 				isErr:  true,
 			},
 			{
-				role:   Role{Slug: userRole, IsEmailConfirmed: true},
+				role:   Role{Slug: userRole, IsRegistrationConfirmed: true},
 				method: http.MethodGet,
 				path:   validPathWithParam,
 				isOk:   true,
 			},
 			{
-				role:   Role{Slug: userRole, IsEmailConfirmed: true},
+				role:   Role{Slug: userRole, IsRegistrationConfirmed: true},
 				method: http.MethodPut,
 				path:   validPathWithParam,
 				isErr:  true,
@@ -96,13 +96,13 @@ func Test_blackListAccessManager(t *testing.T) {
 				isErr:  false,
 			},
 			{
-				role:   Role{Slug: userRole, IsEmailConfirmed: true},
+				role:   Role{Slug: userRole, IsRegistrationConfirmed: true},
 				method: http.MethodGet,
 				path:   simpleInvalidPath,
 				isErr:  true,
 			},
 			{
-				role:   Role{Slug: "unknown", IsEmailConfirmed: true},
+				role:   Role{Slug: "unknown", IsRegistrationConfirmed: true},
 				method: http.MethodGet,
 				path:   validPathWithParams,
 				isErr:  true,
@@ -126,37 +126,37 @@ func Test_blackListAccessManager(t *testing.T) {
 	}
 	requestsData := []requestData{
 		{
-			role:      Role{Slug: userRole, IsEmailConfirmed: true},
+			role:      Role{Slug: userRole, IsRegistrationConfirmed: true},
 			method:    http.MethodGet,
 			path:      endpointConversion(simpleValidPath),
 			hasAccess: true,
 		},
 		{
-			role:      Role{Slug: adminRole, IsEmailConfirmed: true},
+			role:      Role{Slug: adminRole, IsRegistrationConfirmed: true},
 			method:    http.MethodGet,
 			path:      endpointConversion(simpleValidPath),
 			hasAccess: true,
 		},
 		{
-			role:      Role{Slug: userRole, IsEmailConfirmed: true},
+			role:      Role{Slug: userRole, IsRegistrationConfirmed: true},
 			method:    http.MethodGet,
 			path:      endpointConversion(validPathWithParamExample),
 			hasAccess: true,
 		},
 		{
-			role:      Role{Slug: userRole, IsEmailConfirmed: true},
+			role:      Role{Slug: userRole, IsRegistrationConfirmed: true},
 			method:    http.MethodGet,
 			path:      strings.TrimPrefix(endpointConversion(validPathWithParamExample), "/"),
 			hasAccess: true,
 		},
 		{
-			role:      Role{Slug: userRole, IsEmailConfirmed: true},
+			role:      Role{Slug: userRole, IsRegistrationConfirmed: true},
 			method:    http.MethodGet,
 			path:      strings.TrimPrefix(endpointConversion(validPathWithParamExample), "/") + "/",
 			hasAccess: true,
 		},
 		{
-			role:      Role{Slug: userRole, IsEmailConfirmed: true},
+			role:      Role{Slug: userRole, IsRegistrationConfirmed: true},
 			method:    http.MethodPut,
 			path:      endpointConversion(validPathWithParamExample),
 			hasAccess: false,
@@ -182,7 +182,7 @@ func Test_blackListAccessManager(t *testing.T) {
 				Role: &authentication.Role{
 					Slug: data.role.Slug,
 				},
-				IsEmailConfirmed: true,
+				IsRegistrationConfirmed: true,
 			}
 			err := manager.Authorize(request, auth)
 			if data.hasAccess {

--- a/internal/middlewares/bearer_auth.go
+++ b/internal/middlewares/bearer_auth.go
@@ -45,13 +45,13 @@ func BearerAuthenticateFunc(key interface{}, _ *zap.Logger) func(string) (interf
 					}
 				}
 			}
-			isEmailConfirmed := false
-			if claims[services.EmailVerifiedClaim] != nil {
-				isEmailConfirmed = claims[services.EmailVerifiedClaim].(bool)
+			isRegistrationConfirmed := false
+			if claims[services.RegistrationConfirmedClaim] != nil {
+				isRegistrationConfirmed = claims[services.RegistrationConfirmedClaim].(bool)
 			}
 			isPersonalDataConfirmed := false
-			if claims[services.DataVerifiedClaim] != nil {
-				isPersonalDataConfirmed = claims[services.DataVerifiedClaim].(bool)
+			if claims[services.PersonalDataConfirmedClaim] != nil {
+				isPersonalDataConfirmed = claims[services.PersonalDataConfirmedClaim].(bool)
 			}
 			isReadonly := false
 			if claims[services.ReadonlyAccessClaim] != nil {
@@ -60,7 +60,7 @@ func BearerAuthenticateFunc(key interface{}, _ *zap.Logger) func(string) (interf
 			return authentication.Auth{
 				Id:                      id,
 				Login:                   login,
-				IsEmailConfirmed:        isEmailConfirmed,
+				IsRegistrationConfirmed: isRegistrationConfirmed,
 				IsPersonalDataConfirmed: isPersonalDataConfirmed,
 				IsReadonly:              isReadonly,
 				Role:                    rolePointer,

--- a/internal/repositories/user.go
+++ b/internal/repositories/user.go
@@ -228,7 +228,7 @@ func (r *userRepository) ConfirmRegistration(ctx context.Context, login string) 
 	if err != nil {
 		return err
 	}
-	_, err = tx.User.Update().Where(user.LoginEQ(login)).SetIsConfirmed(true).Save(ctx)
+	_, err = tx.User.Update().Where(user.LoginEQ(login)).SetIsRegistrationConfirmed(true).Save(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/services/registration_confirm.go
+++ b/internal/services/registration_confirm.go
@@ -50,7 +50,7 @@ func (rc *registrationConfirm) SendConfirmationLink(ctx context.Context, login s
 		rc.logger.Error("Error while getting user by login", zap.String("login", login), zap.Error(err))
 		return err
 	}
-	if user.IsConfirmed {
+	if user.IsRegistrationConfirmed {
 		err = ErrRegistrationAlreadyConfirmed
 		rc.logger.Error("Error registration is already confirmed", zap.String("login", login), zap.Error(err))
 		return err

--- a/internal/services/user.go
+++ b/internal/services/user.go
@@ -141,15 +141,15 @@ func (s *tokenManager) GenerateTokens(ctx context.Context, login, password strin
 }
 
 const (
-	IdClaim             = "id"
-	LoginClaim          = "login"
-	RoleClaim           = "role"
-	SlugClaim           = "slug"
-	EmailVerifiedClaim  = "emailVerified"
-	DataVerifiedClaim   = "dataVerified"
-	GroupClaim          = "group"
-	ExpireClaim         = "exp"
-	ReadonlyAccessClaim = "readonlyAccess"
+	IdClaim                    = "id"
+	LoginClaim                 = "login"
+	RoleClaim                  = "role"
+	SlugClaim                  = "slug"
+	RegistrationConfirmedClaim = "registrationConfirmed"
+	PersonalDataConfirmedClaim = "personalDataConfirmed"
+	GroupClaim                 = "group"
+	ExpireClaim                = "exp"
+	ReadonlyAccessClaim        = "readonlyAccess"
 )
 
 func generateJWT(user *ent.User, jwtSecretKey string) (string, error) {
@@ -168,8 +168,8 @@ func generateJWT(user *ent.User, jwtSecretKey string) (string, error) {
 		return "", err
 	}
 
-	claims[EmailVerifiedClaim] = user.Edges.RegistrationConfirm != nil && len(user.Edges.RegistrationConfirm) > 0
-	claims[DataVerifiedClaim] = user.IsConfirmed //TODO: is it right field?
+	claims[RegistrationConfirmedClaim] = user.IsRegistrationConfirmed
+	claims[PersonalDataConfirmedClaim] = isPersonalDataConfirmed(user)
 	claims[ReadonlyAccessClaim] = user.IsReadonly
 	claims[ExpireClaim] = time.Now().Add(accessExpireTime).Unix()
 
@@ -178,6 +178,13 @@ func generateJWT(user *ent.User, jwtSecretKey string) (string, error) {
 		return "", err
 	}
 	return tokenString, nil
+}
+
+func isPersonalDataConfirmed(user *ent.User) bool {
+	return user != nil &&
+		user.Name != "" &&
+		user.Surname != nil && *user.Surname != "" &&
+		user.Phone != nil && *user.Phone != ""
 }
 
 func fillRoleClaims(claims jwt.MapClaims, user *ent.User) error {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2145,6 +2145,7 @@ definitions:
       - is_readonly
       - type
       - org_name
+      - is_registration_confirmed
     properties:
       id:
         type: integer
@@ -2182,6 +2183,9 @@ definitions:
         type: string
       org_name:
         type: string
+      is_registration_confirmed:
+        type: boolean
+        example: false
 
   GetListUsers:
     type: object


### PR DESCRIPTION
[EPMUII-7948](https://jira.epam.com/jira/browse/EPMUII-7948)

### Description

This pull request resolves an issue where users are receiving a 403 error message and being denied access after token refresh due to their email not being confirmed.

### Changes Made

- Removed the email confirmation check in the Authorize method since we have transitioned to access manager configuration for controlling access to REST API endpoints, making the additional layer of security and prevention of unauthorized access unnecessary.
- Renamed isConfirmed and IsEmailConfirmed fields to isRegistrationConfirmed for consistency.
- Modified the logic for calculating the claims fields to include the updated field names: for email confirmation, we no longer need to check the related edges collection. Instead, we can simply check the isRegistrationConfirmed field, which is updated to true after the user follows the link in the email; for personal data confirmation, we consider the data confirmed when the user provides their name, surname, and phone number.
- Exposed the isRegistrationConfirmed field via the REST API to provide the frontend team with access to the registration confirmation status.
- Added the missing isDeleted field in the er.html file.
- Performed small refactoring to improve code readability and maintainability.