### PR TITLE
feat: Remove user confirmation on change email workflow

### DIFF
--- a/internal/handlers/user.go
+++ b/internal/handlers/user.go
@@ -400,6 +400,13 @@ func (c User) ChangeEmail(repo domain.UserRepository,
 				WithPayload(buildInternalErrorPayload(messages.ErrChangeEmail, err.Error()))
 		}
 
+		err = repo.UnConfirmRegistration(ctx, requestedUser.Login)
+		if err != nil {
+			c.logger.Error("error while removing confirmation of registration", zap.Error(err))
+			return users.NewChangeEmailDefault(http.StatusInternalServerError).
+				WithPayload(buildInternalErrorPayload(messages.ErrNewEmailConfirmation, err.Error()))
+		}
+
 		err = changeEmailService.SendEmailConfirmationLink(ctx, requestedUser.Login, p.EmailPatch.NewEmail)
 		if err != nil {
 			c.logger.Error("error while sending link for confirmation new email", zap.Error(err))

--- a/internal/handlers/user_test.go
+++ b/internal/handlers/user_test.go
@@ -1335,6 +1335,7 @@ func (s *UserTestSuite) TestUser_ChangeEmailFunc_OK() {
 	}
 
 	s.userRepository.On("GetUserByID", ctx, user.ID).Return(user, nil)
+	s.userRepository.On("UnConfirmRegistration", ctx, user.Login).Return(nil)
 	s.changeEmailService.On("SendEmailConfirmationLink", ctx, user.Login, testEmail).Return(nil)
 
 	resp := handlerFunc(data, principal)
@@ -1369,6 +1370,7 @@ func (s *UserTestSuite) TestUser_ChangeEmailFunc_Err() {
 	}
 
 	s.userRepository.On("GetUserByID", ctx, user.ID).Return(user, nil)
+	s.userRepository.On("UnConfirmRegistration", ctx, user.Login).Return(nil)
 	err := errors.New("unable to send email confirmation link")
 	s.changeEmailService.On("SendEmailConfirmationLink", ctx, user.Login, testEmail).Return(err)
 

--- a/internal/repositories/user.go
+++ b/internal/repositories/user.go
@@ -248,6 +248,18 @@ func (r *userRepository) ConfirmRegistration(ctx context.Context, login string) 
 	return nil
 }
 
+func (r *userRepository) UnConfirmRegistration(ctx context.Context, login string) error {
+	tx, err := middlewares.TxFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = tx.User.Update().Where(user.LoginEQ(login)).SetIsRegistrationConfirmed(false).Save(ctx)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (r *userRepository) Delete(ctx context.Context, userId int) error {
 	tx, err := middlewares.TxFromContext(ctx)
 	if err != nil {

--- a/pkg/domain/repositories.go
+++ b/pkg/domain/repositories.go
@@ -170,5 +170,6 @@ type UserRepository interface {
 	Delete(ctx context.Context, userId int) error
 	UsersListTotal(ctx context.Context) (int, error)
 	ConfirmRegistration(ctx context.Context, login string) error
+	UnConfirmRegistration(ctx context.Context, login string) error
 	SetIsReadonly(ctx context.Context, id int, isReadonly bool) error
 }


### PR DESCRIPTION
User confirmation is set to false in the change email workflow until the new email is confirmed.
