### PR TITLE
Removed unnecessary DB.EntMigrations and added DB.ShowSql parameter to config

### DIFF
--- a/cmd/swagger/main.go
+++ b/cmd/swagger/main.go
@@ -11,7 +11,6 @@ import (
 
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/config"
 	internalDB "git.epam.com/epm-lstr/epm-lstr-lc/be/internal/db"
-	entMigrate "git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent/migrate"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/logger"
 )
 
@@ -29,15 +28,9 @@ func main() {
 		lg.Fatal("fail to setup app config", zap.Error(err))
 	}
 
-	entClient, db, err := internalDB.GetDB(conf.DB.GetConnectionString())
+	entClient, db, err := internalDB.GetDB(conf.DB)
 	if err != nil {
 		lg.Fatal("failed to db connection", zap.Error(err))
-	}
-
-	if conf.DB.EntMigrations {
-		if err := entClient.Schema.Create(ctx, entMigrate.WithDropIndex(true)); err != nil {
-			lg.Fatal("failed creating schema resources", zap.Error(err))
-		}
 	}
 
 	if err := internalDB.ApplyMigrations(db); err != nil {

--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
     "port": "5432",
     "user": "csr",
     "database": "csr",
-    "ent_migrations": true
+    "showSql": false
   },
   "JWTSecretKey": 123,
   "email": {
@@ -64,7 +64,14 @@
         ],
         "PATCH": [
           "/v1/users/me",
+          "/v1/users/me/email",
           "/v1/users/me/password"
+        ],
+        "POST": [
+          "/equipment/search"
+        ],
+        "DELETE": [
+          "/v1/users/me"
         ]
       }
     },
@@ -98,10 +105,12 @@
         ],
         "PATCH": [
           "/v1/users/me",
+          "/v1/users/me/email",
           "/v1/users/me/password"
         ],
         "POST": [
-          "/v1/orders"
+          "/v1/orders",
+          "/equipment/search"
         ],
         "DELETE": [
           "/v1/users/me"

--- a/int-test-infra/config.json
+++ b/int-test-infra/config.json
@@ -5,7 +5,7 @@
     "user": "csr",
     "password": "password",
     "database": "csr",
-    "ent_migrations": false
+    "showSql": false
   },
   "JWTSecretKey": 123,
   "email": {

--- a/internal/config/app.go
+++ b/internal/config/app.go
@@ -21,12 +21,12 @@ type AppConfig struct {
 }
 
 type DB struct {
-	Host          string `validate:"required"`
-	Port          string
-	User          string `validate:"required"`
-	Password      string
-	Database      string `validate:"required"`
-	EntMigrations bool
+	Host     string `validate:"required"`
+	Port     string
+	User     string `validate:"required"`
+	Password string
+	Database string `validate:"required"`
+	ShowSql  bool
 }
 
 func (db DB) GetConnectionString() string {

--- a/internal/db/connection.go
+++ b/internal/db/connection.go
@@ -8,11 +8,12 @@ import (
 	entsql "entgo.io/ent/dialect/sql"
 	_ "github.com/jackc/pgx/v4/stdlib"
 
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/config"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent"
 )
 
-func GetDB(connectionString string) (*ent.Client, *sql.DB, error) {
-	db, err := sql.Open("pgx", connectionString)
+func GetDB(cfg config.DB) (*ent.Client, *sql.DB, error) {
+	db, err := sql.Open("pgx", cfg.GetConnectionString())
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to open sql connection: %w", err)
 	}
@@ -21,7 +22,15 @@ func GetDB(connectionString string) (*ent.Client, *sql.DB, error) {
 		return nil, nil, fmt.Errorf("failed to ping sql connection: %w", err)
 	}
 
-	entClient := ent.NewClient(ent.Driver(entsql.OpenDB(dialect.Postgres, db)))
+	opts := []ent.Option{
+		ent.Driver(entsql.OpenDB(dialect.Postgres, db)),
+	}
+
+	if cfg.ShowSql {
+		opts = append(opts, ent.Debug())
+	}
+
+	entClient := ent.NewClient(opts...)
 
 	return entClient, db, nil
 }

--- a/internal/db/connection_test.go
+++ b/internal/db/connection_test.go
@@ -1,12 +1,13 @@
 package db
 
 import (
+	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/config"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestGetDB(t *testing.T) {
-	_, _, err := GetDB("host=123")
+	_, _, err := GetDB(config.DB{Host: "123"})
 	require.ErrorContains(t, err, "failed to ping sql connection: failed to connect")
 }


### PR DESCRIPTION
### Description
This pull request removes the unnecessary DB.EntMigrations parameter from the config as we are using SQL migrations. Additionally, it introduces the DB.ShowSql parameter to the config, enabling the display of SQL queries for debugging purposes.

The config.json file has also been updated to align with the staging environment, ensuring consistency and proper configuration.

### Note
- it turned out that that DB.EntMigrations was not being used due to [the issue with Viper](https://github.com/spf13/viper/issues/125), this problem arises when a parameter has an underscore in its name
- need to update config on the staging environment before merge