### PR TITLE
[EPMUII-7958] Orders Management list

### DIFF
--- a/internal/handlers/order.go
+++ b/internal/handlers/order.go
@@ -225,7 +225,7 @@ func (o Order) ListUserOrdersFunc(repository domain.OrderRepository) orders.GetU
 			}
 		}
 
-		total, err := repository.OrdersTotal(ctx, userID)
+		total, err := repository.OrdersTotal(ctx, &userID)
 		if err != nil {
 			o.logger.Error("Error while getting total of all user's orders", zap.Error(err))
 			return orders.NewGetUserOrdersDefault(http.StatusInternalServerError).
@@ -286,7 +286,7 @@ func (o Order) ListAllOrdersFunc(repository domain.OrderRepository) orders.GetAl
 			orderFilter.EquipmentID = &eid
 		}
 
-		total, err := repository.OrdersTotal(ctx, -1)
+		total, err := repository.OrdersTotal(ctx, nil)
 		if err != nil {
 			o.logger.Error("Error while getting total of all orders", zap.Error(err))
 			return orders.NewGetAllOrdersDefault(http.StatusInternalServerError).

--- a/internal/handlers/order.go
+++ b/internal/handlers/order.go
@@ -27,9 +27,10 @@ func SetOrderHandler(logger *zap.Logger, api *operations.BeAPI) {
 	equipmentRepo := repositories.NewEquipmentRepository()
 	ordersHandler := NewOrder(logger)
 
-	api.OrdersGetAllOrdersHandler = ordersHandler.ListOrderFunc(orderRepo)
+	api.OrdersGetUserOrdersHandler = ordersHandler.ListUserOrdersFunc(orderRepo)
 	api.OrdersCreateOrderHandler = ordersHandler.CreateOrderFunc(orderRepo, eqStatusRepo, equipmentRepo)
 	api.OrdersUpdateOrderHandler = ordersHandler.UpdateOrderFunc(orderRepo)
+	api.OrdersGetAllOrdersHandler = ordersHandler.ListAllOrdersFunc(orderRepo)
 }
 
 type Order struct {
@@ -42,7 +43,7 @@ func NewOrder(logger *zap.Logger) *Order {
 	}
 }
 
-func mapOrder(o *ent.Order, log *zap.Logger) (*models.Order, error) {
+func mapUserOrder(o *ent.Order, log *zap.Logger) (*models.UserOrder, error) {
 	if o == nil {
 		log.Warn("order is nil")
 		return nil, errors.New("order is nil")
@@ -143,7 +144,7 @@ func mapOrder(o *ent.Order, log *zap.Logger) (*models.Order, error) {
 		statusToOrder = mappedStatus
 	}
 
-	return &models.Order{
+	return &models.UserOrder{
 		Description: &o.Description,
 		Equipments:  orderEquipments,
 		ID:          &id,
@@ -159,10 +160,10 @@ func mapOrder(o *ent.Order, log *zap.Logger) (*models.Order, error) {
 	}, nil
 }
 
-func mapOrdersToResponse(entOrders []*ent.Order, log *zap.Logger) ([]*models.Order, error) {
-	modelOrders := make([]*models.Order, len(entOrders))
+func mapUserOrdersToResponse(entOrders []*ent.Order, log *zap.Logger) ([]*models.UserOrder, error) {
+	modelOrders := make([]*models.UserOrder, len(entOrders))
 	for i, o := range entOrders {
-		order, err := mapOrder(o, log)
+		order, err := mapUserOrder(o, log)
 		if err != nil {
 			log.Error("failed to map order", zap.Error(err))
 			return nil, err
@@ -173,8 +174,33 @@ func mapOrdersToResponse(entOrders []*ent.Order, log *zap.Logger) ([]*models.Ord
 	return modelOrders, nil
 }
 
-func (o Order) ListOrderFunc(repository domain.OrderRepository) orders.GetAllOrdersHandlerFunc {
-	return func(p orders.GetAllOrdersParams, principal *models.Principal) middleware.Responder {
+func mapOrdersToResponse(entOrders []*ent.Order, log *zap.Logger) ([]*models.Order, error) {
+	modelOrders := make([]*models.Order, len(entOrders))
+	for i, o := range entOrders {
+		uo, err := mapUserOrder(o, log)
+		if err != nil {
+			log.Error("failed to map order", zap.Error(err))
+			return nil, err
+		}
+		user := mapUserInfoWoRole(o.Edges.Users)
+		mo := &models.Order{
+			Description: uo.Description,
+			Equipments:  uo.Equipments,
+			ID:          uo.ID,
+			IsFirst:     uo.IsFirst,
+			LastStatus:  uo.LastStatus,
+			Quantity:    uo.Quantity,
+			RentEnd:     uo.RentEnd,
+			RentStart:   uo.RentStart,
+			User:        user,
+		}
+		modelOrders[i] = mo
+	}
+	return modelOrders, nil
+}
+
+func (o Order) ListUserOrdersFunc(repository domain.OrderRepository) orders.GetUserOrdersHandlerFunc {
+	return func(p orders.GetUserOrdersParams, principal *models.Principal) middleware.Responder {
 		ctx := p.HTTPRequest.Context()
 		userID := int(principal.ID)
 		limit := utils.GetValueByPointerOrDefaultValue(p.Limit, math.MaxInt)
@@ -194,7 +220,7 @@ func (o Order) ListOrderFunc(repository domain.OrderRepository) orders.GetAllOrd
 		if p.Status != nil {
 			_, ok := domain.AllOrderStatuses[*p.Status]
 			if !ok {
-				return orders.NewGetAllOrdersDefault(http.StatusBadRequest).
+				return orders.NewGetUserOrdersDefault(http.StatusBadRequest).
 					WithPayload(buildStringPayload(fmt.Sprintf("Invalid order status '%v'", *p.Status)))
 			}
 		}
@@ -202,13 +228,74 @@ func (o Order) ListOrderFunc(repository domain.OrderRepository) orders.GetAllOrd
 		total, err := repository.OrdersTotal(ctx, userID)
 		if err != nil {
 			o.logger.Error("Error while getting total of all user's orders", zap.Error(err))
-			return orders.NewGetAllOrdersDefault(http.StatusInternalServerError).
+			return orders.NewGetUserOrdersDefault(http.StatusInternalServerError).
 				WithPayload(buildErrorPayload(err))
 		}
 
 		var items []*ent.Order
 		if total > 0 {
 			items, err = repository.List(ctx, userID, orderFilter)
+			if err != nil {
+				o.logger.Error("list items failed", zap.Error(err))
+				return orders.NewGetUserOrdersDefault(http.StatusInternalServerError).WithPayload(buildErrorPayload(err))
+			}
+		}
+
+		mappedOrders, err := mapUserOrdersToResponse(items, o.logger)
+		if err != nil {
+			o.logger.Error("map orders to response failed", zap.Error(err))
+			return orders.NewGetUserOrdersDefault(http.StatusInternalServerError).WithPayload(buildErrorPayload(err))
+		}
+		totalOrders := int64(total)
+		listOrders := &models.UserOrdersList{
+			Items: mappedOrders,
+			Total: &totalOrders,
+		}
+		return orders.NewGetUserOrdersOK().WithPayload(listOrders)
+	}
+}
+
+func (o Order) ListAllOrdersFunc(repository domain.OrderRepository) orders.GetAllOrdersHandlerFunc {
+	return func(p orders.GetAllOrdersParams, _ *models.Principal) middleware.Responder {
+		ctx := p.HTTPRequest.Context()
+		limit := utils.GetValueByPointerOrDefaultValue(p.Limit, math.MaxInt)
+		offset := utils.GetValueByPointerOrDefaultValue(p.Offset, 0)
+		orderBy := utils.GetValueByPointerOrDefaultValue(p.OrderBy, utils.AscOrder)
+		orderColumn := utils.GetValueByPointerOrDefaultValue(p.OrderColumn, order.FieldID)
+
+		orderFilter := domain.OrderFilter{
+			Filter: domain.Filter{
+				Limit:       int(limit),
+				Offset:      int(offset),
+				OrderBy:     orderBy,
+				OrderColumn: orderColumn,
+			},
+		}
+		
+		if p.Status != nil {
+			_, ok := domain.AllOrderStatuses[*p.Status]
+			if !ok {
+				return orders.NewGetAllOrdersDefault(http.StatusBadRequest).
+					WithPayload(buildStringPayload(fmt.Sprintf("Invalid order status '%v'", *p.Status)))
+			}
+			orderFilter.Status = p.Status
+		}
+		
+		if p.EquipmentID != nil {
+			eid := int(*p.EquipmentID)
+			orderFilter.EquipmentID = &eid
+		}
+
+		total, err := repository.OrdersTotal(ctx, -1)
+		if err != nil {
+			o.logger.Error("Error while getting total of all orders", zap.Error(err))
+			return orders.NewGetAllOrdersDefault(http.StatusInternalServerError).
+				WithPayload(buildErrorPayload(err))
+		}
+
+		var items []*ent.Order
+		if total > 0 {
+			items, err = repository.List(ctx, -1, orderFilter)
 			if err != nil {
 				o.logger.Error("list items failed", zap.Error(err))
 				return orders.NewGetAllOrdersDefault(http.StatusInternalServerError).WithPayload(buildErrorPayload(err))
@@ -221,7 +308,7 @@ func (o Order) ListOrderFunc(repository domain.OrderRepository) orders.GetAllOrd
 			return orders.NewGetAllOrdersDefault(http.StatusInternalServerError).WithPayload(buildErrorPayload(err))
 		}
 		totalOrders := int64(total)
-		listOrders := &models.OrderList{
+		listOrders := &models.OrdersList{
 			Items: mappedOrders,
 			Total: &totalOrders,
 		}
@@ -269,14 +356,14 @@ func (o Order) CreateOrderFunc(
 			OrderID:     int64(order.ID),
 		}); err != nil {
 			o.logger.Error("error while creating equipment status", zap.Error(err))
-			return orders.NewGetAllOrdersDefault(http.StatusInternalServerError).
+			return orders.NewGetUserOrdersDefault(http.StatusInternalServerError).
 				WithPayload(buildErrorPayload(err))
 		}
 
-		mappedOrder, err := mapOrder(order, o.logger)
+		mappedOrder, err := mapUserOrder(order, o.logger)
 		if err != nil {
 			o.logger.Error("failed to map order", zap.Error(err))
-			return orders.NewGetAllOrdersDefault(http.StatusInternalServerError).WithPayload(buildErrorPayload(err))
+			return orders.NewGetUserOrdersDefault(http.StatusInternalServerError).WithPayload(buildErrorPayload(err))
 		}
 
 		return orders.NewCreateOrderCreated().WithPayload(mappedOrder)
@@ -295,7 +382,7 @@ func (o Order) UpdateOrderFunc(repository domain.OrderRepository) orders.UpdateO
 			return orders.NewUpdateOrderDefault(http.StatusInternalServerError).WithPayload(buildErrorPayload(err))
 		}
 
-		mappedOrder, err := mapOrder(order, o.logger)
+		mappedOrder, err := mapUserOrder(order, o.logger)
 		if err != nil {
 			o.logger.Error("failed to map order", zap.Error(err))
 			return orders.NewUpdateOrderDefault(http.StatusInternalServerError).WithPayload(buildErrorPayload(err))

--- a/internal/handlers/order.go
+++ b/internal/handlers/order.go
@@ -271,7 +271,7 @@ func (o Order) ListAllOrdersFunc(repository domain.OrderRepository) orders.GetAl
 				OrderColumn: orderColumn,
 			},
 		}
-		
+
 		if p.Status != nil {
 			_, ok := domain.AllOrderStatuses[*p.Status]
 			if !ok {
@@ -280,7 +280,7 @@ func (o Order) ListAllOrdersFunc(repository domain.OrderRepository) orders.GetAl
 			}
 			orderFilter.Status = p.Status
 		}
-		
+
 		if p.EquipmentID != nil {
 			eid := int(*p.EquipmentID)
 			orderFilter.EquipmentID = &eid

--- a/internal/handlers/order.go
+++ b/internal/handlers/order.go
@@ -234,7 +234,7 @@ func (o Order) ListUserOrdersFunc(repository domain.OrderRepository) orders.GetU
 
 		var items []*ent.Order
 		if total > 0 {
-			items, err = repository.List(ctx, userID, orderFilter)
+			items, err = repository.List(ctx, &userID, orderFilter)
 			if err != nil {
 				o.logger.Error("list items failed", zap.Error(err))
 				return orders.NewGetUserOrdersDefault(http.StatusInternalServerError).WithPayload(buildErrorPayload(err))
@@ -295,7 +295,7 @@ func (o Order) ListAllOrdersFunc(repository domain.OrderRepository) orders.GetAl
 
 		var items []*ent.Order
 		if total > 0 {
-			items, err = repository.List(ctx, -1, orderFilter)
+			items, err = repository.List(ctx, nil, orderFilter)
 			if err != nil {
 				o.logger.Error("list items failed", zap.Error(err))
 				return orders.NewGetAllOrdersDefault(http.StatusInternalServerError).WithPayload(buildErrorPayload(err))

--- a/internal/handlers/order_status.go
+++ b/internal/handlers/order_status.go
@@ -288,9 +288,9 @@ func (h *OrderStatus) GetOrdersByStatus(repository domain.OrderRepositoryWithFil
 					WithPayload(buildStringPayload(fmt.Sprintf("Can't get orders by status. error: %s", err.Error())))
 			}
 		}
-		ordersResult := make([]*models.Order, len(ordersByStatus))
+		ordersResult := make([]*models.UserOrder, len(ordersByStatus))
 		for index, order := range ordersByStatus {
-			tmpOrder, errMap := mapOrder(order, h.logger)
+			tmpOrder, errMap := mapUserOrder(order, h.logger)
 			if errMap != nil {
 				h.logger.Error("GetOrdersByStatus error", zap.Error(errMap))
 				return orders.NewGetOrdersByStatusDefault(http.StatusInternalServerError).
@@ -300,7 +300,7 @@ func (h *OrderStatus) GetOrdersByStatus(repository domain.OrderRepositoryWithFil
 		}
 
 		totalOrders := int64(total)
-		listOrders := &models.OrderList{
+		listOrders := &models.UserOrdersList{
 			Items: ordersResult,
 			Total: &totalOrders,
 		}
@@ -335,9 +335,9 @@ func (h *OrderStatus) GetOrdersByPeriodAndStatus(repository domain.OrderReposito
 					WithPayload(buildStringPayload("Can't get orders by period and status"))
 			}
 		}
-		ordersResult := make([]*models.Order, len(ordersByPeriodAndStatus))
+		ordersResult := make([]*models.UserOrder, len(ordersByPeriodAndStatus))
 		for index, order := range ordersByPeriodAndStatus {
-			tmpOrder, errMap := mapOrder(order, h.logger)
+			tmpOrder, errMap := mapUserOrder(order, h.logger)
 			if errMap != nil {
 				h.logger.Error("GetOrdersByPeriodAndStatus error", zap.Error(errMap))
 				return orders.NewGetOrdersByDateAndStatusDefault(http.StatusInternalServerError).
@@ -347,7 +347,7 @@ func (h *OrderStatus) GetOrdersByPeriodAndStatus(repository domain.OrderReposito
 		}
 
 		totalOrders := int64(total)
-		listOrders := &models.OrderList{
+		listOrders := &models.UserOrdersList{
 			Items: ordersResult,
 			Total: &totalOrders,
 		}

--- a/internal/handlers/order_status_test.go
+++ b/internal/handlers/order_status_test.go
@@ -1172,7 +1172,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByStatus_EmptyResult() {
 	resp.WriteResponse(responseRecorder, producer)
 	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
-	responseOrders := models.OrderList{}
+	responseOrders := models.UserOrdersList{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseOrders)
 	if err != nil {
 		t.Fatal(err)
@@ -1250,7 +1250,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByStatus_EmptyPagination
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
 	require.Equal(t, http.StatusOK, responseRecorder.Code)
-	responseOrders := models.OrderList{}
+	responseOrders := models.UserOrdersList{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseOrders)
 	if err != nil {
 		t.Fatal(err)
@@ -1310,7 +1310,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByStatus_LimitGreaterTha
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
 	require.Equal(t, http.StatusOK, responseRecorder.Code)
-	responseOrders := models.OrderList{}
+	responseOrders := models.UserOrdersList{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseOrders)
 	if err != nil {
 		t.Fatal(err)
@@ -1370,7 +1370,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByStatus_LimitLessThanTo
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
 	require.Equal(t, http.StatusOK, responseRecorder.Code)
-	responseOrders := models.OrderList{}
+	responseOrders := models.UserOrdersList{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseOrders)
 	if err != nil {
 		t.Fatal(err)
@@ -1431,7 +1431,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByStatus_SecondPage() {
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
 	require.Equal(t, http.StatusOK, responseRecorder.Code)
-	responseOrders := models.OrderList{}
+	responseOrders := models.UserOrdersList{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseOrders)
 	if err != nil {
 		t.Fatal(err)
@@ -1493,7 +1493,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByStatus_SeveralPages() 
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
 	require.Equal(t, http.StatusOK, responseRecorder.Code)
-	firstPage := models.OrderList{}
+	firstPage := models.UserOrdersList{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &firstPage)
 	if err != nil {
 		t.Fatal(err)
@@ -1524,7 +1524,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByStatus_SeveralPages() 
 	producer = runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
 	require.Equal(t, http.StatusOK, responseRecorder.Code)
-	secondPage := models.OrderList{}
+	secondPage := models.UserOrdersList{}
 	err = json.Unmarshal(responseRecorder.Body.Bytes(), &secondPage)
 	if err != nil {
 		t.Fatal(err)
@@ -1619,7 +1619,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByPeriodAndStatus_EmptyR
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
 	require.Equal(t, http.StatusOK, responseRecorder.Code)
-	responseOrders := models.OrderList{}
+	responseOrders := models.UserOrdersList{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseOrders)
 	if err != nil {
 		t.Fatal(err)
@@ -1760,7 +1760,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByPeriodAndStatus_LimitG
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
 	require.Equal(t, http.StatusOK, responseRecorder.Code)
-	responseOrders := models.OrderList{}
+	responseOrders := models.UserOrdersList{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseOrders)
 	if err != nil {
 		t.Fatal(err)
@@ -1824,7 +1824,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByPeriodAndStatus_LimitL
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
 	require.Equal(t, http.StatusOK, responseRecorder.Code)
-	responseOrders := models.OrderList{}
+	responseOrders := models.UserOrdersList{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseOrders)
 	if err != nil {
 		t.Fatal(err)
@@ -1889,7 +1889,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByPeriodAndStatus_Second
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
 	require.Equal(t, http.StatusOK, responseRecorder.Code)
-	responseOrders := models.OrderList{}
+	responseOrders := models.UserOrdersList{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseOrders)
 	if err != nil {
 		t.Fatal(err)
@@ -1955,7 +1955,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByPeriodAndStatus_Severa
 	producer := runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
 	require.Equal(t, http.StatusOK, responseRecorder.Code)
-	firstPage := models.OrderList{}
+	firstPage := models.UserOrdersList{}
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &firstPage)
 	if err != nil {
 		t.Fatal(err)
@@ -1988,7 +1988,7 @@ func (s *OrderStatusTestSuite) TestOrderStatus_GetOrdersByPeriodAndStatus_Severa
 	producer = runtime.JSONProducer()
 	resp.WriteResponse(responseRecorder, producer)
 	require.Equal(t, http.StatusOK, responseRecorder.Code)
-	secondPage := models.OrderList{}
+	secondPage := models.UserOrdersList{}
 	err = json.Unmarshal(responseRecorder.Body.Bytes(), &secondPage)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/handlers/order_test.go
+++ b/internal/handlers/order_test.go
@@ -111,7 +111,7 @@ func (s *orderTestSuite) TearDownTest() {
 	s.equipmentRepository.AssertExpectations(s.T())
 }
 
-func (s *orderTestSuite) TestOrder_ListOrder_RepoErr() {
+func (s *orderTestSuite) TestOrder_ListUserOrders_RepoErr() {
 	t := s.T()
 	request := http.Request{}
 	ctx := request.Context()
@@ -132,7 +132,7 @@ func (s *orderTestSuite) TestOrder_ListOrder_RepoErr() {
 	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 }
 
-func (s *orderTestSuite) TestOrder_ListOrder_WrongStatus() {
+func (s *orderTestSuite) TestOrder_ListUserOrders_WrongStatus() {
 	t := s.T()
 	request := http.Request{}
 	userID := 1
@@ -161,7 +161,7 @@ func (s *orderTestSuite) TestOrder_ListOrder_WrongStatus() {
 	require.Equal(t, fmt.Sprintf("Invalid order status '%v'", st), response.Data.Message)
 }
 
-func (s *orderTestSuite) TestOrder_ListOrder_MapErr() {
+func (s *orderTestSuite) TestOrder_ListUserOrders_MapErr() {
 	t := s.T()
 	request := http.Request{}
 	ctx := request.Context()
@@ -192,7 +192,7 @@ func (s *orderTestSuite) TestOrder_ListOrder_MapErr() {
 	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 }
 
-func (s *orderTestSuite) TestOrder_ListOrder_NotFound() {
+func (s *orderTestSuite) TestOrder_ListUserOrders_NotFound() {
 	t := s.T()
 	request := http.Request{}
 	ctx := request.Context()
@@ -219,7 +219,7 @@ func (s *orderTestSuite) TestOrder_ListOrder_NotFound() {
 	require.Equal(t, 0, len(response.Items))
 }
 
-func (s *orderTestSuite) TestOrder_ListOrder_EmptyParams() {
+func (s *orderTestSuite) TestOrder_ListUserOrders_EmptyParams() {
 	t := s.T()
 	request := http.Request{}
 	ctx := request.Context()
@@ -262,7 +262,7 @@ func (s *orderTestSuite) TestOrder_ListOrder_EmptyParams() {
 	}
 }
 
-func (s *orderTestSuite) TestOrder_ListOrder_LimitGreaterThanTotal() {
+func (s *orderTestSuite) TestOrder_ListUserOrders_LimitGreaterThanTotal() {
 	t := s.T()
 	request := http.Request{}
 	ctx := request.Context()
@@ -316,7 +316,7 @@ func (s *orderTestSuite) TestOrder_ListOrder_LimitGreaterThanTotal() {
 	}
 }
 
-func (s *orderTestSuite) TestOrder_ListOrder_LimitLessThanTotal() {
+func (s *orderTestSuite) TestOrder_ListUserOrders_LimitLessThanTotal() {
 	t := s.T()
 	request := http.Request{}
 	ctx := request.Context()
@@ -372,7 +372,7 @@ func (s *orderTestSuite) TestOrder_ListOrder_LimitLessThanTotal() {
 	}
 }
 
-func (s *orderTestSuite) TestOrder_ListOrder_SecondPage() {
+func (s *orderTestSuite) TestOrder_ListUserOrders_SecondPage() {
 	t := s.T()
 	request := http.Request{}
 	ctx := request.Context()
@@ -428,7 +428,7 @@ func (s *orderTestSuite) TestOrder_ListOrder_SecondPage() {
 	}
 }
 
-func (s *orderTestSuite) TestOrder_ListOrder_SeveralPages() {
+func (s *orderTestSuite) TestOrder_ListUserOrders_SeveralPages() {
 	t := s.T()
 	request := http.Request{}
 	ctx := request.Context()
@@ -517,7 +517,7 @@ func (s *orderTestSuite) TestOrder_ListOrder_SeveralPages() {
 	require.False(t, ordersDuplicated(t, firstPage.Items, secondPage.Items))
 }
 
-func (s *orderTestSuite) TestOrder_ListOrder_StatusFilter() {
+func (s *orderTestSuite) TestOrder_ListUserOrders_StatusFilter() {
 	t := s.T()
 	request := http.Request{}
 	ctx := request.Context()

--- a/internal/handlers/order_test.go
+++ b/internal/handlers/order_test.go
@@ -42,7 +42,7 @@ func TestSetOrderHandler(t *testing.T) {
 	}
 	api := operations.NewBeAPI(swaggerSpec)
 	SetOrderHandler(logger, api)
-	require.NotEmpty(t, api.OrdersGetAllOrdersHandler)
+	require.NotEmpty(t, api.OrdersGetUserOrdersHandler)
 	require.NotEmpty(t, api.OrdersCreateOrderHandler)
 	require.NotEmpty(t, api.OrdersUpdateOrderHandler)
 }
@@ -120,8 +120,8 @@ func (s *orderTestSuite) TestOrder_ListOrder_RepoErr() {
 	err := errors.New("error")
 	s.orderRepository.On("OrdersTotal", ctx, userID).Return(0, err)
 
-	handlerFunc := s.orderHandler.ListOrderFunc(s.orderRepository)
-	data := orders.GetAllOrdersParams{HTTPRequest: &request}
+	handlerFunc := s.orderHandler.ListUserOrdersFunc(s.orderRepository)
+	data := orders.GetUserOrdersParams{HTTPRequest: &request}
 
 	principal := &models.Principal{ID: int64(userID)}
 	resp := handlerFunc.Handle(data, principal)
@@ -138,8 +138,8 @@ func (s *orderTestSuite) TestOrder_ListOrder_WrongStatus() {
 	userID := 1
 	st := "qwe"
 
-	handlerFunc := s.orderHandler.ListOrderFunc(s.orderRepository)
-	data := orders.GetAllOrdersParams{
+	handlerFunc := s.orderHandler.ListUserOrdersFunc(s.orderRepository)
+	data := orders.GetUserOrdersParams{
 		HTTPRequest: &request,
 		Status:      &st,
 	}
@@ -181,8 +181,8 @@ func (s *orderTestSuite) TestOrder_ListOrder_MapErr() {
 	s.orderRepository.On("List", ctx, userID, filter).
 		Return(orderList, nil)
 
-	handlerFunc := s.orderHandler.ListOrderFunc(s.orderRepository)
-	data := orders.GetAllOrdersParams{HTTPRequest: &request}
+	handlerFunc := s.orderHandler.ListUserOrdersFunc(s.orderRepository)
+	data := orders.GetUserOrdersParams{HTTPRequest: &request}
 	principal := &models.Principal{ID: int64(userID)}
 	resp := handlerFunc.Handle(data, principal)
 
@@ -200,8 +200,8 @@ func (s *orderTestSuite) TestOrder_ListOrder_NotFound() {
 	userID := 1
 	s.orderRepository.On("OrdersTotal", ctx, userID).Return(0, nil)
 
-	handlerFunc := s.orderHandler.ListOrderFunc(s.orderRepository)
-	data := orders.GetAllOrdersParams{HTTPRequest: &request}
+	handlerFunc := s.orderHandler.ListUserOrdersFunc(s.orderRepository)
+	data := orders.GetUserOrdersParams{HTTPRequest: &request}
 	principal := &models.Principal{ID: int64(userID)}
 	resp := handlerFunc.Handle(data, principal)
 
@@ -210,7 +210,7 @@ func (s *orderTestSuite) TestOrder_ListOrder_NotFound() {
 	resp.WriteResponse(responseRecorder, producer)
 	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
-	var response models.OrderList
+	var response models.UserOrdersList
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &response)
 	if err != nil {
 		t.Fatal(err)
@@ -240,8 +240,8 @@ func (s *orderTestSuite) TestOrder_ListOrder_EmptyParams() {
 	s.orderRepository.On("List", ctx, userID, filter).
 		Return(orderList, nil)
 
-	handlerFunc := s.orderHandler.ListOrderFunc(s.orderRepository)
-	data := orders.GetAllOrdersParams{HTTPRequest: &request}
+	handlerFunc := s.orderHandler.ListUserOrdersFunc(s.orderRepository)
+	data := orders.GetUserOrdersParams{HTTPRequest: &request}
 	principal := &models.Principal{ID: int64(userID)}
 	resp := handlerFunc.Handle(data, principal)
 
@@ -250,7 +250,7 @@ func (s *orderTestSuite) TestOrder_ListOrder_EmptyParams() {
 	resp.WriteResponse(responseRecorder, producer)
 	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
-	var response models.OrderList
+	var response models.UserOrdersList
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &response)
 	if err != nil {
 		t.Fatal(err)
@@ -288,8 +288,8 @@ func (s *orderTestSuite) TestOrder_ListOrder_LimitGreaterThanTotal() {
 	s.orderRepository.On("List", ctx, userID, filter).
 		Return(orderList, nil)
 
-	handlerFunc := s.orderHandler.ListOrderFunc(s.orderRepository)
-	data := orders.GetAllOrdersParams{
+	handlerFunc := s.orderHandler.ListUserOrdersFunc(s.orderRepository)
+	data := orders.GetUserOrdersParams{
 		HTTPRequest: &request,
 		Limit:       &limit,
 		Offset:      &offset,
@@ -304,7 +304,7 @@ func (s *orderTestSuite) TestOrder_ListOrder_LimitGreaterThanTotal() {
 	resp.WriteResponse(responseRecorder, producer)
 	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
-	var response models.OrderList
+	var response models.UserOrdersList
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &response)
 	if err != nil {
 		t.Fatal(err)
@@ -344,8 +344,8 @@ func (s *orderTestSuite) TestOrder_ListOrder_LimitLessThanTotal() {
 	s.orderRepository.On("List", ctx, userID, filter).
 		Return(orderList[:limit], nil)
 
-	handlerFunc := s.orderHandler.ListOrderFunc(s.orderRepository)
-	data := orders.GetAllOrdersParams{
+	handlerFunc := s.orderHandler.ListUserOrdersFunc(s.orderRepository)
+	data := orders.GetUserOrdersParams{
 		HTTPRequest: &request,
 		Limit:       &limit,
 		Offset:      &offset,
@@ -360,7 +360,7 @@ func (s *orderTestSuite) TestOrder_ListOrder_LimitLessThanTotal() {
 	resp.WriteResponse(responseRecorder, producer)
 	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
-	var response models.OrderList
+	var response models.UserOrdersList
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &response)
 	if err != nil {
 		t.Fatal(err)
@@ -400,8 +400,8 @@ func (s *orderTestSuite) TestOrder_ListOrder_SecondPage() {
 	s.orderRepository.On("List", ctx, userID, filter).
 		Return(orderList[offset:], nil)
 
-	handlerFunc := s.orderHandler.ListOrderFunc(s.orderRepository)
-	data := orders.GetAllOrdersParams{
+	handlerFunc := s.orderHandler.ListUserOrdersFunc(s.orderRepository)
+	data := orders.GetUserOrdersParams{
 		HTTPRequest: &request,
 		Limit:       &limit,
 		Offset:      &offset,
@@ -416,7 +416,7 @@ func (s *orderTestSuite) TestOrder_ListOrder_SecondPage() {
 	resp.WriteResponse(responseRecorder, producer)
 	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
-	var response models.OrderList
+	var response models.UserOrdersList
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &response)
 	if err != nil {
 		t.Fatal(err)
@@ -456,8 +456,8 @@ func (s *orderTestSuite) TestOrder_ListOrder_SeveralPages() {
 	s.orderRepository.On("List", ctx, userID, filter).
 		Return(orderList[:limit], nil)
 
-	handlerFunc := s.orderHandler.ListOrderFunc(s.orderRepository)
-	data := orders.GetAllOrdersParams{
+	handlerFunc := s.orderHandler.ListUserOrdersFunc(s.orderRepository)
+	data := orders.GetUserOrdersParams{
 		HTTPRequest: &request,
 		Limit:       &limit,
 		Offset:      &offset,
@@ -472,7 +472,7 @@ func (s *orderTestSuite) TestOrder_ListOrder_SeveralPages() {
 	resp.WriteResponse(responseRecorder, producer)
 	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
-	var firstPage models.OrderList
+	var firstPage models.UserOrdersList
 	err := json.Unmarshal(responseRecorder.Body.Bytes(), &firstPage)
 	if err != nil {
 		t.Fatal(err)
@@ -489,7 +489,7 @@ func (s *orderTestSuite) TestOrder_ListOrder_SeveralPages() {
 	s.orderRepository.On("List", ctx, userID, filter).
 		Return(orderList[offset:], nil)
 
-	data = orders.GetAllOrdersParams{
+	data = orders.GetUserOrdersParams{
 		HTTPRequest: &request,
 		Limit:       &limit,
 		Offset:      &offset,
@@ -503,7 +503,7 @@ func (s *orderTestSuite) TestOrder_ListOrder_SeveralPages() {
 	resp.WriteResponse(responseRecorder, producer)
 	require.Equal(t, http.StatusOK, responseRecorder.Code)
 
-	var secondPage models.OrderList
+	var secondPage models.UserOrdersList
 	err = json.Unmarshal(responseRecorder.Body.Bytes(), &secondPage)
 	if err != nil {
 		t.Fatal(err)
@@ -544,7 +544,7 @@ func (s *orderTestSuite) TestOrder_ListOrder_StatusFilter() {
 	orderList[2].Edges.OrderStatus[0].ID = 6 // prepared (active)
 	orderList[3].Edges.OrderStatus[0].ID = 4 // rejected (finished)
 
-	handlerFunc := s.orderHandler.ListOrderFunc(s.orderRepository)
+	handlerFunc := s.orderHandler.ListUserOrdersFunc(s.orderRepository)
 	tests := map[string]struct {
 		fl   domain.OrderFilter
 		ords []*ent.Order
@@ -584,7 +584,7 @@ func (s *orderTestSuite) TestOrder_ListOrder_StatusFilter() {
 			s.orderRepository.On("List", ctx, userID, tc.fl).
 				Return(tc.ords, nil)
 
-			data := orders.GetAllOrdersParams{
+			data := orders.GetUserOrdersParams{
 				HTTPRequest: &request,
 				Limit:       &limit,
 				Offset:      &offset,
@@ -600,7 +600,7 @@ func (s *orderTestSuite) TestOrder_ListOrder_StatusFilter() {
 			resp.WriteResponse(responseRecorder, producer)
 			require.Equal(t, http.StatusOK, responseRecorder.Code)
 
-			var response models.OrderList
+			var response models.UserOrdersList
 			err := json.Unmarshal(responseRecorder.Body.Bytes(), &response)
 			if err != nil {
 				t.Fatal(err)
@@ -914,7 +914,7 @@ func (s *orderTestSuite) TestOrder_UpdateOrder_OK() {
 	require.Equal(t, orderToReturn.ID, int(*responseOrder.ID))
 }
 
-func containsOrder(t *testing.T, list []*ent.Order, order *models.Order) bool {
+func containsOrder(t *testing.T, list []*ent.Order, order *models.UserOrder) bool {
 	t.Helper()
 	for _, v := range list {
 		if v.ID == int(*order.ID) && v.Description == *order.Description &&
@@ -929,7 +929,7 @@ func containsOrder(t *testing.T, list []*ent.Order, order *models.Order) bool {
 	return false
 }
 
-func ordersDuplicated(t *testing.T, array1, array2 []*models.Order) bool {
+func ordersDuplicated(t *testing.T, array1, array2 []*models.UserOrder) bool {
 	t.Helper()
 	diff := make(map[int64]int, len(array1))
 	for _, v := range array1 {

--- a/internal/handlers/order_test.go
+++ b/internal/handlers/order_test.go
@@ -178,7 +178,7 @@ func (s *orderTestSuite) TestOrder_ListUserOrders_MapErr() {
 	var orderList []*ent.Order
 	orderList = append(orderList, orderWithNoEdges())
 	s.orderRepository.On("OrdersTotal", ctx, userID).Return(1, nil)
-	s.orderRepository.On("List", ctx, userID, filter).
+	s.orderRepository.On("List", ctx, &userID, filter).
 		Return(orderList, nil)
 
 	handlerFunc := s.orderHandler.ListUserOrdersFunc(s.orderRepository)
@@ -237,7 +237,7 @@ func (s *orderTestSuite) TestOrder_ListUserOrders_EmptyParams() {
 		orderWithAllEdges(t, 1),
 	}
 	s.orderRepository.On("OrdersTotal", ctx, userID).Return(1, nil)
-	s.orderRepository.On("List", ctx, userID, filter).
+	s.orderRepository.On("List", ctx, &userID, filter).
 		Return(orderList, nil)
 
 	handlerFunc := s.orderHandler.ListUserOrdersFunc(s.orderRepository)
@@ -285,7 +285,7 @@ func (s *orderTestSuite) TestOrder_ListUserOrders_LimitGreaterThanTotal() {
 		orderWithAllEdges(t, 2),
 	}
 	s.orderRepository.On("OrdersTotal", ctx, userID).Return(2, nil)
-	s.orderRepository.On("List", ctx, userID, filter).
+	s.orderRepository.On("List", ctx, &userID, filter).
 		Return(orderList, nil)
 
 	handlerFunc := s.orderHandler.ListUserOrdersFunc(s.orderRepository)
@@ -341,7 +341,7 @@ func (s *orderTestSuite) TestOrder_ListUserOrders_LimitLessThanTotal() {
 		orderWithAllEdges(t, 4),
 	}
 	s.orderRepository.On("OrdersTotal", ctx, userID).Return(4, nil)
-	s.orderRepository.On("List", ctx, userID, filter).
+	s.orderRepository.On("List", ctx, &userID, filter).
 		Return(orderList[:limit], nil)
 
 	handlerFunc := s.orderHandler.ListUserOrdersFunc(s.orderRepository)
@@ -397,7 +397,7 @@ func (s *orderTestSuite) TestOrder_ListUserOrders_SecondPage() {
 		orderWithAllEdges(t, 4),
 	}
 	s.orderRepository.On("OrdersTotal", ctx, userID).Return(4, nil)
-	s.orderRepository.On("List", ctx, userID, filter).
+	s.orderRepository.On("List", ctx, &userID, filter).
 		Return(orderList[offset:], nil)
 
 	handlerFunc := s.orderHandler.ListUserOrdersFunc(s.orderRepository)
@@ -453,7 +453,7 @@ func (s *orderTestSuite) TestOrder_ListUserOrders_SeveralPages() {
 		orderWithAllEdges(t, 4),
 	}
 	s.orderRepository.On("OrdersTotal", ctx, userID).Return(4, nil)
-	s.orderRepository.On("List", ctx, userID, filter).
+	s.orderRepository.On("List", ctx, &userID, filter).
 		Return(orderList[:limit], nil)
 
 	handlerFunc := s.orderHandler.ListUserOrdersFunc(s.orderRepository)
@@ -486,7 +486,7 @@ func (s *orderTestSuite) TestOrder_ListUserOrders_SeveralPages() {
 	offset = limit
 	filter.Offset = int(offset)
 	s.orderRepository.On("OrdersTotal", ctx, userID).Return(4, nil)
-	s.orderRepository.On("List", ctx, userID, filter).
+	s.orderRepository.On("List", ctx, &userID, filter).
 		Return(orderList[offset:], nil)
 
 	data = orders.GetUserOrdersParams{
@@ -581,7 +581,7 @@ func (s *orderTestSuite) TestOrder_ListUserOrders_StatusFilter() {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			s.orderRepository.On("OrdersTotal", ctx, userID).Return(4, nil)
-			s.orderRepository.On("List", ctx, userID, tc.fl).
+			s.orderRepository.On("List", ctx, &userID, tc.fl).
 				Return(tc.ords, nil)
 
 			data := orders.GetUserOrdersParams{

--- a/internal/handlers/order_test.go
+++ b/internal/handlers/order_test.go
@@ -118,7 +118,7 @@ func (s *orderTestSuite) TestOrder_ListUserOrders_RepoErr() {
 
 	userID := 1
 	err := errors.New("error")
-	s.orderRepository.On("OrdersTotal", ctx, userID).Return(0, err)
+	s.orderRepository.On("OrdersTotal", ctx, &userID).Return(0, err)
 
 	handlerFunc := s.orderHandler.ListUserOrdersFunc(s.orderRepository)
 	data := orders.GetUserOrdersParams{HTTPRequest: &request}
@@ -177,7 +177,7 @@ func (s *orderTestSuite) TestOrder_ListUserOrders_MapErr() {
 	}
 	var orderList []*ent.Order
 	orderList = append(orderList, orderWithNoEdges())
-	s.orderRepository.On("OrdersTotal", ctx, userID).Return(1, nil)
+	s.orderRepository.On("OrdersTotal", ctx, &userID).Return(1, nil)
 	s.orderRepository.On("List", ctx, &userID, filter).
 		Return(orderList, nil)
 
@@ -198,7 +198,7 @@ func (s *orderTestSuite) TestOrder_ListUserOrders_NotFound() {
 	ctx := request.Context()
 
 	userID := 1
-	s.orderRepository.On("OrdersTotal", ctx, userID).Return(0, nil)
+	s.orderRepository.On("OrdersTotal", ctx, &userID).Return(0, nil)
 
 	handlerFunc := s.orderHandler.ListUserOrdersFunc(s.orderRepository)
 	data := orders.GetUserOrdersParams{HTTPRequest: &request}
@@ -236,7 +236,7 @@ func (s *orderTestSuite) TestOrder_ListUserOrders_EmptyParams() {
 	orderList := []*ent.Order{
 		orderWithAllEdges(t, 1),
 	}
-	s.orderRepository.On("OrdersTotal", ctx, userID).Return(1, nil)
+	s.orderRepository.On("OrdersTotal", ctx, &userID).Return(1, nil)
 	s.orderRepository.On("List", ctx, &userID, filter).
 		Return(orderList, nil)
 
@@ -284,7 +284,7 @@ func (s *orderTestSuite) TestOrder_ListUserOrders_LimitGreaterThanTotal() {
 		orderWithAllEdges(t, 1),
 		orderWithAllEdges(t, 2),
 	}
-	s.orderRepository.On("OrdersTotal", ctx, userID).Return(2, nil)
+	s.orderRepository.On("OrdersTotal", ctx, &userID).Return(2, nil)
 	s.orderRepository.On("List", ctx, &userID, filter).
 		Return(orderList, nil)
 
@@ -340,7 +340,7 @@ func (s *orderTestSuite) TestOrder_ListUserOrders_LimitLessThanTotal() {
 		orderWithAllEdges(t, 3),
 		orderWithAllEdges(t, 4),
 	}
-	s.orderRepository.On("OrdersTotal", ctx, userID).Return(4, nil)
+	s.orderRepository.On("OrdersTotal", ctx, &userID).Return(4, nil)
 	s.orderRepository.On("List", ctx, &userID, filter).
 		Return(orderList[:limit], nil)
 
@@ -396,7 +396,7 @@ func (s *orderTestSuite) TestOrder_ListUserOrders_SecondPage() {
 		orderWithAllEdges(t, 3),
 		orderWithAllEdges(t, 4),
 	}
-	s.orderRepository.On("OrdersTotal", ctx, userID).Return(4, nil)
+	s.orderRepository.On("OrdersTotal", ctx, &userID).Return(4, nil)
 	s.orderRepository.On("List", ctx, &userID, filter).
 		Return(orderList[offset:], nil)
 
@@ -452,7 +452,7 @@ func (s *orderTestSuite) TestOrder_ListUserOrders_SeveralPages() {
 		orderWithAllEdges(t, 3),
 		orderWithAllEdges(t, 4),
 	}
-	s.orderRepository.On("OrdersTotal", ctx, userID).Return(4, nil)
+	s.orderRepository.On("OrdersTotal", ctx, &userID).Return(4, nil)
 	s.orderRepository.On("List", ctx, &userID, filter).
 		Return(orderList[:limit], nil)
 
@@ -485,7 +485,7 @@ func (s *orderTestSuite) TestOrder_ListUserOrders_SeveralPages() {
 
 	offset = limit
 	filter.Offset = int(offset)
-	s.orderRepository.On("OrdersTotal", ctx, userID).Return(4, nil)
+	s.orderRepository.On("OrdersTotal", ctx, &userID).Return(4, nil)
 	s.orderRepository.On("List", ctx, &userID, filter).
 		Return(orderList[offset:], nil)
 
@@ -580,7 +580,7 @@ func (s *orderTestSuite) TestOrder_ListUserOrders_StatusFilter() {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			s.orderRepository.On("OrdersTotal", ctx, userID).Return(4, nil)
+			s.orderRepository.On("OrdersTotal", ctx, &userID).Return(4, nil)
 			s.orderRepository.On("List", ctx, &userID, tc.fl).
 				Return(tc.ords, nil)
 

--- a/internal/handlers/user.go
+++ b/internal/handlers/user.go
@@ -411,16 +411,24 @@ func (c User) ChangeEmail(repo domain.UserRepository,
 }
 
 func mapUserInfo(user *ent.User) (*models.UserInfo, error) {
-	userID := int64(user.ID)
-	passportDate := user.PassportIssueDate.String()
 	if user.Edges.Role == nil {
 		return nil, errors.New("role is nil")
 	}
+	info := mapUserInfoWoRole(user)
 	userRole := user.Edges.Role
 	userRoleInfo := models.UserInfoRole{
 		ID:   int64(userRole.ID),
 		Name: userRole.Name,
 	}
+
+	info.Role = &userRoleInfo
+
+	return info, nil
+}
+
+func mapUserInfoWoRole(user *ent.User) *models.UserInfo {
+	userID := int64(user.ID)
+	passportDate := user.PassportIssueDate.String()
 	typeString := user.Type.String()
 	result := &models.UserInfo{
 		Email:                   &user.Email,
@@ -435,10 +443,9 @@ func mapUserInfo(user *ent.User) (*models.UserInfo, error) {
 		PassportSeries:          user.PassportSeries,
 		Patronymic:              user.Patronymic,
 		PhoneNumber:             user.Phone,
-		Role:                    &userRoleInfo,
 		Surname:                 user.Surname,
 		Type:                    &typeString,
 		IsRegistrationConfirmed: &user.IsRegistrationConfirmed,
 	}
-	return result, nil
+	return result
 }

--- a/internal/integration-tests/common/utils.go
+++ b/internal/integration-tests/common/utils.go
@@ -186,7 +186,7 @@ func ManagerUserLogin(t *testing.T) *users.LoginOK {
 	ctx := context.Background()
 	client := SetupClient()
 	l, p, _ := ManagerLoginPassword(t)
-	// login and get token with admin role
+	// login and get token with manager role
 	loginUser, err := LoginUser(ctx, client, l, p)
 	require.NoError(t, err)
 	return loginUser
@@ -228,7 +228,7 @@ func OperatorUserLogin(t *testing.T) *users.LoginOK {
 	ctx := context.Background()
 	client := SetupClient()
 	l, p, _ := OperatorLoginPassword(t)
-	// login and get token with admin role
+	// login and get token with operator role
 	loginUser, err := LoginUser(ctx, client, l, p)
 	require.NoError(t, err)
 	return loginUser
@@ -270,7 +270,7 @@ func UserLogin(t *testing.T) *users.LoginOK {
 	ctx := context.Background()
 	client := SetupClient()
 	l, p, _ := UserLoginPassword(t)
-	// login and get token with admin role
+	// login and get token with user role
 	loginUser, err := LoginUser(ctx, client, l, p)
 	require.NoError(t, err)
 	return loginUser

--- a/internal/integration-tests/common/utils.go
+++ b/internal/integration-tests/common/utils.go
@@ -108,7 +108,7 @@ func GetUser(ctx context.Context, client *client.Be, authInfo runtime.ClientAuth
 	return currentUser, nil
 }
 
-func AdminLoginPassword(t *testing.T) (string, string, int64) {
+func CreateLoginPassword(t *testing.T, roleId int64) (string, string, int64) {
 	t.Helper()
 	l, p, err := GenerateLoginAndPassword()
 	require.NoError(t, err)
@@ -124,11 +124,10 @@ func AdminLoginPassword(t *testing.T) (string, string, int64) {
 	require.NoError(t, err)
 	auth := AuthInfoFunc(loginUser.GetPayload().AccessToken)
 
-	role := int64(AdminID)
 	params := &users.AssignRoleToUserParams{
 		UserID: *user.ID,
 		Data: &models.AssignRoleToUser{
-			RoleID: &role,
+			RoleID: &roleId,
 		},
 	}
 	params.SetContext(ctx)
@@ -143,133 +142,40 @@ func AdminUserLogin(t *testing.T) *users.LoginOK {
 	t.Helper()
 	ctx := context.Background()
 	client := SetupClient()
-	l, p, _ := AdminLoginPassword(t)
+	l, p, _ := CreateLoginPassword(t, 1)
 	// login and get token with admin role
 	loginUser, err := LoginUser(ctx, client, l, p)
 	require.NoError(t, err)
 	return loginUser
 }
 
-func ManagerLoginPassword(t *testing.T) (string, string, int64) {
-	t.Helper()
-	l, p, err := GenerateLoginAndPassword()
-	require.NoError(t, err)
-
-	ctx := context.Background()
-	client := SetupClient()
-
-	user, err := CreateUser(ctx, client, l, p)
-	require.NoError(t, err)
-
-	// login and get token
-	loginUser, err := LoginUser(ctx, client, l, p)
-	require.NoError(t, err)
-	auth := AuthInfoFunc(loginUser.GetPayload().AccessToken)
-
-	role := int64(2) // manager
-	params := &users.AssignRoleToUserParams{
-		UserID: *user.ID,
-		Data: &models.AssignRoleToUser{
-			RoleID: &role,
-		},
-	}
-	params.SetContext(ctx)
-	params.SetHTTPClient(http.DefaultClient)
-
-	r, err := client.Users.AssignRoleToUser(params, auth)
-	require.NoError(t, err, r)
-	return l, p, *user.ID
-}
-
 func ManagerUserLogin(t *testing.T) *users.LoginOK {
 	t.Helper()
 	ctx := context.Background()
 	client := SetupClient()
-	l, p, _ := ManagerLoginPassword(t)
+	l, p, _ := CreateLoginPassword(t, 2)
 	// login and get token with manager role
 	loginUser, err := LoginUser(ctx, client, l, p)
 	require.NoError(t, err)
 	return loginUser
 }
 
-func OperatorLoginPassword(t *testing.T) (string, string, int64) {
-	t.Helper()
-	l, p, err := GenerateLoginAndPassword()
-	require.NoError(t, err)
-
-	ctx := context.Background()
-	client := SetupClient()
-
-	user, err := CreateUser(ctx, client, l, p)
-	require.NoError(t, err)
-
-	// login and get token
-	loginUser, err := LoginUser(ctx, client, l, p)
-	require.NoError(t, err)
-	auth := AuthInfoFunc(loginUser.GetPayload().AccessToken)
-
-	role := int64(3) // operator
-	params := &users.AssignRoleToUserParams{
-		UserID: *user.ID,
-		Data: &models.AssignRoleToUser{
-			RoleID: &role,
-		},
-	}
-	params.SetContext(ctx)
-	params.SetHTTPClient(http.DefaultClient)
-
-	r, err := client.Users.AssignRoleToUser(params, auth)
-	require.NoError(t, err, r)
-	return l, p, *user.ID
-}
-
 func OperatorUserLogin(t *testing.T) *users.LoginOK {
 	t.Helper()
 	ctx := context.Background()
 	client := SetupClient()
-	l, p, _ := OperatorLoginPassword(t)
+	l, p, _ := CreateLoginPassword(t, 3)
 	// login and get token with operator role
 	loginUser, err := LoginUser(ctx, client, l, p)
 	require.NoError(t, err)
 	return loginUser
 }
 
-func UserLoginPassword(t *testing.T) (string, string, int64) {
-	t.Helper()
-	l, p, err := GenerateLoginAndPassword()
-	require.NoError(t, err)
-
-	ctx := context.Background()
-	client := SetupClient()
-
-	user, err := CreateUser(ctx, client, l, p)
-	require.NoError(t, err)
-
-	// login and get token
-	loginUser, err := LoginUser(ctx, client, l, p)
-	require.NoError(t, err)
-	auth := AuthInfoFunc(loginUser.GetPayload().AccessToken)
-
-	role := int64(4) // user
-	params := &users.AssignRoleToUserParams{
-		UserID: *user.ID,
-		Data: &models.AssignRoleToUser{
-			RoleID: &role,
-		},
-	}
-	params.SetContext(ctx)
-	params.SetHTTPClient(http.DefaultClient)
-
-	r, err := client.Users.AssignRoleToUser(params, auth)
-	require.NoError(t, err, r)
-	return l, p, *user.ID
-}
-
 func UserLogin(t *testing.T) *users.LoginOK {
 	t.Helper()
 	ctx := context.Background()
 	client := SetupClient()
-	l, p, _ := UserLoginPassword(t)
+	l, p, _ := CreateLoginPassword(t, 4)
 	// login and get token with user role
 	loginUser, err := LoginUser(ctx, client, l, p)
 	require.NoError(t, err)

--- a/internal/integration-tests/orders/order_test.go
+++ b/internal/integration-tests/orders/order_test.go
@@ -561,7 +561,7 @@ func TestIntegration_ListAllOrders(t *testing.T) {
 	_, err = client.Orders.CreateOrder(createParams, auth2)
 	require.NoError(t, err)
 
-	// Due to the lack of a Delete method, we cannot clean up orders and 
+	// Due to the lack of a Delete method, we cannot clean up orders and
 	// verify the exact number of orders. For this reason, we are only using
 	// assert.NotEmpty in the cases below.
 	t.Run("Get All Orders as Admin Ok", func(t *testing.T) {

--- a/internal/integration-tests/orders/order_test.go
+++ b/internal/integration-tests/orders/order_test.go
@@ -197,7 +197,7 @@ func TestIntegration_CreateOrder(t *testing.T) {
 	})
 }
 
-func TestIntegration_GetAllOrders(t *testing.T) {
+func TestIntegration_GetUserOrders(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -209,8 +209,8 @@ func TestIntegration_GetAllOrders(t *testing.T) {
 
 	t.Run("Get All Orders Ok", func(t *testing.T) {
 		wantOrders := 1
-		params := orders.NewGetAllOrdersParamsWithContext(ctx)
-		res, err := client.Orders.GetAllOrders(params, auth)
+		params := orders.NewGetUserOrdersParamsWithContext(ctx)
+		res, err := client.Orders.GetUserOrders(params, auth)
 		require.NoError(t, err)
 
 		// check that it has one created order
@@ -237,7 +237,7 @@ func TestIntegration_GetAllOrders(t *testing.T) {
 
 		// orders number changed
 		wantOrders = 2
-		res, err = client.Orders.GetAllOrders(params, auth)
+		res, err = client.Orders.GetUserOrders(params, auth)
 		require.NoError(t, err)
 
 		assert.Equal(t, wantOrders, len(res.GetPayload().Items))
@@ -273,30 +273,30 @@ func TestIntegration_GetAllOrders(t *testing.T) {
 		orderBy := utils.AscOrder
 		orderColumn := order.FieldID
 
-		params := orders.NewGetAllOrdersParamsWithContext(ctx)
+		params := orders.NewGetUserOrdersParamsWithContext(ctx)
 		params.OrderBy = &orderBy
 		params.Limit = &limit
 		params.Offset = &offset
 		params.OrderColumn = &orderColumn
-		res, err := client.Orders.GetAllOrders(params, auth)
+		res, err := client.Orders.GetUserOrders(params, auth)
 		require.NoError(t, err)
 
 		assert.Equal(t, int(limit), len(res.Payload.Items))
 	})
 
 	t.Run("Get All Orders failed: access", func(t *testing.T) {
-		params := orders.NewGetAllOrdersParamsWithContext(ctx)
+		params := orders.NewGetUserOrdersParamsWithContext(ctx)
 		token := common.TokenNotExist
-		_, gotErr := client.Orders.GetAllOrders(params, common.AuthInfoFunc(&token))
+		_, gotErr := client.Orders.GetUserOrders(params, common.AuthInfoFunc(&token))
 		require.Error(t, gotErr)
 
-		wantErr := orders.NewGetAllOrdersDefault(http.StatusUnauthorized)
+		wantErr := orders.NewGetUserOrdersDefault(http.StatusUnauthorized)
 		wantErr.Payload = &models.Error{Data: nil}
 		assert.Equal(t, wantErr, gotErr)
 	})
 
 	t.Run("Get All Orders failed: validation error", func(t *testing.T) {
-		params := orders.NewGetAllOrdersParamsWithContext(ctx)
+		params := orders.NewGetUserOrdersParamsWithContext(ctx)
 		limit := int64(1)
 		offset := int64(0)
 		orderBy := utils.AscOrder
@@ -307,16 +307,16 @@ func TestIntegration_GetAllOrders(t *testing.T) {
 		params.Limit = &limit
 		params.Offset = &offset
 		params.OrderColumn = &orderColumn
-		_, gotErr := client.Orders.GetAllOrders(params, auth)
+		_, gotErr := client.Orders.GetUserOrders(params, auth)
 		require.Error(t, gotErr)
 
-		wantErr := orders.NewGetAllOrdersDefault(http.StatusUnprocessableEntity)
+		wantErr := orders.NewGetUserOrdersDefault(http.StatusUnprocessableEntity)
 		wantErr.Payload = &models.Error{Data: nil}
 		assert.Equal(t, wantErr, gotErr)
 	})
 
 	t.Run("Get All Orders OK: rent_start column to order by", func(t *testing.T) {
-		params := orders.NewGetAllOrdersParamsWithContext(ctx)
+		params := orders.NewGetUserOrdersParamsWithContext(ctx)
 		limit := int64(1)
 		offset := int64(0)
 		orderBy := utils.AscOrder
@@ -327,7 +327,7 @@ func TestIntegration_GetAllOrders(t *testing.T) {
 		params.Limit = &limit
 		params.Offset = &offset
 		params.OrderColumn = &orderColumn
-		_, err := client.Orders.GetAllOrders(params, auth)
+		_, err := client.Orders.GetUserOrders(params, auth)
 		require.NoError(t, err)
 	})
 }
@@ -349,8 +349,8 @@ func TestIntegration_List_Filtered(t *testing.T) {
 		createParams := orders.NewCreateOrderParamsWithContext(ctx)
 		desc := fmt.Sprintf("order %v", i)
 		eqID := equip.ID
-		rentStart := strfmt.DateTime(time.Now().Add(time.Hour * time.Duration(2 * i) * 24))
-		rentEnd := strfmt.DateTime(time.Now().Add(time.Hour * time.Duration(2 * i + 1) * 24))
+		rentStart := strfmt.DateTime(time.Now().Add(time.Hour * time.Duration(2*i) * 24))
+		rentEnd := strfmt.DateTime(time.Now().Add(time.Hour * time.Duration(2*i+1) * 24))
 		createParams.Data = &models.OrderCreateRequest{
 			Description: desc,
 			EquipmentID: eqID,
@@ -362,10 +362,10 @@ func TestIntegration_List_Filtered(t *testing.T) {
 	}
 
 	t.Run("Get Orders All Ok", func(t *testing.T) {
-		listParams := orders.NewGetAllOrdersParamsWithContext(ctx)
+		listParams := orders.NewGetUserOrdersParamsWithContext(ctx)
 		listParams.Status = &domain.OrderStatusAll
 		// filter 'all', get all 7 (5+2) orders
-		res, err := client.Orders.GetAllOrders(listParams, auth)
+		res, err := client.Orders.GetUserOrders(listParams, auth)
 		require.NoError(t, err)
 		assert.Equal(t, ordersToCreate+existingOrders, len(res.GetPayload().Items))
 		for _, o := range res.Payload.Items {
@@ -374,10 +374,10 @@ func TestIntegration_List_Filtered(t *testing.T) {
 	})
 
 	t.Run("Get Orders Active Ok", func(t *testing.T) {
-		listParams := orders.NewGetAllOrdersParamsWithContext(ctx)
+		listParams := orders.NewGetUserOrdersParamsWithContext(ctx)
 		listParams.Status = &domain.OrderStatusActive
 		// filter 'active', still  7 (5+2) orders
-		res, err := client.Orders.GetAllOrders(listParams, auth)
+		res, err := client.Orders.GetUserOrders(listParams, auth)
 		require.NoError(t, err)
 		assert.Equal(t, ordersToCreate+existingOrders, len(res.GetPayload().Items))
 		for _, o := range res.Payload.Items {
@@ -386,16 +386,16 @@ func TestIntegration_List_Filtered(t *testing.T) {
 	})
 
 	t.Run("Get Orders Finished zero", func(t *testing.T) {
-		listParams := orders.NewGetAllOrdersParamsWithContext(ctx)
+		listParams := orders.NewGetUserOrdersParamsWithContext(ctx)
 		listParams.Status = &domain.OrderStatusFinished
 		// filter 'finished', 0 orders (all of them are active)
-		res, err := client.Orders.GetAllOrders(listParams, auth)
+		res, err := client.Orders.GetUserOrders(listParams, auth)
 		require.NoError(t, err)
 		assert.Equal(t, 0, len(res.GetPayload().Items))
 	})
 
-	listParams := orders.NewGetAllOrdersParamsWithContext(ctx)
-	res, err := client.Orders.GetAllOrders(listParams, auth)
+	listParams := orders.NewGetUserOrdersParamsWithContext(ctx)
+	res, err := client.Orders.GetUserOrders(listParams, auth)
 	require.NoError(t, err)
 
 	managerLogin := common.ManagerUserLogin(t)
@@ -415,65 +415,65 @@ func TestIntegration_List_Filtered(t *testing.T) {
 		dt := strfmt.DateTime(time.Now())
 		osp := orders.NewAddNewOrderStatusParamsWithContext(ctx)
 		osp.Data = &models.NewOrderStatus{
-			OrderID: o.ID,
+			OrderID:   o.ID,
 			CreatedAt: &dt,
-			Status: &st,
-			Comment: &st,
+			Status:    &st,
+			Comment:   &st,
 		}
 		_, err = client.Orders.AddNewOrderStatus(osp, managerAuth)
 		require.NoError(t, err)
 	}
 
 	t.Run("Get Orders 7 Active Ok", func(t *testing.T) {
-		listParams := orders.NewGetAllOrdersParamsWithContext(ctx)
+		listParams := orders.NewGetUserOrdersParamsWithContext(ctx)
 		listParams.Status = &domain.OrderStatusActive
 		// filter 'active', still  7 (5+2) orders
-		res, err := client.Orders.GetAllOrders(listParams, auth)
+		res, err := client.Orders.GetUserOrders(listParams, auth)
 		require.NoError(t, err)
 		assert.Equal(t, 7, len(res.GetPayload().Items))
 	})
 
 	t.Run("Get Orders 6 Approved Ok", func(t *testing.T) {
-		listParams := orders.NewGetAllOrdersParamsWithContext(ctx)
+		listParams := orders.NewGetUserOrdersParamsWithContext(ctx)
 		listParams.Status = &domain.OrderStatusApproved
 		// filter 'active', still  7 (5+2) orders
-		res, err := client.Orders.GetAllOrders(listParams, auth)
+		res, err := client.Orders.GetUserOrders(listParams, auth)
 		require.NoError(t, err)
 		assert.Equal(t, 6, len(res.GetPayload().Items))
 	})
 
 	t.Run("Get Orders 1 In_Review Ok", func(t *testing.T) {
-		listParams := orders.NewGetAllOrdersParamsWithContext(ctx)
+		listParams := orders.NewGetUserOrdersParamsWithContext(ctx)
 		listParams.Status = &domain.OrderStatusInReview
 		// filter 'active', still  7 (5+2) orders
-		res, err := client.Orders.GetAllOrders(listParams, auth)
+		res, err := client.Orders.GetUserOrders(listParams, auth)
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(res.GetPayload().Items))
 	})
 
 	t.Run("Get Orders 1 Finished Ok", func(t *testing.T) {
-		listParams := orders.NewGetAllOrdersParamsWithContext(ctx)
+		listParams := orders.NewGetUserOrdersParamsWithContext(ctx)
 		listParams.Status = &domain.OrderStatusFinished
 		// filter 'active', still  7 (5+2) orders
-		res, err := client.Orders.GetAllOrders(listParams, auth)
+		res, err := client.Orders.GetUserOrders(listParams, auth)
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(res.GetPayload().Items))
 	})
 
 	t.Run("Get Orders 1 Rejected Ok", func(t *testing.T) {
-		listParams := orders.NewGetAllOrdersParamsWithContext(ctx)
+		listParams := orders.NewGetUserOrdersParamsWithContext(ctx)
 		listParams.Status = &domain.OrderStatusRejected
 		// filter 'active', still  7 (5+2) orders
-		res, err := client.Orders.GetAllOrders(listParams, auth)
+		res, err := client.Orders.GetUserOrders(listParams, auth)
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(res.GetPayload().Items))
 	})
 
 	t.Run("Get Orders 0 Closed Ok", func(t *testing.T) {
-		listParams := orders.NewGetAllOrdersParamsWithContext(ctx)
+		listParams := orders.NewGetUserOrdersParamsWithContext(ctx)
 		listParams.Status = &domain.OrderStatusClosed
 		// filter 'active', still  7 (5+2) orders
-		res, err := client.Orders.GetAllOrders(listParams, auth)
+		res, err := client.Orders.GetUserOrders(listParams, auth)
 		require.NoError(t, err)
 		assert.Equal(t, 0, len(res.GetPayload().Items))
 	})
@@ -482,46 +482,46 @@ func TestIntegration_List_Filtered(t *testing.T) {
 	dt := strfmt.DateTime(time.Now())
 	osp := orders.NewAddNewOrderStatusParamsWithContext(ctx)
 	osp.Data = &models.NewOrderStatus{
-		OrderID: res.Payload.Items[0].ID,
+		OrderID:   res.Payload.Items[0].ID,
 		CreatedAt: &dt,
-		Status: &domain.OrderStatusClosed,
-		Comment: &domain.OrderStatusClosed,
+		Status:    &domain.OrderStatusClosed,
+		Comment:   &domain.OrderStatusClosed,
 	}
 	_, err = client.Orders.AddNewOrderStatus(osp, auth)
 	require.NoError(t, err)
 
 	t.Run("Get Orders 6 Active Ok", func(t *testing.T) {
-		listParams := orders.NewGetAllOrdersParamsWithContext(ctx)
+		listParams := orders.NewGetUserOrdersParamsWithContext(ctx)
 		listParams.Status = &domain.OrderStatusActive
 		// filter 'active', still  7 (5+2) orders
-		res, err := client.Orders.GetAllOrders(listParams, auth)
+		res, err := client.Orders.GetUserOrders(listParams, auth)
 		require.NoError(t, err)
 		assert.Equal(t, 6, len(res.GetPayload().Items))
-	})	
+	})
 
 	t.Run("Get Orders 2 Finished Ok", func(t *testing.T) {
-		listParams := orders.NewGetAllOrdersParamsWithContext(ctx)
+		listParams := orders.NewGetUserOrdersParamsWithContext(ctx)
 		listParams.Status = &domain.OrderStatusFinished
 		// filter 'active', still  7 (5+2) orders
-		res, err := client.Orders.GetAllOrders(listParams, auth)
+		res, err := client.Orders.GetUserOrders(listParams, auth)
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(res.GetPayload().Items))
-	})	
+	})
 
 	t.Run("Get Orders 1 Closed Ok", func(t *testing.T) {
-		listParams := orders.NewGetAllOrdersParamsWithContext(ctx)
+		listParams := orders.NewGetUserOrdersParamsWithContext(ctx)
 		listParams.Status = &domain.OrderStatusClosed
 		// filter 'active', still  7 (5+2) orders
-		res, err := client.Orders.GetAllOrders(listParams, auth)
+		res, err := client.Orders.GetUserOrders(listParams, auth)
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(res.GetPayload().Items))
 	})
 
 	t.Run("Get Orders 0 In_Review Ok", func(t *testing.T) {
-		listParams := orders.NewGetAllOrdersParamsWithContext(ctx)
+		listParams := orders.NewGetUserOrdersParamsWithContext(ctx)
 		listParams.Status = &domain.OrderStatusInReview
 		// filter 'active', still  7 (5+2) orders
-		res, err := client.Orders.GetAllOrders(listParams, auth)
+		res, err := client.Orders.GetUserOrders(listParams, auth)
 		require.NoError(t, err)
 		assert.Equal(t, 0, len(res.GetPayload().Items))
 	})

--- a/internal/integration-tests/orders/order_test.go
+++ b/internal/integration-tests/orders/order_test.go
@@ -561,6 +561,9 @@ func TestIntegration_ListAllOrders(t *testing.T) {
 	_, err = client.Orders.CreateOrder(createParams, auth2)
 	require.NoError(t, err)
 
+	// Due to the lack of a Delete method, we cannot clean up orders and 
+	// verify the exact number of orders. For this reason, we are only using
+	// assert.NotEmpty in the cases below.
 	t.Run("Get All Orders as Admin Ok", func(t *testing.T) {
 		listParams := orders.NewGetAllOrdersParamsWithContext(ctx)
 		res, err := client.Orders.GetAllOrders(listParams, auth)

--- a/internal/integration-tests/user/get_data_integration_test.go
+++ b/internal/integration-tests/user/get_data_integration_test.go
@@ -28,7 +28,7 @@ func TestIntegration_GetCurrentUser(t *testing.T) {
 	ctx := context.Background()
 	client := utils.SetupClient()
 
-	l, p, id := utils.AdminLoginPassword(t)
+	l, p, id := utils.CreateLoginPassword(t, 1)
 
 	testLogin = l
 	testPassword = p

--- a/internal/repositories/order.go
+++ b/internal/repositories/order.go
@@ -103,14 +103,14 @@ func (r *orderRepository) List(ctx context.Context, ownerId *int, filter domain.
 	return items, err
 }
 
-func (r *orderRepository) OrdersTotal(ctx context.Context, ownerId int) (int, error) {
+func (r *orderRepository) OrdersTotal(ctx context.Context, ownerId *int) (int, error) {
 	tx, err := middlewares.TxFromContext(ctx)
 	if err != nil {
 		return 0, err
 	}
 	query := tx.Order.Query()
-	if ownerId > 0 {
-		query = query.Where(order.HasUsersWith(user.ID(ownerId)))
+	if ownerId != nil {
+		query = query.Where(order.HasUsersWith(user.ID(*ownerId)))
 	}
 	return query.Count(ctx)
 }

--- a/internal/repositories/order.go
+++ b/internal/repositories/order.go
@@ -71,6 +71,9 @@ func getQuantity(quantity int, maxQuantity int) (*int, error) {
 	return &quantity, nil
 }
 
+// List retrieves a list of orders from the order repository based on the provided criteria.
+// It takes an optional ownerId to filter orders by owner and a domain.OrderFilter for 
+// additional filtering options. If ownerId is `nil` it retrievesall  orders for all users.
 func (r *orderRepository) List(ctx context.Context, ownerId *int, filter domain.OrderFilter) ([]*ent.Order, error) {
 	if !utils.IsValueInList(filter.OrderColumn, fieldsToOrderOrders) {
 		return nil, errors.New("wrong column to order by")

--- a/internal/repositories/order.go
+++ b/internal/repositories/order.go
@@ -71,7 +71,7 @@ func getQuantity(quantity int, maxQuantity int) (*int, error) {
 	return &quantity, nil
 }
 
-func (r *orderRepository) List(ctx context.Context, ownerId int, filter domain.OrderFilter) ([]*ent.Order, error) {
+func (r *orderRepository) List(ctx context.Context, ownerId *int, filter domain.OrderFilter) ([]*ent.Order, error) {
 	if !utils.IsValueInList(filter.OrderColumn, fieldsToOrderOrders) {
 		return nil, errors.New("wrong column to order by")
 	}
@@ -86,8 +86,8 @@ func (r *orderRepository) List(ctx context.Context, ownerId int, filter domain.O
 	query := tx.Order.Query().
 		Order(orderFunc).Limit(filter.Limit).Offset(filter.Offset)
 
-	if ownerId > 0 {
-		query = query.Where(order.HasUsersWith(user.ID(ownerId)))
+	if ownerId != nil {
+		query = query.Where(order.HasUsersWith(user.ID(*ownerId)))
 	}
 
 	query = r.applyListFilters(query, filter)

--- a/internal/repositories/order.go
+++ b/internal/repositories/order.go
@@ -72,7 +72,7 @@ func getQuantity(quantity int, maxQuantity int) (*int, error) {
 }
 
 // List retrieves a list of orders from the order repository based on the provided criteria.
-// It takes an optional ownerId to filter orders by owner and a domain.OrderFilter for 
+// It takes an optional ownerId to filter orders by owner and a domain.OrderFilter for
 // additional filtering options. If ownerId is `nil` it retrievesall  orders for all users.
 func (r *orderRepository) List(ctx context.Context, ownerId *int, filter domain.OrderFilter) ([]*ent.Order, error) {
 	if !utils.IsValueInList(filter.OrderColumn, fieldsToOrderOrders) {

--- a/internal/repositories/order_test.go
+++ b/internal/repositories/order_test.go
@@ -493,7 +493,13 @@ func (s *OrderSuite) TestOrderRepository_OrdersTotal() {
 	tx, err := s.client.Tx(ctx)
 	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
-	totalOrders, err := s.orderRepository.OrdersTotal(ctx, s.user.ID)
+	totalOrders, err := s.orderRepository.OrdersTotal(ctx, &s.user.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.Equal(t, len(s.orders), totalOrders)
+	// Check orders for all users (should be the same amount because of only user)
+	totalOrders, err = s.orderRepository.OrdersTotal(ctx, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/repositories/order_test.go
+++ b/internal/repositories/order_test.go
@@ -476,7 +476,7 @@ func (s *OrderSuite) TestOrderRepository_Create_isFirstFieldForPreviousCreatedOr
 			OrderColumn: order.FieldID,
 		},
 	}
-	orderList, err := s.orderRepository.List(ctx, s.user.ID, filter)
+	orderList, err := s.orderRepository.List(ctx, &s.user.ID, filter)
 	require.NoError(t, err)
 
 	for _, order := range orderList {
@@ -516,7 +516,7 @@ func (s *OrderSuite) TestOrderRepository_List_EmptyOrderBy() {
 	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 
-	orders, err := s.orderRepository.List(ctx, s.user.ID, filter)
+	orders, err := s.orderRepository.List(ctx, &s.user.ID, filter)
 	require.Error(t, err)
 	require.NoError(t, tx.Rollback())
 	require.Nil(t, orders)
@@ -536,7 +536,7 @@ func (s *OrderSuite) TestOrderRepository_List_WrongOrderColumn() {
 	tx, err := s.client.Tx(ctx)
 	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
-	orders, err := s.orderRepository.List(ctx, s.user.ID, filter)
+	orders, err := s.orderRepository.List(ctx, &s.user.ID, filter)
 	require.Error(t, err)
 	require.NoError(t, tx.Rollback())
 	require.Nil(t, orders)
@@ -556,7 +556,7 @@ func (s *OrderSuite) TestOrderRepository_List_OrderByIDDesc() {
 	tx, err := s.client.Tx(ctx)
 	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
-	orders, err := s.orderRepository.List(ctx, s.user.ID, filter)
+	orders, err := s.orderRepository.List(ctx, &s.user.ID, filter)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -584,7 +584,7 @@ func (s *OrderSuite) TestOrderRepository_List_OrderByRentStartDesc() {
 	tx, err := s.client.Tx(ctx)
 	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
-	orders, err := s.orderRepository.List(ctx, s.user.ID, filter)
+	orders, err := s.orderRepository.List(ctx, &s.user.ID, filter)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -612,7 +612,7 @@ func (s *OrderSuite) TestOrderRepository_List_OrderByIDAsc() {
 	tx, err := s.client.Tx(ctx)
 	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
-	orders, err := s.orderRepository.List(ctx, s.user.ID, filter)
+	orders, err := s.orderRepository.List(ctx, &s.user.ID, filter)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -640,7 +640,7 @@ func (s *OrderSuite) TestOrderRepository_List_OrderByRentStartAsc() {
 	tx, err := s.client.Tx(ctx)
 	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
-	orders, err := s.orderRepository.List(ctx, s.user.ID, filter)
+	orders, err := s.orderRepository.List(ctx, &s.user.ID, filter)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -668,7 +668,7 @@ func (s *OrderSuite) TestOrderRepository_List_Limit() {
 	tx, err := s.client.Tx(ctx)
 	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
-	orders, err := s.orderRepository.List(ctx, s.user.ID, filter)
+	orders, err := s.orderRepository.List(ctx, &s.user.ID, filter)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -691,7 +691,7 @@ func (s *OrderSuite) TestOrderRepository_List_Offset() {
 	tx, err := s.client.Tx(ctx)
 	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
-	orders, err := s.orderRepository.List(ctx, s.user.ID, filter)
+	orders, err := s.orderRepository.List(ctx, &s.user.ID, filter)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -769,7 +769,7 @@ func (s *OrderSuite) TestOrderRepository_List_StatusFilter() {
 			tx, err := s.client.Tx(ctx)
 			require.NoError(t, err)
 			ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
-			orders, err := s.orderRepository.List(ctx, s.user.ID, tc.fl)
+			orders, err := s.orderRepository.List(ctx, &s.user.ID, tc.fl)
 			if tc.expectedErr != "" {
 				require.EqualError(t, err, tc.expectedErr)
 				require.NoError(t, tx.Rollback())
@@ -825,7 +825,7 @@ func (s *OrderSuite) TestOrderRepository_List_EquipmentFilter() {
 			tx, err := s.client.Tx(ctx)
 			require.NoError(t, err)
 			ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
-			orders, err := s.orderRepository.List(ctx, s.user.ID, tc.fl)
+			orders, err := s.orderRepository.List(ctx, &s.user.ID, tc.fl)
 			require.NoError(t, err)
 			ids := make([]int, 0, len(orders))
 			for _, o := range orders {

--- a/internal/repositories/order_test.go
+++ b/internal/repositories/order_test.go
@@ -806,14 +806,14 @@ func (s *OrderSuite) TestOrderRepository_List_EquipmentFilter() {
 		},
 		"only Equipment ID 1": {
 			fl: domain.OrderFilter{
-				Filter: filter,
+				Filter:      filter,
 				EquipmentID: &s.equipments[0].ID,
 			},
 			expectedIDs: []int{s.orders[0].ID, s.orders[2].ID},
 		},
 		"only Equipment ID 2": {
 			fl: domain.OrderFilter{
-				Filter: filter,
+				Filter:      filter,
 				EquipmentID: &s.equipments[1].ID,
 			},
 			expectedIDs: []int{s.orders[1].ID, s.orders[3].ID},

--- a/pkg/domain/repositories.go
+++ b/pkg/domain/repositories.go
@@ -25,7 +25,8 @@ type CategoryFilter struct {
 
 type OrderFilter struct {
 	Filter
-	Status *string
+	Status      *string
+	EquipmentID *int
 }
 
 type CategoryRepository interface {

--- a/pkg/domain/repositories.go
+++ b/pkg/domain/repositories.go
@@ -71,7 +71,7 @@ type EquipmentStatusNameRepository interface {
 }
 
 type OrderRepository interface {
-	List(ctx context.Context, ownerId int, filter OrderFilter) ([]*ent.Order, error)
+	List(ctx context.Context, ownerId *int, filter OrderFilter) ([]*ent.Order, error)
 	OrdersTotal(ctx context.Context, ownerId int) (int, error)
 	Create(ctx context.Context, data *models.OrderCreateRequest, ownerId int, equipmentIDs []int) (*ent.Order, error)
 	Update(ctx context.Context, id int, data *models.OrderUpdateRequest, ownerId int) (*ent.Order, error)

--- a/pkg/domain/repositories.go
+++ b/pkg/domain/repositories.go
@@ -72,7 +72,7 @@ type EquipmentStatusNameRepository interface {
 
 type OrderRepository interface {
 	List(ctx context.Context, ownerId *int, filter OrderFilter) ([]*ent.Order, error)
-	OrdersTotal(ctx context.Context, ownerId int) (int, error)
+	OrdersTotal(ctx context.Context, ownerId *int) (int, error)
 	Create(ctx context.Context, data *models.OrderCreateRequest, ownerId int, equipmentIDs []int) (*ent.Order, error)
 	Update(ctx context.Context, id int, data *models.OrderUpdateRequest, ownerId int) (*ent.Order, error)
 }

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1050,7 +1050,7 @@ paths:
     get:
       tags:
         - Orders
-      operationId: GetAllOrders
+      operationId: GetUserOrders
       parameters:
         - name: status
           in: query
@@ -1106,7 +1106,7 @@ paths:
         200:
           description: Success
           schema:
-            $ref: "#/definitions/OrderList"
+            $ref: "#/definitions/UserOrdersList"
         default:
           description: 'Unexpected error'
           schema:
@@ -1123,7 +1123,7 @@ paths:
         201:
           description: 'Order created'
           schema:
-            $ref: '#/definitions/Order'
+            $ref: '#/definitions/UserOrder'
         default:
           description: 'Unexpected error'
           schema:
@@ -1159,7 +1159,7 @@ paths:
         200:
           description: Order updated
           schema:
-            $ref: "#/definitions/Order"
+            $ref: "#/definitions/UserOrder"
         default:
           description: Unexpected error.
           schema:
@@ -1266,7 +1266,7 @@ paths:
         200:
           description: Success
           schema:
-            $ref: "#/definitions/OrderList"
+            $ref: "#/definitions/UserOrdersList"
         404:
           description: No orders found
           schema:
@@ -1335,7 +1335,7 @@ paths:
         200:
           description: Success
           schema:
-            $ref: "#/definitions/OrderList"
+            $ref: "#/definitions/UserOrdersList"
         404:
           description: No orders found
           schema:
@@ -1921,6 +1921,79 @@ paths:
           description: Unexpected error.
           schema:
             $ref: "#/definitions/Error"
+  /management/orders:
+    get:
+      summary: Get all orders
+      security:
+        - Bearer: [ ]
+      tags:
+        - Orders
+      operationId: GetAllOrders
+      parameters:
+        - name: status
+          in: query
+          required: false
+          description: filter orders by status (in review, approved, closed, etc) or aggregated status (all, active or finished)
+          type: string
+          enum:
+            - all
+            - active
+            - finished
+            - in review
+            - approved
+            - in progress
+            - rejected
+            - closed
+            - prepared
+            - overdue
+            - blocked
+          default: all
+        - name: equipment_id
+          in: query
+          required: false
+          description: filter orders by Equipment's ID
+          type: integer
+        - name: limit
+          in: query
+          required: false
+          description: limit of items in page
+          type: integer
+          default: 20
+        - name: offset
+          in: query
+          required: false
+          description: offset of items
+          type: integer
+          default: 0
+        - name: order_by
+          in: query
+          required: false
+          description: how to order list
+          type: string
+          enum:
+            - asc
+            - desc
+          default: asc
+        - name: order_column
+          in: query
+          required: false
+          description: column to order by
+          type: string
+          enum:
+            - id
+            - name
+            - title
+          default: id
+      responses:
+        200:
+          description: Success
+          schema:
+            $ref: "#/definitions/OrdersList"
+        default:
+          description: Unexpected error.
+          schema:
+            $ref: "#/definitions/Error"
+
 definitions:
   principal:
     type: object
@@ -3085,7 +3158,7 @@ definitions:
       rent_end:
         type: string
         format: date-time
-  Order:
+  UserOrder:
     type: object
     required:
       - id
@@ -3113,6 +3186,44 @@ definitions:
       user:
         type: object
         $ref: '#/definitions/UserEmbeddable'
+      equipments:
+        type: array
+        items:
+          $ref: '#/definitions/EquipmentResponse'
+      last_status:
+        type: object
+        $ref: '#/definitions/OrderStatus'
+      is_first:
+        type: boolean
+        example: false
+  Order:
+    type: object
+    required:
+      - id
+      - description
+      - quantity
+      - rent_start
+      - rent_end
+      - user
+      - equipments
+      - last_status
+      - is_first
+    properties:
+      id:
+        type: integer
+      description:
+        type: string
+      quantity:
+        type: integer
+      rent_start:
+        type: string
+        format: date-time
+      rent_end:
+        type: string
+        format: date-time
+      user:
+        type: object
+        $ref: '#/definitions/UserInfo'
       equipments:
         type: array
         items:
@@ -3151,7 +3262,19 @@ definitions:
         $ref: '#/definitions/UserEmbeddable'
       order_id:
         type: integer
-  OrderList:
+  UserOrdersList:
+    type: object
+    required:
+      - total
+      - items
+    properties:
+      total:
+        type: integer
+      items:
+        type: array
+        items:
+          $ref: "#/definitions/UserOrder"
+  OrdersList:
     type: object
     required:
       - total

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1958,7 +1958,7 @@ paths:
           required: false
           description: limit of items in page
           type: integer
-          default: 20
+          default: 10
         - name: offset
           in: query
           required: false
@@ -1973,7 +1973,7 @@ paths:
           enum:
             - asc
             - desc
-          default: asc
+          default: desc
         - name: order_column
           in: query
           required: false


### PR DESCRIPTION
This PR adds new API endpoint `/management/orders` to List all existing orders [EPMUII-7958](https://jira.epam.com/jira/browse/EPMUII-7958)

[Design](https://www.figma.com/file/nWRSG6GHkiipp3DD4oKpfX/L.Cat?type=design&node-id=2239-20613&mode=design&t=Ta4UzcsXVoRXO6yp-4)

The main differences from the existing `/v1/orders` are:
* Allows to show all orders of all users;
* Response contains almost all UserInfo with Name, Surname, tel, etc;
* Allows to filter by EquipmentID (ref. to [EPMUII-8076](https://jira.epam.com/jira/browse/EPMUII-8076));

An existing `OrderRepository` is used with few small changes:
* `List` allows to skip a filtering by UsedID if corresponding arg is negative)
* An additional filtering by EquipmentID was added