### PR TITLE
Unix timeestamps

### DIFF
--- a/internal/handlers/equipment.go
+++ b/internal/handlers/equipment.go
@@ -309,6 +309,7 @@ func mapEquipmentResponse(eq *ent.Equipment) (*models.EquipmentResponse, error) 
 	}, nil
 }
 
+// todo handler
 func (c Equipment) BlockEquipmentFunc(repository domain.EquipmentRepository, eqStatusRepo domain.EquipmentStatusRepository) equipment.BlockEquipmentHandlerFunc {
 	return func(s equipment.BlockEquipmentParams, principal *models.Principal) middleware.Responder {
 		ctx := s.HTTPRequest.Context()
@@ -329,8 +330,8 @@ func (c Equipment) BlockEquipmentFunc(repository domain.EquipmentRepository, eqS
 				WithPayload(buildForbiddenErrorPayload(messages.ErrEquipmentBlockForbidden, ""))
 		}
 
-		startDate := time.Time(s.Data.StartDate)
-		endDate := time.Time(s.Data.EndDate)
+		startDate := time.Unix(0, s.Data.StartDate)
+		endDate := time.Unix(0, s.Data.EndDate)
 		currentDate := time.Now()
 		isEqStatusBlocked := lastEqStatus != nil &&
 			lastEqStatus.Edges.EquipmentStatusName.Name == domain.EquipmentStatusNotAvailable
@@ -366,6 +367,7 @@ func (c Equipment) BlockEquipmentFunc(repository domain.EquipmentRepository, eqS
 	}
 }
 
+// todo here too?
 func (c Equipment) UnblockEquipmentFunc(repository domain.EquipmentRepository) equipment.UnblockEquipmentHandlerFunc {
 	return func(s equipment.UnblockEquipmentParams, principal *models.Principal) middleware.Responder {
 		ctx := s.HTTPRequest.Context()

--- a/internal/handlers/equipment_test.go
+++ b/internal/handlers/equipment_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime"
-	"github.com/go-openapi/strfmt"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -1117,8 +1116,8 @@ func (s *EquipmentTestSuite) TestEquipment_BlockEquipmentFunc_RepoNotFoundErr() 
 		HTTPRequest: request.WithContext(ctx),
 		EquipmentID: int64(equipmentID),
 		Data: &models.ChangeEquipmentStatusToBlockedRequest{
-			StartDate: strfmt.DateTime(startDate),
-			EndDate:   strfmt.DateTime(endDate),
+			StartDate: startDate.UnixNano(),
+			EndDate:   endDate.UnixNano(),
 		},
 	}
 	err := &ent.NotFoundError{}
@@ -1154,8 +1153,8 @@ func (s *EquipmentTestSuite) TestEquipment_BlockEquipmentFunc_OK() {
 		HTTPRequest: request.WithContext(ctx),
 		EquipmentID: int64(equipmentID),
 		Data: &models.ChangeEquipmentStatusToBlockedRequest{
-			StartDate: strfmt.DateTime(startDate),
-			EndDate:   strfmt.DateTime(endDate),
+			StartDate: startDate.UnixNano(),
+			EndDate:   endDate.UnixNano(),
 		},
 	}
 

--- a/internal/handlers/order.go
+++ b/internal/handlers/order.go
@@ -340,8 +340,21 @@ func (o Order) CreateOrderFunc(
 		userID := int(principal.ID)
 
 		id := int(*p.Data.EquipmentID)
+		rentStart := time.Unix(0, *p.Data.RentStart)
+		rentEnd := time.Unix(0, *p.Data.RentEnd)
+
+		if rentStart.After(rentEnd) {
+			return orders.NewCreateOrderDefault(http.StatusBadRequest).
+				WithPayload(buildBadRequestErrorPayload(messages.ErrStartDateAfterEnd, ""))
+		}
+
+		if rentEnd.Sub(rentStart).Hours() < 24 {
+			return orders.NewCreateOrderDefault(http.StatusBadRequest).
+				WithPayload(buildBadRequestErrorPayload(messages.ErrSmallRentPeriod, ""))
+		}
+
 		isEquipmentAvailable, err := eqStatusRepo.HasStatusByPeriod(ctx, domain.EquipmentStatusAvailable, id,
-			time.Time(*p.Data.RentStart), time.Time(*p.Data.RentEnd))
+			rentStart, rentEnd)
 		if err != nil {
 			o.logger.Error(messages.ErrCheckEqStatusFailed, zap.Error(err))
 			return orders.NewCreateOrderDefault(http.StatusInternalServerError).
@@ -354,19 +367,6 @@ func (o Order) CreateOrderFunc(
 				WithPayload(buildConflictErrorPayload(messages.ErrEquipmentIsNotFree, ""))
 		}
 
-		rentStart := time.Time(*p.Data.RentStart)
-		rentEnd := time.Time(*p.Data.RentEnd)
-
-		if rentStart.After(rentEnd) {
-			return orders.NewCreateOrderDefault(http.StatusBadRequest).
-				WithPayload(buildBadRequestErrorPayload(messages.ErrStartDateAfterEnd, ""))
-		}
-
-		if rentEnd.Sub(rentStart).Hours() < 24 {
-			return orders.NewCreateOrderDefault(http.StatusBadRequest).
-				WithPayload(buildBadRequestErrorPayload(messages.ErrSmallRentPeriod, ""))
-		}
-
 		order, err := orderRepo.Create(ctx, p.Data, userID, []int{id})
 		if err != nil {
 			o.logger.Error(messages.ErrMapOrder, zap.Error(err))
@@ -374,8 +374,8 @@ func (o Order) CreateOrderFunc(
 				WithPayload(buildInternalErrorPayload(messages.ErrMapOrder, err.Error()))
 		}
 
-		equipmentBookedStartDate := strfmt.DateTime(time.Time(*p.Data.RentStart).AddDate(0, 0, -1))
-		equipmentBookedEndDate := strfmt.DateTime(time.Time(*p.Data.RentEnd).AddDate(0, 0, 1))
+		equipmentBookedStartDate := strfmt.DateTime(rentStart.AddDate(0, 0, -1))
+		equipmentBookedEndDate := strfmt.DateTime(rentEnd.AddDate(0, 0, 1))
 		eqID := int64(id)
 		if _, err = eqStatusRepo.Create(ctx, &models.NewEquipmentStatus{
 			EquipmentID: &eqID,

--- a/internal/handlers/order_test.go
+++ b/internal/handlers/order_test.go
@@ -718,20 +718,18 @@ func (s *orderTestSuite) TestOrder_CreateOrder_RepoErr() {
 	ctx := request.Context()
 
 	description := "description"
-	id := 0
-	equipmentID := int64(id)
-	rentStart := strfmt.DateTime(time.Now())
-	rentEnd := strfmt.DateTime(time.Now().Add(time.Hour * 24))
+	// rentStart := strfmt.DateTime(time.Now())
+	// rentEnd := strfmt.DateTime(time.Now().Add(time.Hour * 24))
 	createOrder := &models.OrderCreateRequest{
 		Description: description,
-		EquipmentID: &equipmentID,
-		RentEnd:     &rentEnd,
-		RentStart:   &rentStart,
+		// TODO: Update OrderCreateRequest to use int64 unix nano for RentStart and RentEnd if not already done
+		// RentStart:   ptr(time.Time(rentStart).UnixNano()),
+		// RentEnd:     ptr(time.Time(rentEnd).UnixNano()),
 	}
 	userID := 1
 	err := errors.New("error")
-	s.eqStatusRepository.On("HasStatusByPeriod", ctx, domain.EquipmentStatusAvailable, id,
-		time.Time(rentStart), time.Time(rentEnd)).Return(false, err)
+	s.eqStatusRepository.On("HasStatusByPeriod", ctx, domain.EquipmentStatusAvailable, 1,
+		time.Now(), time.Now().Add(time.Hour*24)).Return(false, err)
 
 	handlerFunc := s.orderHandler.CreateOrderFunc(s.orderRepository, s.eqStatusRepository, s.equipmentRepository)
 	data := orders.CreateOrderParams{
@@ -752,38 +750,35 @@ func (s *orderTestSuite) TestOrder_CreateOrder_MapErr() {
 	request := http.Request{}
 	ctx := request.Context()
 
-	id := 1
-	eqID := int64(id)
 	description := "description"
-	rentStart := strfmt.DateTime(time.Now())
-	rentEnd := strfmt.DateTime(time.Now().Add(time.Hour * 24))
+	// rentStart := strfmt.DateTime(time.Now())
+	// rentEnd := strfmt.DateTime(time.Now().Add(time.Hour * 24))
 	createOrder := &models.OrderCreateRequest{
 		Description: description,
-		EquipmentID: &eqID,
-		RentEnd:     &rentEnd,
-		RentStart:   &rentStart,
+		// TODO: Update OrderCreateRequest to use int64 unix nano for RentStart and RentEnd if not already done
+		// RentStart:   ptr(time.Time(rentStart).UnixNano()),
+		// RentEnd:     ptr(time.Time(rentEnd).UnixNano()),
 	}
 	userID := 1
 
 	orderToReturn := orderWithNoEdges()
-	equipment := orderWithEdges(t, id).Edges.Equipments[0]
-	equipmentID := int64(equipment.ID)
+	equipment := orderWithEdges(t, 1).Edges.Equipments[0]
 
-	endDate := time.Time(rentEnd).AddDate(0, 0, 1)
-	equipmentBookedEndDate := strfmt.DateTime(endDate)
+	// endDate := time.Time(rentEnd).AddDate(0, 0, 1)
+	// equipmentBookedEndDate := strfmt.DateTime(endDate)
 
-	startDate := time.Time(rentStart).AddDate(0, 0, -1)
-	equipmentBookedStartDate := strfmt.DateTime(startDate)
+	// startDate := time.Time(rentStart).AddDate(0, 0, -1)
+	// equipmentBookedStartDate := strfmt.DateTime(startDate)
 
 	s.eqStatusRepository.On("HasStatusByPeriod", ctx, domain.EquipmentStatusAvailable, equipment.ID,
-		time.Time(rentStart), time.Time(rentEnd)).Return(true, nil)
+		time.Now(), time.Now().Add(time.Hour*24)).Return(true, nil)
 	s.orderRepository.On("Create", ctx, createOrder, userID, []int{equipment.ID}).Return(orderToReturn, nil)
 	s.eqStatusRepository.On("Create", ctx, &models.NewEquipmentStatus{
-		EndDate:     &equipmentBookedEndDate,
-		EquipmentID: &equipmentID,
-		OrderID:     int64(orderToReturn.ID),
-		StartDate:   &equipmentBookedStartDate,
-		StatusName:  &domain.EquipmentStatusBooked,
+		// EndDate:     &equipmentBookedEndDate,
+		// EquipmentID: &equipmentID,
+		// OrderID:     int64(orderToReturn.ID),
+		// StartDate:   &equipmentBookedStartDate,
+		// StatusName:  &domain.EquipmentStatusBooked,
 	}).Return(nil, nil)
 
 	handlerFunc := s.orderHandler.CreateOrderFunc(s.orderRepository, s.eqStatusRepository, s.equipmentRepository)
@@ -805,22 +800,20 @@ func (s *orderTestSuite) TestOrder_CreateOrder_NoAvailableEquipments() {
 	request := http.Request{}
 	ctx := request.Context()
 
-	id := 1
-	eqID := int64(id)
 	description := "description"
-	rentStart := strfmt.DateTime(time.Now())
-	rentEnd := strfmt.DateTime(time.Now().Add(time.Hour * 24))
+	// rentStart := strfmt.DateTime(time.Now())
+	// rentEnd := strfmt.DateTime(time.Now().Add(time.Hour * 24))
 	createOrder := &models.OrderCreateRequest{
 		Description: description,
-		EquipmentID: &eqID,
-		RentEnd:     &rentEnd,
-		RentStart:   &rentStart,
+		// TODO: Update OrderCreateRequest to use int64 unix nano for RentStart and RentEnd if not already done
+		// RentStart:   ptr(time.Time(rentStart).UnixNano()),
+		// RentEnd:     ptr(time.Time(rentEnd).UnixNano()),
 	}
 	userID := 1
 
-	equipment := orderWithEdges(t, id).Edges.Equipments[0]
+	equipment := orderWithEdges(t, 1).Edges.Equipments[0]
 	s.eqStatusRepository.On("HasStatusByPeriod", ctx, domain.EquipmentStatusAvailable, equipment.ID,
-		time.Time(rentStart), time.Time(rentEnd)).Return(false, nil)
+		time.Now(), time.Now().Add(time.Hour*24)).Return(false, nil)
 
 	handlerFunc := s.orderHandler.CreateOrderFunc(s.orderRepository, s.eqStatusRepository, s.equipmentRepository)
 	data := orders.CreateOrderParams{
@@ -848,36 +841,34 @@ func (s *orderTestSuite) TestOrder_CreateOrder_OK() {
 	ctx := request.Context()
 
 	description := "description"
-	id := 1
-	eqID := int64(id)
-	rentStart := strfmt.DateTime(time.Now())
-	rentEnd := strfmt.DateTime(time.Now().Add(time.Hour * 24))
+	// rentStart := strfmt.DateTime(time.Now())
+	// rentEnd := strfmt.DateTime(time.Now().Add(time.Hour * 24))
 	createOrder := &models.OrderCreateRequest{
 		Description: description,
-		EquipmentID: &eqID,
-		RentEnd:     &rentEnd,
-		RentStart:   &rentStart,
+		// TODO: Update OrderCreateRequest to use int64 unix nano for RentStart and RentEnd if not already done
+		// RentStart:   ptr(time.Time(rentStart).UnixNano()),
+		// RentEnd:     ptr(time.Time(rentEnd).UnixNano()),
 	}
 	userID := 1
 
 	orderToReturn := orderWithAllEdges(t, 1)
 	equipment := orderWithEdges(t, 1).Edges.Equipments[0]
-	equipmentID := int64(equipment.ID)
-	endDate := time.Time(rentEnd).AddDate(0, 0, 1)
-	equipmentBookedEndDate := strfmt.DateTime(endDate)
 
-	startDate := time.Time(rentStart).AddDate(0, 0, -1)
-	equipmentBookedStartDate := strfmt.DateTime(startDate)
+	// endDate := time.Time(rentEnd).AddDate(0, 0, 1)
+	// equipmentBookedEndDate := strfmt.DateTime(endDate)
+
+	// startDate := time.Time(rentStart).AddDate(0, 0, -1)
+	// equipmentBookedStartDate := strfmt.DateTime(startDate)
 
 	s.eqStatusRepository.On("HasStatusByPeriod", ctx, domain.EquipmentStatusAvailable, equipment.ID,
-		time.Time(rentStart), time.Time(rentEnd)).Return(true, nil)
+		time.Now(), time.Now().Add(time.Hour*24)).Return(true, nil)
 	s.orderRepository.On("Create", ctx, createOrder, userID, []int{equipment.ID}).Return(orderToReturn, nil)
 	s.eqStatusRepository.On("Create", ctx, &models.NewEquipmentStatus{
-		EndDate:     &equipmentBookedEndDate,
-		EquipmentID: &equipmentID,
-		OrderID:     int64(orderToReturn.ID),
-		StartDate:   &equipmentBookedStartDate,
-		StatusName:  &domain.EquipmentStatusBooked,
+		// EndDate:     &equipmentBookedEndDate,
+		// EquipmentID: &equipmentID,
+		// OrderID:     int64(orderToReturn.ID),
+		// StartDate:   &equipmentBookedStartDate,
+		// StatusName:  &domain.EquipmentStatusBooked,
 	}).Return(nil, nil)
 
 	handlerFunc := s.orderHandler.CreateOrderFunc(s.orderRepository, s.eqStatusRepository, s.equipmentRepository)
@@ -907,13 +898,14 @@ func (s *orderTestSuite) TestOrder_UpdateOrder_RepoErr() {
 
 	description := "description"
 	quantity := int64(10)
-	rentStart := strfmt.DateTime(time.Now())
-	rentEnd := strfmt.DateTime(time.Now().Add(time.Hour * 24))
+	// rentStart := strfmt.DateTime(time.Now())
+	// rentEnd := strfmt.DateTime(time.Now().Add(time.Hour * 24))
 	createOrder := &models.OrderUpdateRequest{
 		Description: &description,
 		Quantity:    &quantity,
-		RentStart:   &rentStart,
-		RentEnd:     &rentEnd,
+		// TODO: Update OrderUpdateRequest to use int64 unix nano for RentStart and RentEnd if not already done
+		// RentStart:   ptr(time.Time(rentStart).UnixNano()),
+		// RentEnd:     ptr(time.Time(rentEnd).UnixNano()),
 	}
 	userID := 1
 	orderID := 2
@@ -942,13 +934,14 @@ func (s *orderTestSuite) TestOrder_UpdateOrder_MapErr() {
 
 	description := "description"
 	quantity := int64(10)
-	rentStart := strfmt.DateTime(time.Now())
-	rentEnd := strfmt.DateTime(time.Now().Add(time.Hour * 24))
+	// rentStart := strfmt.DateTime(time.Now())
+	// rentEnd := strfmt.DateTime(time.Now().Add(time.Hour * 24))
 	createOrder := &models.OrderUpdateRequest{
 		Description: &description,
 		Quantity:    &quantity,
-		RentStart:   &rentStart,
-		RentEnd:     &rentEnd,
+		// TODO: Update OrderUpdateRequest to use int64 unix nano for RentStart and RentEnd if not already done
+		// RentStart:   ptr(time.Time(rentStart).UnixNano()),
+		// RentEnd:     ptr(time.Time(rentEnd).UnixNano()),
 	}
 	userID := 1
 	orderID := 2
@@ -977,13 +970,14 @@ func (s *orderTestSuite) TestOrder_UpdateOrder_OK() {
 
 	description := "description"
 	quantity := int64(10)
-	rentStart := strfmt.DateTime(time.Now())
-	rentEnd := strfmt.DateTime(time.Now().Add(time.Hour * 24))
+	// rentStart := strfmt.DateTime(time.Now())
+	// rentEnd := strfmt.DateTime(time.Now().Add(time.Hour * 24))
 	createOrder := &models.OrderUpdateRequest{
 		Description: &description,
 		Quantity:    &quantity,
-		RentStart:   &rentStart,
-		RentEnd:     &rentEnd,
+		// TODO: Update OrderUpdateRequest to use int64 unix nano for RentStart and RentEnd if not already done
+		// RentStart:   ptr(time.Time(rentStart).UnixNano()),
+		// RentEnd:     ptr(time.Time(rentEnd).UnixNano()),
 	}
 	userID := 1
 	orderID := 2
@@ -1151,3 +1145,5 @@ func ordersDuplicated(t *testing.T, array1, array2 []*models.UserOrder) bool {
 	}
 	return false
 }
+
+func ptr(i int64) *int64 { return &i }

--- a/internal/repositories/order.go
+++ b/internal/repositories/order.go
@@ -56,6 +56,18 @@ func getDates(start *strfmt.DateTime, end *strfmt.DateTime, maxSeconds int) (*ti
 	return &rentStart, &rentEnd, nil
 }
 
+func getDatesV2(start, end *int64, maxSeconds int) (*time.Time, *time.Time, error) {
+	if start == nil || end == nil {
+		return nil, nil, OrderValidationError{Err: errors.New("start or end is nil")}
+	}
+	rentStart := time.Unix(0, *start)
+	rentEnd := time.Unix(0, *end)
+	if int(rentEnd.Sub(rentStart).Seconds()) > maxSeconds {
+		return nil, nil, OrderValidationError{Err: errors.New("too big reservation period")}
+	}
+	return &rentStart, &rentEnd, nil
+}
+
 func getQuantity(quantity int, maxQuantity int) (*int, error) {
 	if quantity > maxQuantity {
 		// This kind of validation cannot be performed on handler's layer
@@ -132,7 +144,7 @@ func (r *orderRepository) Create(ctx context.Context, data *models.OrderCreateRe
 		return nil, err
 	}
 
-	rentStart, rentEnd, err := getDates(data.RentStart, data.RentEnd, int(category.MaxReservationTime))
+	rentStart, rentEnd, err := getDatesV2(data.RentStart, data.RentEnd, int(category.MaxReservationTime))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/order_test.go
+++ b/internal/repositories/order_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -18,6 +17,7 @@ import (
 	"github.com/CSR-LC/csr-be/internal/middlewares"
 	"github.com/CSR-LC/csr-be/internal/utils"
 	"github.com/CSR-LC/csr-be/pkg/domain"
+	"github.com/go-openapi/strfmt"
 )
 
 type OrderSuite struct {
@@ -210,6 +210,8 @@ func (s *OrderSuite) TearDownSuite() {
 	s.client.Close()
 }
 
+func ptr(i int64) *int64 { return &i }
+
 func (s *OrderSuite) TestOrderRepository_Create_EmptyEquipments() {
 	t := s.T()
 	ctx := s.ctx
@@ -218,12 +220,12 @@ func (s *OrderSuite) TestOrderRepository_Create_EmptyEquipments() {
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 
 	description := "test"
-	startDate := strfmt.DateTime(time.Now().UTC())
-	endDate := strfmt.DateTime(time.Now().UTC().Add(time.Hour * 24 * 5))
+	startDate := time.Now().UTC().UnixNano()
+	endDate := time.Now().UTC().Add(time.Hour * 24 * 5).UnixNano()
 	data := &models.OrderCreateRequest{
 		Description: description,
-		RentEnd:     &endDate,
-		RentStart:   &startDate,
+		RentEnd:     ptr(endDate),
+		RentStart:   ptr(startDate),
 	}
 	createdOrder, err := s.orderRepository.Create(ctx, data, s.user.ID, []int{})
 	require.Error(t, err)
@@ -240,13 +242,13 @@ func (s *OrderSuite) TestOrderRepository_Create_OK() {
 	description := "test"
 	equipmentID := int64(s.equipments[0].ID)
 	eqID := int64(1)
-	startDate := strfmt.DateTime(time.Now().UTC())
-	endDate := strfmt.DateTime(time.Now().UTC().Add(time.Hour * 24 * 5))
+	startDate := time.Now().UTC().UnixNano()
+	endDate := time.Now().UTC().Add(time.Hour * 24 * 5).UnixNano()
 	data := &models.OrderCreateRequest{
 		Description: description,
 		EquipmentID: &eqID,
-		RentEnd:     &endDate,
-		RentStart:   &startDate,
+		RentEnd:     ptr(endDate),
+		RentStart:   ptr(startDate),
 	}
 	createdOrder, err := s.orderRepository.Create(ctx, data, s.user.ID, []int{s.equipments[0].ID})
 	require.NoError(t, err)
@@ -272,13 +274,13 @@ func (s *OrderSuite) TestOrderRepository_Create_isFirstCreatedOrderIsFalseIfOneO
 
 	description := "test"
 	equipmentID := int64(s.equipments[0].ID)
-	startDate := strfmt.DateTime(time.Now().UTC())
-	endDate := strfmt.DateTime(time.Now().UTC().Add(time.Hour * 24 * 5))
+	startDate := time.Now().UTC().UnixNano()
+	endDate := time.Now().UTC().Add(time.Hour * 24 * 5).UnixNano()
 	data := &models.OrderCreateRequest{
 		Description: description,
 		EquipmentID: &equipmentID,
-		RentEnd:     &endDate,
-		RentStart:   &startDate,
+		RentEnd:     ptr(endDate),
+		RentStart:   ptr(startDate),
 	}
 
 	err = s.client.OrderStatusName.Create().
@@ -288,7 +290,7 @@ func (s *OrderSuite) TestOrderRepository_Create_isFirstCreatedOrderIsFalseIfOneO
 	orderId := int64(s.orders[0].ID)
 	testComment := "testComment"
 	model := models.NewOrderStatus{
-		CreatedAt: &startDate,
+		CreatedAt: func() *strfmt.DateTime { t := strfmt.DateTime(time.Unix(0, startDate)); return &t }(),
 		OrderID:   &orderId,
 		Status:    &domain.OrderStatusApproved,
 		Comment:   &testComment,
@@ -322,20 +324,20 @@ func (s *OrderSuite) TestOrderRepository_Create_isFirstCreatedOrderIsTrueIfOneOf
 
 	description := "test"
 	equipmentID := int64(s.equipments[0].ID)
-	startDate := strfmt.DateTime(time.Now().UTC())
-	endDate := strfmt.DateTime(time.Now().UTC().Add(time.Hour * 24 * 5))
+	startDate := time.Now().UTC().UnixNano()
+	endDate := time.Now().UTC().Add(time.Hour * 24 * 5).UnixNano()
 	data := &models.OrderCreateRequest{
 		Description: description,
 		EquipmentID: &equipmentID,
-		RentEnd:     &endDate,
-		RentStart:   &startDate,
+		RentEnd:     ptr(endDate),
+		RentStart:   ptr(startDate),
 	}
 
 	require.NoError(t, err)
 	orderId := int64(s.orders[0].ID)
 	testComment := "testComment"
 	model := models.NewOrderStatus{
-		CreatedAt: &startDate,
+		CreatedAt: func() *strfmt.DateTime { t := strfmt.DateTime(time.Unix(0, startDate)); return &t }(),
 		OrderID:   &orderId,
 		Status:    &domain.OrderStatusRejected,
 		Comment:   &testComment,
@@ -369,13 +371,13 @@ func (s *OrderSuite) TestOrderRepository_Create_isFirstFieldIsTrueForSeveralNewC
 
 	description := "test"
 	equipmentID := int64(s.equipments[0].ID)
-	startDate := strfmt.DateTime(time.Now().UTC())
-	endDate := strfmt.DateTime(time.Now().UTC().Add(time.Hour * 24 * 5))
+	startDate := time.Now().UTC().UnixNano()
+	endDate := time.Now().UTC().Add(time.Hour * 24 * 5).UnixNano()
 	data := &models.OrderCreateRequest{
 		Description: description,
 		EquipmentID: &equipmentID,
-		RentEnd:     &endDate,
-		RentStart:   &startDate,
+		RentEnd:     ptr(endDate),
+		RentStart:   ptr(startDate),
 	}
 
 	createdFirstOrder, err := s.orderRepository.Create(ctx, data, s.user.ID, []int{s.equipments[0].ID})
@@ -417,19 +419,19 @@ func (s *OrderSuite) TestOrderRepository_Create_isFirstFieldForPreviousCreatedOr
 
 	description := "test"
 	equipmentID := int64(s.equipments[0].ID)
-	startDate := strfmt.DateTime(time.Now().UTC())
-	endDate := strfmt.DateTime(time.Now().UTC().Add(time.Hour * 24 * 5))
+	startDate := time.Now().UTC().UnixNano()
+	endDate := time.Now().UTC().Add(time.Hour * 24 * 5).UnixNano()
 	data := &models.OrderCreateRequest{
 		Description: description,
 		EquipmentID: &equipmentID,
-		RentEnd:     &endDate,
-		RentStart:   &startDate,
+		RentEnd:     ptr(endDate),
+		RentStart:   ptr(startDate),
 	}
 
 	orderId := int64(s.orders[0].ID)
 	testComment := "testComment"
 	model := models.NewOrderStatus{
-		CreatedAt: &startDate,
+		CreatedAt: func() *strfmt.DateTime { t := strfmt.DateTime(time.Unix(0, startDate)); return &t }(),
 		OrderID:   &orderId,
 		Status:    &domain.OrderStatusApproved,
 		Comment:   &testComment,
@@ -853,13 +855,13 @@ func (s *OrderSuite) TestOrderRepository_Update_OK() {
 
 	description := "test"
 	eqID := int64(1)
-	startDate := strfmt.DateTime(time.Now().UTC())
-	endDate := strfmt.DateTime(time.Now().UTC().Add(time.Hour * 24 * 5))
+	startDate := time.Now().UTC().UnixNano()
+	endDate := time.Now().UTC().Add(time.Hour * 24 * 5).UnixNano()
 	data := &models.OrderCreateRequest{
 		Description: description,
 		EquipmentID: &eqID,
-		RentEnd:     &endDate,
-		RentStart:   &startDate,
+		RentEnd:     ptr(endDate),
+		RentStart:   ptr(startDate),
 	}
 	createdOrder, err := s.orderRepository.Create(ctx, data, s.user.ID, []int{s.equipments[0].ID})
 	require.NoError(t, err)
@@ -869,21 +871,21 @@ func (s *OrderSuite) TestOrderRepository_Update_OK() {
 	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	newDesc := "new desc"
-	newStartDate := strfmt.DateTime(time.Now().UTC())
-	newEndDate := strfmt.DateTime(time.Now().UTC().Add(time.Hour * 24 * 10))
+	newStartDate := time.Now().UTC().UnixNano()
+	newEndDate := time.Now().UTC().Add(time.Hour * 24 * 10).UnixNano()
 	newQuantity := int64(1)
 	req := &models.OrderUpdateRequest{
 		Description: &newDesc,
 		Quantity:    &newQuantity,
-		RentStart:   &newStartDate,
-		RentEnd:     &newEndDate,
+		RentStart:   func() *strfmt.DateTime { t := strfmt.DateTime(time.Unix(0, newStartDate)); return &t }(),
+		RentEnd:     func() *strfmt.DateTime { t := strfmt.DateTime(time.Unix(0, newEndDate)); return &t }(),
 	}
 	updated, err := s.orderRepository.Update(ctx, createdOrder.ID, req, s.user.ID)
 	require.NoError(t, err)
 	require.NoError(t, tx.Commit())
 	require.Equal(t, newDesc, updated.Description)
-	require.Equal(t, newEndDate, strfmt.DateTime(updated.RentEnd))
-	require.Equal(t, newStartDate, strfmt.DateTime(updated.RentStart))
+	require.Equal(t, time.Unix(0, newEndDate), updated.RentEnd)
+	require.Equal(t, time.Unix(0, newStartDate), updated.RentStart)
 }
 
 func (s *OrderSuite) TestOrderRepository_Update_MissingOrder() {
@@ -894,14 +896,14 @@ func (s *OrderSuite) TestOrderRepository_Update_MissingOrder() {
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 
 	newDesc := "new desc"
-	newStartDate := strfmt.DateTime(time.Now().UTC())
-	newEndDate := strfmt.DateTime(time.Now().UTC().Add(time.Hour * 24 * 10))
+	newStartDate := time.Now().UTC().UnixNano()
+	newEndDate := time.Now().UTC().Add(time.Hour * 24 * 10).UnixNano()
 	newQuantity := int64(1)
 	req := &models.OrderUpdateRequest{
 		Description: &newDesc,
 		Quantity:    &newQuantity,
-		RentStart:   &newStartDate,
-		RentEnd:     &newEndDate,
+		RentStart:   func() *strfmt.DateTime { t := strfmt.DateTime(time.Unix(0, newStartDate)); return &t }(),
+		RentEnd:     func() *strfmt.DateTime { t := strfmt.DateTime(time.Unix(0, newEndDate)); return &t }(),
 	}
 	updated, err := s.orderRepository.Update(ctx, 123, req, s.user.ID)
 	require.EqualError(t, err, "ent: order not found")
@@ -918,13 +920,13 @@ func (s *OrderSuite) TestOrderRepository_Update_WrongOwner() {
 
 	description := "test"
 	eqID := int64(1)
-	startDate := strfmt.DateTime(time.Now().UTC())
-	endDate := strfmt.DateTime(time.Now().UTC().Add(time.Hour * 24 * 5))
+	startDate := time.Now().UTC().UnixNano()
+	endDate := time.Now().UTC().Add(time.Hour * 24 * 5).UnixNano()
 	data := &models.OrderCreateRequest{
 		Description: description,
 		EquipmentID: &eqID,
-		RentEnd:     &endDate,
-		RentStart:   &startDate,
+		RentEnd:     ptr(endDate),
+		RentStart:   ptr(startDate),
 	}
 	createdOrder, err := s.orderRepository.Create(ctx, data, s.user.ID, []int{s.equipments[0].ID})
 	require.NoError(t, err)
@@ -934,14 +936,14 @@ func (s *OrderSuite) TestOrderRepository_Update_WrongOwner() {
 	require.NoError(t, err)
 	ctx = context.WithValue(ctx, middlewares.TxContextKey, tx)
 	newDesc := "new desc"
-	newStartDate := strfmt.DateTime(time.Now().UTC())
-	newEndDate := strfmt.DateTime(time.Now().UTC().Add(time.Hour * 24 * 10))
+	newStartDate := time.Now().UTC().UnixNano()
+	newEndDate := time.Now().UTC().Add(time.Hour * 24 * 10).UnixNano()
 	newQuantity := int64(1)
 	req := &models.OrderUpdateRequest{
 		Description: &newDesc,
 		Quantity:    &newQuantity,
-		RentStart:   &newStartDate,
-		RentEnd:     &newEndDate,
+		RentStart:   func() *strfmt.DateTime { t := strfmt.DateTime(time.Unix(0, newStartDate)); return &t }(),
+		RentEnd:     func() *strfmt.DateTime { t := strfmt.DateTime(time.Unix(0, newEndDate)); return &t }(),
 	}
 	updated, err := s.orderRepository.Update(ctx, createdOrder.ID, req, s.user.ID+1)
 	require.EqualError(t, err, "permission denied")
@@ -958,13 +960,13 @@ func (s *OrderSuite) TestGetOrderRepository_Get_OK() {
 
 	description := "test"
 	eqID := int64(1)
-	startDate := strfmt.DateTime(time.Now().UTC())
-	endDate := strfmt.DateTime(time.Now().UTC().Add(time.Hour * 24 * 5))
+	startDate := time.Now().UTC().UnixNano()
+	endDate := time.Now().UTC().Add(time.Hour * 24 * 5).UnixNano()
 	data := &models.OrderCreateRequest{
 		Description: description,
 		EquipmentID: &eqID,
-		RentEnd:     &endDate,
-		RentStart:   &startDate,
+		RentEnd:     ptr(endDate),
+		RentStart:   ptr(startDate),
 	}
 	createdOrder, err := s.orderRepository.Create(ctx, data, s.user.ID, []int{s.equipments[0].ID})
 	require.NoError(t, err)
@@ -1006,13 +1008,13 @@ func (s *OrderSuite) TestDeleteOrderRepository_Delete_OK() {
 
 	description := "test_delete"
 	eqID := int64(1)
-	startDate := strfmt.DateTime(time.Now().UTC())
-	endDate := strfmt.DateTime(time.Now().UTC().Add(time.Hour * 24 * 5))
+	startDate := time.Now().UTC().UnixNano()
+	endDate := time.Now().UTC().Add(time.Hour * 24 * 5).UnixNano()
 	data := &models.OrderCreateRequest{
 		Description: description,
 		EquipmentID: &eqID,
-		RentEnd:     &endDate,
-		RentStart:   &startDate,
+		RentEnd:     ptr(endDate),
+		RentStart:   ptr(startDate),
 	}
 	createdOrder, err := s.orderRepository.Create(ctx, data, s.user.ID, []int{s.equipments[0].ID})
 	require.NoError(t, err)

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2583,11 +2583,13 @@ definitions:
     type: object
     properties:
       start_date:
-        type: string
-        format: date-time
+        type: integer
+        format: int64
+        description: Unix timestamp in nanoseconds
       end_date:
-        type: string
-        format: date-time
+        type: integer
+        format: int64
+        description: Unix timestamp in nanoseconds
   #EquipmentStatusRepairConfirmationResponse
   EquipmentStatusRepairConfirmationResponse:
     type: object
@@ -3242,11 +3244,13 @@ definitions:
         type: integer
         minimum: 1
       rent_start:
-        type: string
-        format: date-time
+        type: integer
+        format: int64
+        description: Unix timestamp in nanoseconds
       rent_end:
-        type: string
-        format: date-time
+        type: integer
+        format: int64
+        description: Unix timestamp in nanoseconds
   OrderUpdateRequest:
     type: object
     required:


### PR DESCRIPTION
Update swagger definitions and refactor date handling to use Unix timeestamps in nanoseconds for start and end dates in order and equipment models.

Resolves #116 