### PR TITLE
[EPMUII-7936] Orders filtering and some fixes

### DIFF
--- a/er.html
+++ b/er.html
@@ -10,12 +10,26 @@ erDiagram
         int id
         string name
     }
+    Category {
+        int id
+        string name
+        bool has_subcategory
+        int64 max_reservation_time
+        int64 max_reservation_units
+    }
+    EmailConfirm {
+        int id
+        timeDOTTime ttl
+        string token
+        string email
+    }
     Equipment {
         int id
-        string category
+        string termsOfUse
         string name
         string title
         int64 compensationCost
+        bool tech_issue
         string condition
         int64 inventoryNumber
         string supplier
@@ -23,14 +37,20 @@ erDiagram
         int64 maximumDays
         string description
     }
-    Group {
+    EquipmentStatus {
         int id
+        string comment
+        timeDOTTime created_at
+        timeDOTTime updated_at
+        timeDOTTime start_date
+        timeDOTTime end_date
     }
-    Kind {
+    EquipmentStatusName {
         int id
         string name
-        int64 max_reservation_time
-        int64 max_reservation_units
+    }
+    Group {
+        int id
     }
     Order {
         int id
@@ -39,28 +59,56 @@ erDiagram
         timeDOTTime rent_start
         timeDOTTime rent_end
         timeDOTTime created_at
+        bool is_first
     }
     OrderStatus {
         int id
         string comment
         timeDOTTime current_date
     }
+    OrderStatusName {
+        int id
+        string status
+    }
+    PasswordReset {
+        int id
+        timeDOTTime ttl
+        string token
+    }
     Permission {
         int id
         string name
+    }
+    PetKind {
+        int id
+        string name
+    }
+    PetSize {
+        int id
+        string name
+        string size
+        bool is_universal
+    }
+    Photo {
+        string id
+        string fileName
+        LBRACKRBRACKbyte content
+    }
+    RegistrationConfirm {
+        int id
+        timeDOTTime ttl
+        string token
     }
     Role {
         int id
         string name
         string slug
     }
-    StatusName {
-        int id
-        string status
-    }
-    Statuses {
+    Subcategory {
         int id
         string name
+        int64 max_reservation_time
+        int64 max_reservation_units
     }
     Token {
         int id
@@ -81,39 +129,53 @@ erDiagram
         timeDOTTime passport_issue_date
         string phone
         bool is_readonly
-        bool is_registration_confirmed
-        bool is_deleted
         userDOTType type
         string org_name
         string website
         string vk
+        bool is_registration_confirmed
+        bool is_deleted
     }
     	ActiveArea }o--o{ User : "users/active_areas"
+    	Category |o--o{ Equipment : "equipments/category"
+    	Category |o--o{ Subcategory : "subcategories/category"
+    	Equipment |o--o{ EquipmentStatus : "equipment_status/equipments"
+    	Equipment }o--o{ Order : "order/equipments"
+    	EquipmentStatusName |o--o{ Equipment : "equipments/current_status"
+    	EquipmentStatusName |o--o{ EquipmentStatus : "equipment_status/equipment_status_name"
     	Group }o--o{ User : "users/groups"
     	Group }o--o{ Permission : "permissions/groups"
-    	Kind |o--o{ Equipment : "equipments/kind"
-    	Order }o--o{ User : "users/order"
-    	Order }o--o{ Equipment : "equipments/order"
     	Order |o--o{ OrderStatus : "order_status/order"
+    	Order |o--o{ EquipmentStatus : "equipment_status/order"
+    	OrderStatusName |o--o{ Order : "orders/current_status"
+    	OrderStatusName |o--o{ OrderStatus : "order_status/order_status_name"
+    	PetKind }o--o{ Equipment : "equipments/petKinds"
+    	PetSize |o--o{ Equipment : "equipments/pet_size"
+    	Photo |o--o{ Equipment : "equipments/photo"
     	Role |o--o{ User : "users/role"
-    	StatusName |o--o{ OrderStatus : "order_status/status_name"
-    	Statuses |o--o{ Equipment : "equipments/status"
+    	Subcategory |o--o{ Equipment : "equipments/subcategory"
     	User |o--o{ Token : "tokens/owner"
+    	User |o--o{ Order : "order/users"
     	User |o--o{ OrderStatus : "order_status/users"
+    	User |o--o{ PasswordReset : "password_reset/users"
+    	User |o--o{ RegistrationConfirm : "registration_confirm/users"
+    	User |o--o{ EmailConfirm : "email_confirm/users"
 		</div>
 	<script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+	<script src="https://unpkg.com/panzoom@9.4.3/dist/panzoom.min.js"></script>
 	<script>
 		mermaid.mermaidAPI.initialize({
 			startOnLoad: true,
 		});
 		var observer = new MutationObserver((event) => {
-			document.querySelectorAll('text[id^=entity]').forEach(text => {
+			document.querySelectorAll('text[id^=text-entity]').forEach(text => {
 				text.textContent = text.textContent.replace('DOT', '.');
 				text.textContent = text.textContent.replace('STAR', '*');
 				text.textContent = text.textContent.replace('LBRACK', '[');
 				text.textContent = text.textContent.replace('RBRACK', ']');
 			});
 			observer.disconnect();
+			panzoom(document.getElementById('er-diagram'));
 		});
 		observer.observe(document.getElementById('er-diagram'), { attributes: true, childList: true });
 	</script>

--- a/go.sum
+++ b/go.sum
@@ -1239,6 +1239,7 @@ github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHN
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
 github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t68Nk=
 github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
+github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
@@ -1856,6 +1857,7 @@ golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.7/go.mod h1:LGqMHiF4EqQNHR1JncWGqT5BVaXmza+X+BDGol+dOxo=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.3.1-0.20221202221704-aa9f4b2f3d57 h1:/X0t/E4VxbZE7MLS7auvE7YICHeVvbIa9vkOVvYW/24=
+golang.org/x/tools v0.3.1-0.20221202221704-aa9f4b2f3d57/go.mod h1:/rWhSS2+zyEVwoJf8YAX6L2f0ntZ7Kn/mGgAWcipA5k=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/db/migrations/000011_add_order_current_status_name.sql
+++ b/internal/db/migrations/000011_add_order_current_status_name.sql
@@ -1,0 +1,16 @@
+-- +migrate Up
+ALTER TABLE "orders" ADD COLUMN "order_status_name_orders" INTEGER NULL;
+ALTER TABLE "orders" ADD CONSTRAINT "orders_order_status_name_orders_fkey" FOREIGN KEY("order_status_name_orders") REFERENCES "order_status_names"("id") ON DELETE SET NULL;
+
+UPDATE orders o
+SET order_status_name_orders = (
+    SELECT os.order_status_name_order_status
+    FROM order_status os
+    WHERE os.order_order_status = o.id
+    ORDER BY os.current_date DESC
+    LIMIT 1
+)
+WHERE o.id IN (SELECT DISTINCT order_order_status FROM order_status);
+
+-- +migrate Down
+ALTER TABLE "orders" DROP COLUMN "order_status_name_orders";

--- a/internal/ent/schema/order.go
+++ b/internal/ent/schema/order.go
@@ -29,6 +29,7 @@ func (Order) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.From("users", User.Type).Ref("order").Unique(),
 		edge.From("equipments", Equipment.Type).Ref("order"),
+		edge.From("current_status", OrderStatusName.Type).Ref("orders").Unique(),
 		edge.To("order_status", OrderStatus.Type),
 		edge.To("equipment_status", EquipmentStatus.Type),
 	}

--- a/internal/ent/schema/orderstatusname.go
+++ b/internal/ent/schema/orderstatusname.go
@@ -21,6 +21,7 @@ func (OrderStatusName) Fields() []ent.Field {
 // Edges of the OrderStatusName.
 func (OrderStatusName) Edges() []ent.Edge {
 	return []ent.Edge{
+		edge.To("orders", Order.Type),
 		edge.To("order_status", OrderStatus.Type),
 	}
 }

--- a/internal/handlers/order.go
+++ b/internal/handlers/order.go
@@ -195,7 +195,7 @@ func (o Order) ListOrderFunc(repository domain.OrderRepository) orders.GetAllOrd
 			_, ok := domain.AllOrderStatuses[*p.Status]
 			if !ok {
 				return orders.NewGetAllOrdersDefault(http.StatusBadRequest).
-				WithPayload(buildStringPayload(fmt.Sprintf("Invalid order status '%v'", *p.Status)))
+					WithPayload(buildStringPayload(fmt.Sprintf("Invalid order status '%v'", *p.Status)))
 			}
 		}
 

--- a/internal/handlers/order.go
+++ b/internal/handlers/order.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"errors"
+	"fmt"
 	"math"
 	"net/http"
 	"time"
@@ -14,7 +15,6 @@ import (
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/ent/order"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/models"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi/operations"
-	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi/operations/equipment"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/generated/swagger/restapi/operations/orders"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/repositories"
 	"git.epam.com/epm-lstr/epm-lstr-lc/be/internal/utils"
@@ -182,16 +182,33 @@ func (o Order) ListOrderFunc(repository domain.OrderRepository) orders.GetAllOrd
 		orderBy := utils.GetValueByPointerOrDefaultValue(p.OrderBy, utils.AscOrder)
 		orderColumn := utils.GetValueByPointerOrDefaultValue(p.OrderColumn, order.FieldID)
 
+		orderFilter := domain.OrderFilter{
+			Filter: domain.Filter{
+				Limit:       int(limit),
+				Offset:      int(offset),
+				OrderBy:     orderBy,
+				OrderColumn: orderColumn,
+			},
+			Status: p.Status,
+		}
+		if p.Status != nil {
+			_, ok := domain.AllOrderStatuses[*p.Status]
+			if !ok {
+				return orders.NewGetAllOrdersDefault(http.StatusBadRequest).
+				WithPayload(buildStringPayload(fmt.Sprintf("Invalid order status '%v'", *p.Status)))
+			}
+		}
+
 		total, err := repository.OrdersTotal(ctx, userID)
 		if err != nil {
 			o.logger.Error("Error while getting total of all user's orders", zap.Error(err))
-			return equipment.NewGetAllEquipmentDefault(http.StatusInternalServerError).
+			return orders.NewGetAllOrdersDefault(http.StatusInternalServerError).
 				WithPayload(buildErrorPayload(err))
 		}
 
 		var items []*ent.Order
 		if total > 0 {
-			items, err = repository.List(ctx, userID, int(limit), int(offset), orderBy, orderColumn)
+			items, err = repository.List(ctx, userID, orderFilter)
 			if err != nil {
 				o.logger.Error("list items failed", zap.Error(err))
 				return orders.NewGetAllOrdersDefault(http.StatusInternalServerError).WithPayload(buildErrorPayload(err))

--- a/internal/handlers/order_test.go
+++ b/internal/handlers/order_test.go
@@ -137,14 +137,18 @@ func (s *orderTestSuite) TestOrder_ListOrder_MapErr() {
 	ctx := request.Context()
 
 	userID := 1
-	limit := math.MaxInt
-	offset := 0
-	orderBy := utils.AscOrder
-	orderColumn := order.FieldID
+	filter := domain.OrderFilter{
+		Filter: domain.Filter{
+			Limit:       math.MaxInt,
+			Offset:      0,
+			OrderBy:     utils.AscOrder,
+			OrderColumn: order.FieldID,
+		},
+	}
 	var orderList []*ent.Order
 	orderList = append(orderList, orderWithNoEdges())
 	s.orderRepository.On("OrdersTotal", ctx, userID).Return(1, nil)
-	s.orderRepository.On("List", ctx, userID, limit, offset, orderBy, orderColumn).
+	s.orderRepository.On("List", ctx, userID, filter).
 		Return(orderList, nil)
 
 	handlerFunc := s.orderHandler.ListOrderFunc(s.orderRepository)
@@ -191,15 +195,19 @@ func (s *orderTestSuite) TestOrder_ListOrder_EmptyParams() {
 	ctx := request.Context()
 
 	userID := 1
-	limit := math.MaxInt
-	offset := 0
-	orderBy := utils.AscOrder
-	orderColumn := order.FieldID
+	filter := domain.OrderFilter{
+		Filter: domain.Filter{
+			Limit:       math.MaxInt,
+			Offset:      0,
+			OrderBy:     utils.AscOrder,
+			OrderColumn: order.FieldID,
+		},
+	}
 	orderList := []*ent.Order{
 		orderWithAllEdges(t, 1),
 	}
 	s.orderRepository.On("OrdersTotal", ctx, userID).Return(1, nil)
-	s.orderRepository.On("List", ctx, userID, limit, offset, orderBy, orderColumn).
+	s.orderRepository.On("List", ctx, userID, filter).
 		Return(orderList, nil)
 
 	handlerFunc := s.orderHandler.ListOrderFunc(s.orderRepository)
@@ -218,7 +226,7 @@ func (s *orderTestSuite) TestOrder_ListOrder_EmptyParams() {
 		t.Fatal(err)
 	}
 	require.Equal(t, len(orderList), int(*response.Total))
-	require.GreaterOrEqual(t, limit, len(response.Items))
+	require.GreaterOrEqual(t, filter.Limit, len(response.Items))
 	for _, item := range response.Items {
 		require.True(t, containsOrder(t, orderList, item))
 	}
@@ -234,12 +242,20 @@ func (s *orderTestSuite) TestOrder_ListOrder_LimitGreaterThanTotal() {
 	offset := int64(0)
 	orderBy := utils.AscOrder
 	orderColumn := order.FieldID
+	filter := domain.OrderFilter{
+		Filter: domain.Filter{
+			Limit:       int(limit),
+			Offset:      int(offset),
+			OrderBy:     utils.AscOrder,
+			OrderColumn: order.FieldID,
+		},
+	}
 	orderList := []*ent.Order{
 		orderWithAllEdges(t, 1),
 		orderWithAllEdges(t, 2),
 	}
 	s.orderRepository.On("OrdersTotal", ctx, userID).Return(2, nil)
-	s.orderRepository.On("List", ctx, userID, int(limit), int(offset), orderBy, orderColumn).
+	s.orderRepository.On("List", ctx, userID, filter).
 		Return(orderList, nil)
 
 	handlerFunc := s.orderHandler.ListOrderFunc(s.orderRepository)
@@ -280,6 +296,14 @@ func (s *orderTestSuite) TestOrder_ListOrder_LimitLessThanTotal() {
 	offset := int64(0)
 	orderBy := utils.AscOrder
 	orderColumn := order.FieldID
+	filter := domain.OrderFilter{
+		Filter: domain.Filter{
+			Limit:       int(limit),
+			Offset:      int(offset),
+			OrderBy:     utils.AscOrder,
+			OrderColumn: order.FieldID,
+		},
+	}
 	orderList := []*ent.Order{
 		orderWithAllEdges(t, 1),
 		orderWithAllEdges(t, 2),
@@ -287,7 +311,7 @@ func (s *orderTestSuite) TestOrder_ListOrder_LimitLessThanTotal() {
 		orderWithAllEdges(t, 4),
 	}
 	s.orderRepository.On("OrdersTotal", ctx, userID).Return(4, nil)
-	s.orderRepository.On("List", ctx, userID, int(limit), int(offset), orderBy, orderColumn).
+	s.orderRepository.On("List", ctx, userID, filter).
 		Return(orderList[:limit], nil)
 
 	handlerFunc := s.orderHandler.ListOrderFunc(s.orderRepository)
@@ -328,6 +352,14 @@ func (s *orderTestSuite) TestOrder_ListOrder_SecondPage() {
 	offset := int64(2)
 	orderBy := utils.AscOrder
 	orderColumn := order.FieldID
+	filter := domain.OrderFilter{
+		Filter: domain.Filter{
+			Limit:       int(limit),
+			Offset:      int(offset),
+			OrderBy:     utils.AscOrder,
+			OrderColumn: order.FieldID,
+		},
+	}
 	orderList := []*ent.Order{
 		orderWithAllEdges(t, 1),
 		orderWithAllEdges(t, 2),
@@ -335,7 +367,7 @@ func (s *orderTestSuite) TestOrder_ListOrder_SecondPage() {
 		orderWithAllEdges(t, 4),
 	}
 	s.orderRepository.On("OrdersTotal", ctx, userID).Return(4, nil)
-	s.orderRepository.On("List", ctx, userID, int(limit), int(offset), orderBy, orderColumn).
+	s.orderRepository.On("List", ctx, userID, filter).
 		Return(orderList[offset:], nil)
 
 	handlerFunc := s.orderHandler.ListOrderFunc(s.orderRepository)
@@ -376,6 +408,14 @@ func (s *orderTestSuite) TestOrder_ListOrder_SeveralPages() {
 	offset := int64(0)
 	orderBy := utils.AscOrder
 	orderColumn := order.FieldID
+	filter := domain.OrderFilter{
+		Filter: domain.Filter{
+			Limit:       int(limit),
+			Offset:      int(offset),
+			OrderBy:     utils.AscOrder,
+			OrderColumn: order.FieldID,
+		},
+	}
 	orderList := []*ent.Order{
 		orderWithAllEdges(t, 1),
 		orderWithAllEdges(t, 2),
@@ -383,7 +423,7 @@ func (s *orderTestSuite) TestOrder_ListOrder_SeveralPages() {
 		orderWithAllEdges(t, 4),
 	}
 	s.orderRepository.On("OrdersTotal", ctx, userID).Return(4, nil)
-	s.orderRepository.On("List", ctx, userID, int(limit), int(offset), orderBy, orderColumn).
+	s.orderRepository.On("List", ctx, userID, filter).
 		Return(orderList[:limit], nil)
 
 	handlerFunc := s.orderHandler.ListOrderFunc(s.orderRepository)
@@ -414,8 +454,9 @@ func (s *orderTestSuite) TestOrder_ListOrder_SeveralPages() {
 	}
 
 	offset = limit
+	filter.Offset = int(offset)
 	s.orderRepository.On("OrdersTotal", ctx, userID).Return(4, nil)
-	s.orderRepository.On("List", ctx, userID, int(limit), int(offset), orderBy, orderColumn).
+	s.orderRepository.On("List", ctx, userID, filter).
 		Return(orderList[offset:], nil)
 
 	data = orders.GetAllOrdersParams{

--- a/internal/handlers/order_test.go
+++ b/internal/handlers/order_test.go
@@ -578,38 +578,39 @@ func (s *orderTestSuite) TestOrder_ListOrder_StatusFilter() {
 			ords: []*ent.Order{orderList[3]},
 		},
 	}
-	for _, tc := range tests {
-		tc := tc
-		s.orderRepository.On("OrdersTotal", ctx, userID).Return(4, nil)
-		s.orderRepository.On("List", ctx, userID, tc.fl).
-			Return(tc.ords, nil)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			s.orderRepository.On("OrdersTotal", ctx, userID).Return(4, nil)
+			s.orderRepository.On("List", ctx, userID, tc.fl).
+				Return(tc.ords, nil)
 
-		data := orders.GetAllOrdersParams{
-			HTTPRequest: &request,
-			Limit:       &limit,
-			Offset:      &offset,
-			OrderBy:     &orderBy,
-			OrderColumn: &orderColumn,
-			Status:      tc.fl.Status,
-		}
-		principal := &models.Principal{ID: int64(userID)}
-		resp := handlerFunc.Handle(data, principal)
+			data := orders.GetAllOrdersParams{
+				HTTPRequest: &request,
+				Limit:       &limit,
+				Offset:      &offset,
+				OrderBy:     &orderBy,
+				OrderColumn: &orderColumn,
+				Status:      tc.fl.Status,
+			}
+			principal := &models.Principal{ID: int64(userID)}
+			resp := handlerFunc.Handle(data, principal)
 
-		responseRecorder := httptest.NewRecorder()
-		producer := runtime.JSONProducer()
-		resp.WriteResponse(responseRecorder, producer)
-		require.Equal(t, http.StatusOK, responseRecorder.Code)
+			responseRecorder := httptest.NewRecorder()
+			producer := runtime.JSONProducer()
+			resp.WriteResponse(responseRecorder, producer)
+			require.Equal(t, http.StatusOK, responseRecorder.Code)
 
-		var response models.OrderList
-		err := json.Unmarshal(responseRecorder.Body.Bytes(), &response)
-		if err != nil {
-			t.Fatal(err)
-		}
+			var response models.OrderList
+			err := json.Unmarshal(responseRecorder.Body.Bytes(), &response)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		require.Equal(t, len(tc.ords), len(response.Items))
-		for i, o := range response.Items {
-			require.Equal(t, tc.ords[i].ID, int(*o.ID))
-		}
+			require.Equal(t, len(tc.ords), len(response.Items))
+			for i, o := range response.Items {
+				require.Equal(t, tc.ords[i].ID, int(*o.ID))
+			}
+		})
 	}
 }
 

--- a/internal/handlers/order_test.go
+++ b/internal/handlers/order_test.go
@@ -487,6 +487,102 @@ func (s *orderTestSuite) TestOrder_ListOrder_SeveralPages() {
 	require.False(t, ordersDuplicated(t, firstPage.Items, secondPage.Items))
 }
 
+func (s *orderTestSuite) TestOrder_ListOrder_StatusFilter() {
+	t := s.T()
+	request := http.Request{}
+	ctx := request.Context()
+
+	userID := 1
+	limit := int64(10)
+	offset := int64(0)
+	orderBy := utils.AscOrder
+	orderColumn := order.FieldID
+	filter := domain.Filter{
+		Limit:       int(limit),
+		Offset:      int(offset),
+		OrderBy:     utils.AscOrder,
+		OrderColumn: order.FieldID,
+	}
+	orderList := []*ent.Order{
+		orderWithAllEdges(t, 1),
+		orderWithAllEdges(t, 2),
+		orderWithAllEdges(t, 3),
+		orderWithAllEdges(t, 4),
+	}
+	orderList[0].Edges.OrderStatus[0].ID = 1 // in review (active)
+	orderList[1].Edges.OrderStatus[0].ID = 2 // approved (active)
+	orderList[2].Edges.OrderStatus[0].ID = 6 // prepared (active)
+	orderList[3].Edges.OrderStatus[0].ID = 4 // rejected (finished)
+
+	handlerFunc := s.orderHandler.ListOrderFunc(s.orderRepository)
+	tests := map[string]struct {
+		fl   domain.OrderFilter
+		ords []*ent.Order
+	}{
+		"all": {
+			fl: domain.OrderFilter{
+				Filter: filter,
+				Status: &domain.OrderStatusAll,
+			},
+			ords: orderList,
+		},
+		"active": {
+			fl: domain.OrderFilter{
+				Filter: filter,
+				Status: &domain.OrderStatusActive,
+			},
+			ords: []*ent.Order{orderList[0], orderList[1], orderList[2]},
+		},
+		"finished": {
+			fl: domain.OrderFilter{
+				Filter: filter,
+				Status: &domain.OrderStatusFinished,
+			},
+			ords: []*ent.Order{orderList[3]},
+		},
+		"rejected": {
+			fl: domain.OrderFilter{
+				Filter: filter,
+				Status: &domain.OrderStatusRejected,
+			},
+			ords: []*ent.Order{orderList[3]},
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		s.orderRepository.On("OrdersTotal", ctx, userID).Return(4, nil)
+		s.orderRepository.On("List", ctx, userID, tc.fl).
+			Return(tc.ords, nil)
+
+		data := orders.GetAllOrdersParams{
+			HTTPRequest: &request,
+			Limit:       &limit,
+			Offset:      &offset,
+			OrderBy:     &orderBy,
+			OrderColumn: &orderColumn,
+			Status:      tc.fl.Status,
+		}
+		principal := &models.Principal{ID: int64(userID)}
+		resp := handlerFunc.Handle(data, principal)
+
+		responseRecorder := httptest.NewRecorder()
+		producer := runtime.JSONProducer()
+		resp.WriteResponse(responseRecorder, producer)
+		require.Equal(t, http.StatusOK, responseRecorder.Code)
+
+		var response models.OrderList
+		err := json.Unmarshal(responseRecorder.Body.Bytes(), &response)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		require.Equal(t, len(tc.ords), len(response.Items))
+		for i, o := range response.Items {
+			require.Equal(t, tc.ords[i].ID, int(*o.ID))
+		}
+	}
+}
+
 func (s *orderTestSuite) TestOrder_CreateOrder_RepoErr() {
 	t := s.T()
 	request := http.Request{}

--- a/internal/integration-tests/orders/order_test.go
+++ b/internal/integration-tests/orders/order_test.go
@@ -424,30 +424,107 @@ func TestIntegration_List_Filtered(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// TBD
-	// t.Run("Get Orders 7 Active Ok", func(t *testing.T) {
-	// 	listParams := orders.NewGetAllOrdersParamsWithContext(ctx)
-	// 	listParams.Status = &domain.OrderStatusActive
-	// 	// filter 'active', still  7 (5+2) orders
-	// 	res, err := client.Orders.GetAllOrders(listParams, auth)
-	// 	require.NoError(t, err)
-	// 	for i, o := range res.Payload.Items {
-	// 		fmt.Println("WTF active only", i, *o.LastStatus.Status)
-	// 	}
-	// 	assert.Equal(t, 7, len(res.GetPayload().Items))
-	// })
+	t.Run("Get Orders 7 Active Ok", func(t *testing.T) {
+		listParams := orders.NewGetAllOrdersParamsWithContext(ctx)
+		listParams.Status = &domain.OrderStatusActive
+		// filter 'active', still  7 (5+2) orders
+		res, err := client.Orders.GetAllOrders(listParams, auth)
+		require.NoError(t, err)
+		assert.Equal(t, 7, len(res.GetPayload().Items))
+	})
 
-	// t.Run("Get Orders 1 Finished Ok", func(t *testing.T) {
-	// 	listParams := orders.NewGetAllOrdersParamsWithContext(ctx)
-	// 	listParams.Status = &domain.OrderStatusFinished
-	// 	// filter 'active', still  7 (5+2) orders
-	// 	res, err := client.Orders.GetAllOrders(listParams, auth)
-	// 	require.NoError(t, err)
-	// 	for i, o := range res.Payload.Items {
-	// 		fmt.Println("WTF finished only", i, *o.LastStatus.Status)
-	// 	}
-	// 	assert.Equal(t, 1, len(res.GetPayload().Items))
-	// })
+	t.Run("Get Orders 6 Approved Ok", func(t *testing.T) {
+		listParams := orders.NewGetAllOrdersParamsWithContext(ctx)
+		listParams.Status = &domain.OrderStatusApproved
+		// filter 'active', still  7 (5+2) orders
+		res, err := client.Orders.GetAllOrders(listParams, auth)
+		require.NoError(t, err)
+		assert.Equal(t, 6, len(res.GetPayload().Items))
+	})
+
+	t.Run("Get Orders 1 In_Review Ok", func(t *testing.T) {
+		listParams := orders.NewGetAllOrdersParamsWithContext(ctx)
+		listParams.Status = &domain.OrderStatusInReview
+		// filter 'active', still  7 (5+2) orders
+		res, err := client.Orders.GetAllOrders(listParams, auth)
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(res.GetPayload().Items))
+	})
+
+	t.Run("Get Orders 1 Finished Ok", func(t *testing.T) {
+		listParams := orders.NewGetAllOrdersParamsWithContext(ctx)
+		listParams.Status = &domain.OrderStatusFinished
+		// filter 'active', still  7 (5+2) orders
+		res, err := client.Orders.GetAllOrders(listParams, auth)
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(res.GetPayload().Items))
+	})
+
+	t.Run("Get Orders 1 Rejected Ok", func(t *testing.T) {
+		listParams := orders.NewGetAllOrdersParamsWithContext(ctx)
+		listParams.Status = &domain.OrderStatusRejected
+		// filter 'active', still  7 (5+2) orders
+		res, err := client.Orders.GetAllOrders(listParams, auth)
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(res.GetPayload().Items))
+	})
+
+	t.Run("Get Orders 0 Closed Ok", func(t *testing.T) {
+		listParams := orders.NewGetAllOrdersParamsWithContext(ctx)
+		listParams.Status = &domain.OrderStatusClosed
+		// filter 'active', still  7 (5+2) orders
+		res, err := client.Orders.GetAllOrders(listParams, auth)
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(res.GetPayload().Items))
+	})
+
+	// Close 1st Order
+	dt := strfmt.DateTime(time.Now())
+	osp := orders.NewAddNewOrderStatusParamsWithContext(ctx)
+	osp.Data = &models.NewOrderStatus{
+		OrderID: res.Payload.Items[0].ID,
+		CreatedAt: &dt,
+		Status: &domain.OrderStatusClosed,
+		Comment: &domain.OrderStatusClosed,
+	}
+	_, err = client.Orders.AddNewOrderStatus(osp, auth)
+	require.NoError(t, err)
+
+	t.Run("Get Orders 6 Active Ok", func(t *testing.T) {
+		listParams := orders.NewGetAllOrdersParamsWithContext(ctx)
+		listParams.Status = &domain.OrderStatusActive
+		// filter 'active', still  7 (5+2) orders
+		res, err := client.Orders.GetAllOrders(listParams, auth)
+		require.NoError(t, err)
+		assert.Equal(t, 6, len(res.GetPayload().Items))
+	})	
+
+	t.Run("Get Orders 2 Finished Ok", func(t *testing.T) {
+		listParams := orders.NewGetAllOrdersParamsWithContext(ctx)
+		listParams.Status = &domain.OrderStatusFinished
+		// filter 'active', still  7 (5+2) orders
+		res, err := client.Orders.GetAllOrders(listParams, auth)
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(res.GetPayload().Items))
+	})	
+
+	t.Run("Get Orders 1 Closed Ok", func(t *testing.T) {
+		listParams := orders.NewGetAllOrdersParamsWithContext(ctx)
+		listParams.Status = &domain.OrderStatusClosed
+		// filter 'active', still  7 (5+2) orders
+		res, err := client.Orders.GetAllOrders(listParams, auth)
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(res.GetPayload().Items))
+	})
+
+	t.Run("Get Orders 0 In_Review Ok", func(t *testing.T) {
+		listParams := orders.NewGetAllOrdersParamsWithContext(ctx)
+		listParams.Status = &domain.OrderStatusInReview
+		// filter 'active', still  7 (5+2) orders
+		res, err := client.Orders.GetAllOrders(listParams, auth)
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(res.GetPayload().Items))
+	})
 }
 
 func TestIntegration_UpdateOrder(t *testing.T) {

--- a/internal/repositories/order.go
+++ b/internal/repositories/order.go
@@ -94,13 +94,6 @@ func (r *orderRepository) List(ctx context.Context, ownerId int, filter domain.O
 		return nil, err
 	}
 
-	for i, item := range items { // get order status relations
-		items[i], err = r.getFullOrder(ctx, item)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	return items, err
 }
 

--- a/internal/repositories/order.go
+++ b/internal/repositories/order.go
@@ -152,6 +152,11 @@ func (r *orderRepository) Create(ctx context.Context, data *models.OrderCreateRe
 		isFirst = true
 	}
 
+	statusName, err := tx.OrderStatusName.Query().Where(orderstatusname.StatusEQ(domain.OrderStatusInReview)).Only(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	createdOrder, err := tx.Order.
 		Create().
 		SetDescription(data.Description).
@@ -161,6 +166,7 @@ func (r *orderRepository) Create(ctx context.Context, data *models.OrderCreateRe
 		SetUsers(owner).
 		SetUsersID(owner.ID).
 		SetIsFirst(isFirst).
+		SetCurrentStatus(statusName).
 		AddEquipments(equipments...).
 		AddEquipmentIDs(equipmentIDs...).
 		Save(ctx)
@@ -168,10 +174,6 @@ func (r *orderRepository) Create(ctx context.Context, data *models.OrderCreateRe
 		return nil, err
 	}
 
-	statusName, err := tx.OrderStatusName.Query().Where(orderstatusname.StatusEQ(domain.OrderStatusInReview)).Only(ctx)
-	if err != nil {
-		return nil, err
-	}
 	_, err = tx.OrderStatus.Create().
 		SetComment("Order created").
 		SetCurrentDate(time.Now()).

--- a/internal/repositories/order.go
+++ b/internal/repositories/order.go
@@ -69,11 +69,11 @@ func getQuantity(quantity int, maxQuantity int) (*int, error) {
 	return &quantity, nil
 }
 
-func (r *orderRepository) List(ctx context.Context, ownerId, limit, offset int, orderBy, orderColumn string) ([]*ent.Order, error) {
-	if !utils.IsValueInList(orderColumn, fieldsToOrderOrders) {
+func (r *orderRepository) List(ctx context.Context, ownerId int, filter domain.OrderFilter) ([]*ent.Order, error) {
+	if !utils.IsValueInList(filter.OrderColumn, fieldsToOrderOrders) {
 		return nil, errors.New("wrong column to order by")
 	}
-	orderFunc, err := utils.GetOrderFunc(orderBy, orderColumn)
+	orderFunc, err := utils.GetOrderFunc(filter.OrderBy, filter.OrderColumn)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func (r *orderRepository) List(ctx context.Context, ownerId, limit, offset int, 
 	items, err := tx.Order.Query().
 		Where(order.HasUsersWith(user.ID(ownerId))).
 		Order(orderFunc).
-		Limit(limit).Offset(offset).
+		Limit(filter.Limit).Offset(filter.Offset).
 		WithUsers().WithOrderStatus().
 		All(ctx)
 	if err != nil {

--- a/internal/repositories/order_filter.go
+++ b/internal/repositories/order_filter.go
@@ -70,6 +70,8 @@ func (r *orderFilterRepository) OrdersByPeriodAndStatus(ctx context.Context, fro
 		Where(orderstatus.CurrentDateLTE(to)).
 		QueryOrder().
 		WithOrderStatus().
+		WithEquipments().
+		WithUsers().
 		Order(orderFunc).Limit(limit).Offset(offset).All(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/repositories/order_test.go
+++ b/internal/repositories/order_test.go
@@ -433,7 +433,15 @@ func (s *OrderSuite) TestOrderRepository_Create_isFirstFieldForPreviousCreatedOr
 	err = s.orderStatusRepository.UpdateStatus(ctx, s.user.ID, model)
 	require.NoError(t, err)
 
-	orderList, err := s.orderRepository.List(ctx, s.user.ID, math.MaxInt, 0, utils.AscOrder, order.FieldID)
+	filter := domain.OrderFilter{
+		Filter: domain.Filter{
+			Limit:       math.MaxInt,
+			Offset:      0,
+			OrderBy:     utils.AscOrder,
+			OrderColumn: order.FieldID,
+		},
+	}
+	orderList, err := s.orderRepository.List(ctx, s.user.ID, filter)
 	require.NoError(t, err)
 
 	for _, order := range orderList {
@@ -460,15 +468,20 @@ func (s *OrderSuite) TestOrderRepository_OrdersTotal() {
 
 func (s *OrderSuite) TestOrderRepository_List_EmptyOrderBy() {
 	t := s.T()
-	limit := math.MaxInt
-	offset := 0
-	orderBy := ""
-	orderColumn := order.FieldID
+	filter := domain.OrderFilter{
+		Filter: domain.Filter{
+			Limit:       math.MaxInt,
+			Offset:      0,
+			OrderBy:     "",
+			OrderColumn: order.FieldID,
+		},
+	}
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
 	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
-	orders, err := s.orderRepository.List(ctx, s.user.ID, limit, offset, orderBy, orderColumn)
+
+	orders, err := s.orderRepository.List(ctx, s.user.ID, filter)
 	require.Error(t, err)
 	require.NoError(t, tx.Rollback())
 	require.Nil(t, orders)
@@ -476,15 +489,19 @@ func (s *OrderSuite) TestOrderRepository_List_EmptyOrderBy() {
 
 func (s *OrderSuite) TestOrderRepository_List_WrongOrderColumn() {
 	t := s.T()
-	limit := math.MaxInt
-	offset := 0
-	orderBy := utils.AscOrder
-	orderColumn := order.FieldDescription
+	filter := domain.OrderFilter{
+		Filter: domain.Filter{
+			Limit:       math.MaxInt,
+			Offset:      0,
+			OrderBy:     utils.AscOrder,
+			OrderColumn: order.FieldDescription,
+		},
+	}
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
 	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
-	orders, err := s.orderRepository.List(ctx, s.user.ID, limit, offset, orderBy, orderColumn)
+	orders, err := s.orderRepository.List(ctx, s.user.ID, filter)
 	require.Error(t, err)
 	require.NoError(t, tx.Rollback())
 	require.Nil(t, orders)
@@ -492,15 +509,19 @@ func (s *OrderSuite) TestOrderRepository_List_WrongOrderColumn() {
 
 func (s *OrderSuite) TestOrderRepository_List_OrderByIDDesc() {
 	t := s.T()
-	limit := math.MaxInt
-	offset := 0
-	orderBy := utils.DescOrder
-	orderColumn := order.FieldID
+	filter := domain.OrderFilter{
+		Filter: domain.Filter{
+			Limit:       math.MaxInt,
+			Offset:      0,
+			OrderBy:     utils.DescOrder,
+			OrderColumn: order.FieldID,
+		},
+	}
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
 	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
-	orders, err := s.orderRepository.List(ctx, s.user.ID, limit, offset, orderBy, orderColumn)
+	orders, err := s.orderRepository.List(ctx, s.user.ID, filter)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -516,15 +537,19 @@ func (s *OrderSuite) TestOrderRepository_List_OrderByIDDesc() {
 
 func (s *OrderSuite) TestOrderRepository_List_OrderByRentStartDesc() {
 	t := s.T()
-	limit := math.MaxInt
-	offset := 0
-	orderBy := utils.DescOrder
-	orderColumn := order.FieldRentStart
+	filter := domain.OrderFilter{
+		Filter: domain.Filter{
+			Limit:       math.MaxInt,
+			Offset:      0,
+			OrderBy:     utils.DescOrder,
+			OrderColumn: order.FieldRentStart,
+		},
+	}
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
 	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
-	orders, err := s.orderRepository.List(ctx, s.user.ID, limit, offset, orderBy, orderColumn)
+	orders, err := s.orderRepository.List(ctx, s.user.ID, filter)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -540,15 +565,19 @@ func (s *OrderSuite) TestOrderRepository_List_OrderByRentStartDesc() {
 
 func (s *OrderSuite) TestOrderRepository_List_OrderByIDAsc() {
 	t := s.T()
-	limit := math.MaxInt
-	offset := 0
-	orderBy := utils.AscOrder
-	orderColumn := order.FieldID
+	filter := domain.OrderFilter{
+		Filter: domain.Filter{
+			Limit:       math.MaxInt,
+			Offset:      0,
+			OrderBy:     utils.AscOrder,
+			OrderColumn: order.FieldID,
+		},
+	}
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
 	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
-	orders, err := s.orderRepository.List(ctx, s.user.ID, limit, offset, orderBy, orderColumn)
+	orders, err := s.orderRepository.List(ctx, s.user.ID, filter)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -564,15 +593,19 @@ func (s *OrderSuite) TestOrderRepository_List_OrderByIDAsc() {
 
 func (s *OrderSuite) TestOrderRepository_List_OrderByRentStartAsc() {
 	t := s.T()
-	limit := math.MaxInt
-	offset := 0
-	orderBy := utils.AscOrder
-	orderColumn := order.FieldRentStart
+	filter := domain.OrderFilter{
+		Filter: domain.Filter{
+			Limit:       math.MaxInt,
+			Offset:      0,
+			OrderBy:     utils.AscOrder,
+			OrderColumn: order.FieldRentStart,
+		},
+	}
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
 	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
-	orders, err := s.orderRepository.List(ctx, s.user.ID, limit, offset, orderBy, orderColumn)
+	orders, err := s.orderRepository.List(ctx, s.user.ID, filter)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -588,39 +621,47 @@ func (s *OrderSuite) TestOrderRepository_List_OrderByRentStartAsc() {
 
 func (s *OrderSuite) TestOrderRepository_List_Limit() {
 	t := s.T()
-	limit := 2
-	offset := 0
-	orderBy := utils.AscOrder
-	orderColumn := order.FieldID
+	filter := domain.OrderFilter{
+		Filter: domain.Filter{
+			Limit:       2,
+			Offset:      0,
+			OrderBy:     utils.AscOrder,
+			OrderColumn: order.FieldID,
+		},
+	}
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
 	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
-	orders, err := s.orderRepository.List(ctx, s.user.ID, limit, offset, orderBy, orderColumn)
+	orders, err := s.orderRepository.List(ctx, s.user.ID, filter)
 	if err != nil {
 		t.Fatal(err)
 	}
 	require.NoError(t, tx.Commit())
-	require.Equal(t, limit, len(orders))
+	require.Equal(t, filter.Limit, len(orders))
 	require.Greater(t, len(s.orders), len(orders))
 }
 
 func (s *OrderSuite) TestOrderRepository_List_Offset() {
 	t := s.T()
-	limit := 0
-	offset := 3
-	orderBy := utils.AscOrder
-	orderColumn := order.FieldID
+	filter := domain.OrderFilter{
+		Filter: domain.Filter{
+			Limit:       0,
+			Offset:      3,
+			OrderBy:     utils.AscOrder,
+			OrderColumn: order.FieldID,
+		},
+	}
 	ctx := s.ctx
 	tx, err := s.client.Tx(ctx)
 	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
-	orders, err := s.orderRepository.List(ctx, s.user.ID, limit, offset, orderBy, orderColumn)
+	orders, err := s.orderRepository.List(ctx, s.user.ID, filter)
 	if err != nil {
 		t.Fatal(err)
 	}
 	require.NoError(t, tx.Commit())
-	require.Equal(t, len(s.orders)-offset, len(orders))
+	require.Equal(t, len(s.orders)-filter.Offset, len(orders))
 	require.Greater(t, len(s.orders), len(orders))
 }
 

--- a/internal/repositories/order_test.go
+++ b/internal/repositories/order_test.go
@@ -162,24 +162,25 @@ func (s *OrderSuite) SetupTest() {
 		t.Fatal(err)
 	}
 	for i, order := range s.orders {
+		statusName, err := s.client.OrderStatusName.Query().
+			Where(orderstatusname.StatusEQ(statusNameMap[i+1])).Only(s.ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		o, err := s.client.Order.Create().
 			SetDescription(order.Description).
 			SetQuantity(order.Quantity).
 			SetRentStart(order.RentStart).
 			SetRentEnd(order.RentEnd).
 			SetUsers(order.Edges.Users).
+			SetCurrentStatus(statusName).
 			Save(s.ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
 		s.orders[i].ID = o.ID
 		s.orders[i].CreatedAt = o.CreatedAt
-
-		statusName, err := s.client.OrderStatusName.Query().
-			Where(orderstatusname.StatusEQ(statusNameMap[i+1])).Only(s.ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
 
 		_, err = s.client.OrderStatus.Create().
 			SetComment("Test order status").

--- a/internal/services/user_test.go
+++ b/internal/services/user_test.go
@@ -105,10 +105,10 @@ func (s *UserServiceTestSuite) TestUserService_GenerateAccessToken_DeletedUserEr
 		t.Fatal(err)
 	}
 	user := &ent.User{
-		ID:               1,
+		ID:        1,
 		IsDeleted: true,
-		Login:            login,
-		Password:         string(hashedPassword),
+		Login:     login,
+		Password:  string(hashedPassword),
 		Edges: ent.UserEdges{
 			Role: &ent.Role{
 				ID:   1,

--- a/pkg/domain/order.go
+++ b/pkg/domain/order.go
@@ -9,4 +9,25 @@ var (
 	OrderStatusPrepared   = "prepared"
 	OrderStatusOverdue    = "overdue"
 	OrderStatusBlocked    = "blocked"
+
+	// Aggregated states
+	OrderStatusAll      = "all"
+	OrderStatusActive   = "active"
+	OrderStatusFinished = "finished"
+
+	// AllOrderStatuses contains all allowed OrderStatus values
+	AllOrderStatuses = map[string]struct{}{
+		OrderStatusInReview: {},
+		OrderStatusApproved: {},
+		OrderStatusInProgress: {},
+		OrderStatusRejected: {},
+		OrderStatusClosed: {},
+		OrderStatusPrepared: {},
+		OrderStatusOverdue: {},
+		OrderStatusBlocked: {},
+		// Aggregated states
+		OrderStatusAll: {},
+		OrderStatusActive: {},
+		OrderStatusFinished: {},
+	}
 )

--- a/pkg/domain/order.go
+++ b/pkg/domain/order.go
@@ -17,17 +17,17 @@ var (
 
 	// AllOrderStatuses contains all allowed OrderStatus values
 	AllOrderStatuses = map[string]struct{}{
-		OrderStatusInReview: {},
-		OrderStatusApproved: {},
+		OrderStatusInReview:   {},
+		OrderStatusApproved:   {},
 		OrderStatusInProgress: {},
-		OrderStatusRejected: {},
-		OrderStatusClosed: {},
-		OrderStatusPrepared: {},
-		OrderStatusOverdue: {},
-		OrderStatusBlocked: {},
+		OrderStatusRejected:   {},
+		OrderStatusClosed:     {},
+		OrderStatusPrepared:   {},
+		OrderStatusOverdue:    {},
+		OrderStatusBlocked:    {},
 		// Aggregated states
-		OrderStatusAll: {},
-		OrderStatusActive: {},
+		OrderStatusAll:      {},
+		OrderStatusActive:   {},
 		OrderStatusFinished: {},
 	}
 )

--- a/pkg/domain/order.go
+++ b/pkg/domain/order.go
@@ -30,4 +30,19 @@ var (
 		OrderStatusActive:   {},
 		OrderStatusFinished: {},
 	}
+
+	OrderStatusAggregation = map[string][]string{
+		OrderStatusActive: {
+			OrderStatusInReview,
+			OrderStatusApproved,
+			OrderStatusOverdue,
+			OrderStatusInProgress,
+			OrderStatusPrepared,
+		},
+		OrderStatusFinished: {
+			OrderStatusRejected,
+			OrderStatusBlocked,
+			OrderStatusClosed,
+		},
+	}
 )

--- a/pkg/domain/repositories.go
+++ b/pkg/domain/repositories.go
@@ -23,6 +23,11 @@ type CategoryFilter struct {
 	HasEquipments bool
 }
 
+type OrderFilter struct {
+	Filter
+	Status *string
+}
+
 type CategoryRepository interface {
 	CreateCategory(ctx context.Context, newCategory models.CreateNewCategory) (*ent.Category, error)
 	AllCategories(ctx context.Context, filter CategoryFilter) ([]*ent.Category, error)
@@ -65,7 +70,7 @@ type EquipmentStatusNameRepository interface {
 }
 
 type OrderRepository interface {
-	List(ctx context.Context, ownerId, limit, offset int, orderBy, orderColumn string) ([]*ent.Order, error)
+	List(ctx context.Context, ownerId int, filter OrderFilter) ([]*ent.Order, error)
 	OrdersTotal(ctx context.Context, ownerId int) (int, error)
 	Create(ctx context.Context, data *models.OrderCreateRequest, ownerId int, equipmentIDs []int) (*ent.Order, error)
 	Update(ctx context.Context, id int, data *models.OrderUpdateRequest, ownerId int) (*ent.Order, error)

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1055,8 +1055,20 @@ paths:
         - name: status
           in: query
           required: false
-          description: filter orders by status
+          description: filter orders by status (in review, approved, closed, etc) or aggregated status (all, active or finished)
           type: string
+          enum:
+            - all
+            - active
+            - finished
+            - in review
+            - approved
+            - in progress
+            - rejected
+            - closed
+            - prepared
+            - overdue
+            - blocked
           default: all
         - name: limit
           in: query

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1052,6 +1052,12 @@ paths:
         - Orders
       operationId: GetAllOrders
       parameters:
+        - name: status
+          in: query
+          required: false
+          description: filter orders by status
+          type: string
+          default: all
         - name: limit
           in: query
           required: false


### PR DESCRIPTION
This pull request introduces several changes:

1. The addition of an OrderFilter to allow the filtering of orders based on their status or new aggregated status (`all`, `active`, and `finished`). In my opinion, this filter will likely be extended soon to include the `equipment_id`.

2. To discuss: The removal of the `for` loop with the `getFullOrder` function from `OrderRepository.List`. This modification eliminates the need for multiple additional selects (9*amount of orders). However, currently, equipment information only contains data from the `equipments` table, such as id, name, supplier, etc. Additional details like category, photo, and petKinds are absent. It might be worth considering whether this extra data is necessary in the list of Orders. If deemed necessary, this supplementary data can also be included. 
upd; Iana confirmed that we don't need additional Equipment's fields there.

4. Correction of orders filtering by Date and Status.