### PR TITLE
TimestampsTZ for links TTL

### DIFF
--- a/cmd/swagger/setup.go
+++ b/cmd/swagger/setup.go
@@ -43,7 +43,6 @@ func SetupAPI(entClient *ent.Client, lg *zap.Logger, conf *config.AppConfig) (*r
 	emailConfirmRepository := repositories.NewConfirmEmailRepository()
 
 	// conf
-	passwordTTL := conf.Password.ResetExpirationMinutes
 	jwtSecret := conf.JWTSecretKey
 	// services
 	mailSendClient := email.NewSenderSmtp(conf.Email, email.NewWrapperSmtp(
@@ -52,8 +51,9 @@ func SetupAPI(entClient *ent.Client, lg *zap.Logger, conf *config.AppConfig) (*r
 		conf.Email.Password,
 	))
 	regConfirmService := services.NewRegistrationConfirmService(mailSendClient, userRepository, regConfirmRepo,
-		lg, passwordTTL)
-	passwordService := services.NewPasswordResetService(mailSendClient, userRepository, passwordRepo, lg, passwordTTL, passwordGenerator)
+		lg, conf.Email.ConfirmLinkExpiration)
+	passwordService := services.NewPasswordResetService(mailSendClient,
+		userRepository, passwordRepo, lg, conf.Password.ResetLinkExpiration, passwordGenerator)
 	tokenManager := services.NewTokenManager(userRepository, tokenRepository, jwtSecret, lg)
 	changeEmailService := services.NewEmailChangeService(
 		mailSendClient, userRepository,

--- a/config.json
+++ b/config.json
@@ -13,11 +13,12 @@
     "password": "any",
     "senderFromAddress": "any",
     "senderFromName": "any",
+    "confirmLinkExpiration": "15m",
     "isSendRequired": false
   },
   "password": {
     "length": 8,
-    "resetExpirationMinutes": 15
+    "resetLinkExpiration": "15m"
   },
   "orderStatusOverdueTimeCheckDuration": "4h",
   "server": {

--- a/internal/config/app.go
+++ b/internal/config/app.go
@@ -48,18 +48,19 @@ func (db DB) GetConnectionString() string {
 }
 
 type Email struct {
-	ServerHost        string `validate:"required"`
-	ServerPort        string `validate:"required"`
-	Password          string `validate:"required"`
-	SenderFromAddress string `validate:"required"`
-	SenderFromName    string `validate:"required"`
-	SenderWebsiteUrl  string `validate:"required"`
-	IsSendRequired    bool
+	ServerHost            string        `validate:"required"`
+	ServerPort            string        `validate:"required"`
+	Password              string        `validate:"required"`
+	SenderFromAddress     string        `validate:"required"`
+	SenderFromName        string        `validate:"required"`
+	SenderWebsiteUrl      string        `validate:"required"`
+	ConfirmLinkExpiration time.Duration `validate:"required"`
+	IsSendRequired        bool
 }
 
 type Password struct {
-	ResetExpirationMinutes time.Duration `validate:"required"`
-	Length                 int           `validate:"required,gte=8"`
+	ResetLinkExpiration time.Duration `validate:"required"`
+	Length              int           `validate:"required,gte=8"`
 }
 
 type Server struct {
@@ -105,11 +106,12 @@ func getDefaultConfig() *AppConfig {
 			Password: "password",
 		},
 		Password: Password{
-			Length:                 8,
-			ResetExpirationMinutes: 15 * time.Minute,
+			Length:              8,
+			ResetLinkExpiration: 15 * time.Minute,
 		},
 		Email: Email{
-			SenderWebsiteUrl: "https://csr.golangforall.com/",
+			SenderWebsiteUrl:      "https://csr.golangforall.com/",
+			ConfirmLinkExpiration: 15 * time.Minute,
 		},
 		Server: Server{
 			Host: "127.0.0.1",

--- a/internal/db/migrations/000012_ttl_timestamptz.sql
+++ b/internal/db/migrations/000012_ttl_timestamptz.sql
@@ -1,0 +1,7 @@
+-- +migrate Up
+ALTER TABLE "registration_confirms" ALTER COLUMN "ttl" TYPE TIMESTAMPTZ;
+ALTER TABLE "password_resets" ALTER COLUMN "ttl" TYPE TIMESTAMPTZ;
+
+-- +migrate Down
+ALTER TABLE "registration_confirms" ALTER COLUMN "ttl" TYPE TIMESTAMP;
+ALTER TABLE "password_resets" ALTER COLUMN "ttl" TYPE TIMESTAMP;


### PR DESCRIPTION
There are few fixes:
1/ Because of `timestamp` type TTL field didn't work as expected if server's timezone is not UTC (current TZ on stage is Europe/Moscow)
2/ Fixed wrong duration format in `config.json`
3/ New `resetLinkExpiration` and `confirmLinkExpiration` config parameters instead of old `resetExpirationMinutes`