### PR TITLE
EPMUII-7850 make "name" not mandatory at registration

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1242,6 +1242,8 @@ github.com/spf13/cobra v0.0.6/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHN
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
 github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t68Nk=
+github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
+github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
@@ -1864,6 +1866,8 @@ golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.7/go.mod h1:LGqMHiF4EqQNHR1JncWGqT5BVaXmza+X+BDGol+dOxo=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
+golang.org/x/tools v0.6.0 h1:BOw41kyTf3PuCW1pVQf8+Cyg8pMlkYB1oo9iJ6D/lKM=
+golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/ent/schema/user.go
+++ b/internal/ent/schema/user.go
@@ -18,7 +18,7 @@ func (User) Fields() []ent.Field {
 		field.String("login").Unique(),
 		field.String("email").NotEmpty(),
 		field.String("password").NotEmpty(),
-		field.String("name").NotEmpty(),
+		field.String("name").Optional().Nillable(),
 		field.String("surname").Optional().Nillable(),
 		field.String("patronymic").Optional().Nillable(),
 		field.String("passport_series").Optional().Nillable(),

--- a/internal/handlers/user.go
+++ b/internal/handlers/user.go
@@ -443,7 +443,7 @@ func mapUserInfoWoRole(user *ent.User) *models.UserInfo {
 		ID:                      &userID,
 		IsReadonly:              &user.IsReadonly,
 		Login:                   &user.Login,
-		Name:                    &user.Name,
+		Name:                    user.Name,
 		OrgName:                 user.OrgName,
 		PassportAuthority:       user.PassportAuthority,
 		PassportIssueDate:       &passportDate,

--- a/internal/handlers/user_test.go
+++ b/internal/handlers/user_test.go
@@ -1487,9 +1487,10 @@ func (s *UserTestSuite) TestUser_UpdateReadonlyAccess_InternalError() {
 
 func validUser(t *testing.T, id int) *ent.User {
 	t.Helper()
+	name := fmt.Sprintf("User%d", id)
 	return &ent.User{
 		ID:    id,
-		Name:  fmt.Sprintf("User%d", id),
+		Name:  &name,
 		Login: fmt.Sprintf("user_%d", id),
 		Email: fmt.Sprintf("user_%d@mail.com", id),
 		Edges: ent.UserEdges{

--- a/internal/integration-tests/user/register_integration_test.go
+++ b/internal/integration-tests/user/register_integration_test.go
@@ -33,9 +33,7 @@ func TestIntegration_RegisterUser(t *testing.T) {
 		Login:       &l,
 		Password:    &p,
 		Type:        &userType,
-		// not provided in documentation, but also required
-		// todo: update documentation
-		Name: gofakeit.Name(),
+		Name:        gofakeit.Name(),
 		// not provided in documentation, but also required
 		// todo: update documentation
 		Email: strfmt.Email(gofakeit.Email()),
@@ -47,7 +45,7 @@ func TestIntegration_RegisterUser(t *testing.T) {
 	params.SetHTTPClient(http.DefaultClient)
 
 	t.Run("user person register ok", func(t *testing.T) {
-		// login, password, type required, name and email also
+		// login, password, type required
 		user, err := c.Users.PostUser(params)
 		require.NoError(t, err)
 
@@ -78,9 +76,7 @@ func TestIntegration_RegisterUser(t *testing.T) {
 			Login:       &l,
 			Password:    &p,
 			Type:        &userType,
-			// not provided in documentation, but also required
-			// todo: update documentation
-			Name: gofakeit.Name(),
+			Name:        gofakeit.Name(),
 			// not provided in documentation, but also required
 			// todo: update documentation
 			Email: strfmt.Email(gofakeit.Email()),
@@ -105,9 +101,7 @@ func TestIntegration_RegisterUser(t *testing.T) {
 			Login:       &l,
 			Password:    &p,
 			Type:        &userType,
-			// not provided in documentation, but also required
-			// todo: update documentation
-			Name: gofakeit.Name(),
+			Name:        gofakeit.Name(),
 			// not provided in documentation, but also required
 			// todo: update documentation
 			Email: strfmt.Email(gofakeit.Email()),
@@ -148,45 +142,36 @@ func TestIntegration_RegisterUser(t *testing.T) {
 		assert.Equal(t, errExp, err)
 	})
 
-	t.Run("name validation error", func(t *testing.T) {
+	t.Run("name absence is ok", func(t *testing.T) {
 		userType = "person"
+		l, p, err = utils.GenerateLoginAndPassword()
+		require.NoError(t, err)
 		data = &models.UserRegister{
 			ActiveAreas: []int64{3},
 			Login:       &l,
 			Password:    &p,
 			Type:        &userType,
-			Name:        "",
+			Name:        "d",
 			Email:       strfmt.Email(gofakeit.Email()),
 		}
 		params.SetData(data)
-
 		_, err := c.Users.PostUser(params)
-		require.Error(t, err)
-
-		errExp := users.NewPostUserDefault(http.StatusInternalServerError)
-		codeExp := int32(http.StatusInternalServerError)
-		errExp.Payload = &models.SwaggerError{
-			Code:    &codeExp,
-			Message: &messages.ErrCreateUser,
-			Details: "ent: validator failed for field \"User.name\": value is less than the required length",
-		}
-
-		assert.Equal(t, errExp, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("email validation error", func(t *testing.T) {
-		empty := ""
+		userType = "person"
+		l, p, err = utils.GenerateLoginAndPassword()
+		require.NoError(t, err)
 		data = &models.UserRegister{
 			ActiveAreas: []int64{3},
 			Login:       &l,
 			Password:    &p,
 			Type:        &userType,
 			Name:        gofakeit.Name(),
-			Email:       strfmt.Email(empty),
+			Email:       strfmt.Email(""),
 		}
-
 		params.SetData(data)
-
 		_, err := c.Users.PostUser(params)
 		require.Error(t, err)
 
@@ -197,7 +182,6 @@ func TestIntegration_RegisterUser(t *testing.T) {
 			Message: &messages.ErrCreateUser,
 			Details: "ent: validator failed for field \"User.email\": value is less than the required length",
 		}
-
 		assert.Equal(t, errExp, err)
 	})
 
@@ -259,9 +243,7 @@ func TestIntegration_RegisterUser(t *testing.T) {
 			Login:       &l,
 			Password:    &p,
 			Type:        &userType,
-			// not provided in documentation, but also required
-			// todo: update documentation
-			Name: gofakeit.Name(),
+			Name:        gofakeit.Name(),
 			// not provided in documentation, but also required
 			// todo: update documentation
 			Email: strfmt.Email(gofakeit.Email()),

--- a/internal/middlewares/api_key_auth.go
+++ b/internal/middlewares/api_key_auth.go
@@ -66,7 +66,7 @@ func createPrincipal(user *ent.User) *models.Principal {
 
 func isPersonalDataConfirmed(user *ent.User) bool {
 	return user != nil &&
-		user.Name != "" &&
+		user.Name != nil && *user.Name != "" &&
 		user.Surname != nil && *user.Surname != "" &&
 		user.Phone != nil && *user.Phone != ""
 }

--- a/internal/repositories/equipment_test.go
+++ b/internal/repositories/equipment_test.go
@@ -54,8 +54,9 @@ func (s *EquipmentSuite) SetupTest() {
 		t.Fatal(err)
 	}
 
+	name := "admin"
 	s.user = &ent.User{
-		Login: "admin", Email: "admin@email.com", Password: "12345", Name: "admin",
+		Login: "admin", Email: "admin@email.com", Password: "12345", Name: &name,
 	}
 	_, err = s.client.User.Delete().Exec(s.ctx)
 	if err != nil {
@@ -63,7 +64,7 @@ func (s *EquipmentSuite) SetupTest() {
 	}
 	u, err := s.client.User.Create().
 		SetLogin(s.user.Login).SetEmail(s.user.Email).
-		SetPassword(s.user.Password).SetName(s.user.Name).
+		SetPassword(s.user.Password).SetName(*s.user.Name).
 		Save(s.ctx)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/repositories/order_test.go
+++ b/internal/repositories/order_test.go
@@ -44,8 +44,9 @@ func (s *OrderSuite) SetupTest() {
 	s.orderRepository = NewOrderRepository()
 	s.orderStatusRepository = NewOrderStatusRepository()
 
+	name := "user1"
 	s.user = &ent.User{
-		Login: "user1", Email: "user1@email.com", Password: "1234", Name: "user1",
+		Login: "user1", Email: "user1@email.com", Password: "1234", Name: &name,
 	}
 	_, err := s.client.User.Delete().Exec(s.ctx)
 	if err != nil {
@@ -53,7 +54,7 @@ func (s *OrderSuite) SetupTest() {
 	}
 	u, err := s.client.User.Create().
 		SetLogin(s.user.Login).SetEmail(s.user.Email).
-		SetPassword(s.user.Password).SetName(s.user.Name).
+		SetPassword(s.user.Password).SetName(*s.user.Name).
 		Save(s.ctx)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/repositories/user_test.go
+++ b/internal/repositories/user_test.go
@@ -39,11 +39,12 @@ func (s *UserSuite) SetupTest() {
 
 	s.users = make(map[int]*ent.User)
 	for i := 1; i <= 12; i++ {
+		name := fmt.Sprintf("user%d", i)
 		s.users[i] = &ent.User{
 			Login:    fmt.Sprintf("user_%d", i),
 			Email:    fmt.Sprintf("user_%d@mail.com", i),
 			Password: "password",
-			Name:     fmt.Sprintf("user%d", i),
+			Name:     &name,
 		}
 	}
 
@@ -53,7 +54,7 @@ func (s *UserSuite) SetupTest() {
 	}
 	for i, value := range s.users {
 		user, errCreate := s.client.User.Create().
-			SetName(value.Name).
+			SetName(*value.Name).
 			SetLogin(value.Login).
 			SetPassword(value.Password).
 			SetEmail(value.Email).
@@ -240,8 +241,8 @@ func (s *UserSuite) TestUserRepository_UserList_OrderByNameDesc() {
 	prevUserName := "zzzzzzzzzzzzzzzzzzzzz"
 	for _, value := range users {
 		require.True(t, mapContainsUser(t, value, s.users))
-		require.LessOrEqual(t, value.Name, prevUserName)
-		prevUserName = value.Name
+		require.LessOrEqual(t, *value.Name, prevUserName)
+		prevUserName = *value.Name
 	}
 }
 
@@ -286,8 +287,8 @@ func (s *UserSuite) TestUserRepository_UserList_OrderByNameAsc() {
 	prevUserName := ""
 	for _, value := range users {
 		require.True(t, mapContainsUser(t, value, s.users))
-		require.GreaterOrEqual(t, value.Name, prevUserName)
-		prevUserName = value.Name
+		require.GreaterOrEqual(t, *value.Name, prevUserName)
+		prevUserName = *value.Name
 	}
 }
 
@@ -431,7 +432,7 @@ func (s *UserSuite) TestUserRepository_DeleteUser_OK() {
 func mapContainsUser(t *testing.T, eq *ent.User, m map[int]*ent.User) bool {
 	t.Helper()
 	for _, v := range m {
-		if eq.Name == v.Name && eq.ID == v.ID && eq.Login == v.Login && eq.Email == v.Email {
+		if *eq.Name == *v.Name && eq.ID == v.ID && eq.Login == v.Login && eq.Email == v.Email {
 			return true
 		}
 	}


### PR DESCRIPTION
When registrating a new user the front end must send the name (they typically stub it setting it  same as email because there is no such input field when entering registration data). 
Later, when a user enters his full data (passport, phone, etc) he sees the Email in the Name field which is weird.